### PR TITLE
add lineCount method to interface

### DIFF
--- a/src/main/java/net/consensys/zktracer/module/ModuleTracer.java
+++ b/src/main/java/net/consensys/zktracer/module/ModuleTracer.java
@@ -16,6 +16,7 @@ package net.consensys.zktracer.module;
 
 import java.util.List;
 import net.consensys.zktracer.OpCode;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 public interface ModuleTracer {
@@ -24,4 +25,6 @@ public interface ModuleTracer {
   List<OpCode> supportedOpCodes();
 
   Object trace(MessageFrame frame);
+
+  int lineCount(OpCode opCode, Bytes32 arg1, Bytes32 arg2);
 }

--- a/src/main/java/net/consensys/zktracer/module/shf/ShfTracer.java
+++ b/src/main/java/net/consensys/zktracer/module/shf/ShfTracer.java
@@ -173,6 +173,12 @@ public class ShfTracer implements ModuleTracer {
     return builder.build();
   }
 
+  @Override
+  public int lineCount(OpCode opCode, Bytes32 arg1, Bytes32 arg2) {
+    final Bytes16 arg1Hi = Bytes16.wrap(arg1.slice(0, 16));
+    return maxCt(isOneLineInstruction(opCode, arg1Hi));
+  }
+
   private int maxCt(final boolean isOneLineInstruction) {
     return isOneLineInstruction ? 1 : LIMB_SIZE;
   }


### PR DESCRIPTION
I think we can separate the implementation of the "count lines" and the JSON output.
For the simpler modules (eg the ones with a Go implementation already), the count is either
- a fixed number - eg ADD is 8
- or computed based on the opCode and the args - it's either 1 (if it's effectively a "one line instruction" eg a MUL where one arg is 0 or 1) or a fixed number - eg maxCT() in bin module (LIMB_SIZE is 16) https://github.com/ConsenSys/zk-evm/blob/main/zeroknowledge/modules/bin/trace.go#L103
So if we made the trace modules implement an interface, with a method to get the lines based on the args countLines(opCode, arg1, arg2)  - we should be able to create all the modules and implement that method in advance of the JSON.
- Also required - another RPC method to retrieve the line counts only.
For the remaining modules (no Go implementation eg ROM,RAM,MMU,HUB), the principle is the same but the logic is more complicated (and we will have to read the spec). In the spec it's referred to as Heartbeat. https://ethresear.ch/uploads/short-url/9sQlTuvJOymsl6tM7IAgWuMECPc.pdf