### PR TITLE
23.4.0 snapshot besu

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 version=0.0.1-SNAPSHOT
-besuVersion=23.1.3-SNAPSHOT
+besuVersion=23.4.0-SNAPSHOT
 distributionIdentifier=linea-besu-plugin
 distributionBaseUrl=https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/


### PR DESCRIPTION
23.1.3-SNAPSHOT seems not to have the newly added plugin classes eg 
```
import org.hyperledger.besu.plugin.data.BlockContext;
import org.hyperledger.besu.plugin.services.BlockchainService;
import org.hyperledger.besu.plugin.services.TraceService;
import org.hyperledger.besu.plugin.services.exception.PluginRpcEndpointException;
import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
```