### PR TITLE
setChunk

### DIFF
--- a/src/main/java/net/consensys/linea/zktracer/bytestheta/BaseTheta.java
+++ b/src/main/java/net/consensys/linea/zktracer/bytestheta/BaseTheta.java
@@ -37,6 +37,13 @@ public class BaseTheta extends BaseBytes {
     bytes32.set(index, bytes);
   }
 
+  // set the whole chunk of bytes at the given index.
+  // assumes index is one of 0,1,2,3
+  // assumes length of bytes is 8
+  public void setChunk(int index, Bytes bytes) {
+    bytes32.set(OFFSET * index, bytes);
+  }
+
   public Bytes get(int index) {
     return bytes32.slice(OFFSET * index, OFFSET);
   }
@@ -65,5 +72,22 @@ public class BaseTheta extends BaseBytes {
 
   public void set(int i, int j, byte b) {
     bytes32.set(OFFSET * i + j, b);
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder();
+    sb.append("hi=").append(getHigh()).append(", ");
+    sb.append("lo=").append(getLow()).append(("\n"));
+    sb.append("  0 1 2 3\n  ");
+    sb.append(get(0))
+        .append(" ")
+        .append(get(1))
+        .append(" ")
+        .append(get(2))
+        .append(" ")
+        .append(get(3))
+        .append(" ");
+    return sb.toString();
   }
 }

--- a/src/test/java/net/consensys/linea/zktracer/bytestheta/BaseThetaTest.java
+++ b/src/test/java/net/consensys/linea/zktracer/bytestheta/BaseThetaTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import net.consensys.linea.zktracer.bytes.Bytes16;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.Test;
 
 public class BaseThetaTest {
@@ -113,5 +114,31 @@ public class BaseThetaTest {
     assertThat(baseTheta.get(0, 7)).isZero();
     assertThat(baseTheta.get(2, 7)).isEqualTo(Bytes.fromHexString("0x0b").get(0));
     assertThat(baseTheta.get(3, 0)).isEqualTo(Bytes.fromHexString("0x0d").get(0));
+  }
+
+  @Test
+  public void setBytesTest() {
+    BaseTheta aBaseTheta = BaseTheta.fromBytes32(UInt256.valueOf(43532));
+
+    Bytes a0 = Bytes.fromHexString("0x000000000000aa0c");
+    assertThat(aBaseTheta.get(0)).isEqualTo(a0);
+    assertThat(aBaseTheta.get(1).isZero()).isTrue();
+    assertThat(aBaseTheta.get(2).isZero()).isTrue();
+    assertThat(aBaseTheta.get(3).isZero()).isTrue();
+
+    Bytes b3 = Bytes.fromHexString("0x533a124790000000");
+    Bytes b2 = Bytes.fromHexString("0xfaa47d49bf1d1e67");
+    Bytes b1 = Bytes.fromHexString("0x952951f4425bf6f3");
+    Bytes b0 = Bytes.fromHexString("0x0000000000d55835");
+    Bytes32 bytes32 = Bytes32.wrap(Bytes.concatenate(b3, b2, b1, b0));
+    BaseTheta bBaseTheta = BaseTheta.fromBytes32(bytes32);
+
+    assertThat(bBaseTheta.get(3)).isEqualTo(b3);
+    assertThat(bBaseTheta.get(2)).isEqualTo(b2);
+    assertThat(bBaseTheta.get(1)).isEqualTo(b1);
+    assertThat(bBaseTheta.get(0)).isEqualTo(b0);
+
+    bBaseTheta.setChunk(0, b3);
+    assertThat(bBaseTheta.get(0)).isEqualTo(b3);
   }
 }


### PR DESCRIPTION
function to set a chunk of bytesTheta
```
  // set the whole chunk of bytes at the given index.
  // assumes index is one of 0,1,2,3
  // assumes length of bytes is 8
  public void setChunk(int index, Bytes bytes) {
    bytes32.set(OFFSET * index, bytes);
  }
```

the toString() contains a whole lot of debug - won't be useful long term (checked in by accident, actually) - happy to take this out