### PR TITLE
Max calldata size is already checked when validating the transaction

### DIFF
--- a/src/main/java/net/consensys/linea/sequencer/LineaTransactionSelector.java
+++ b/src/main/java/net/consensys/linea/sequencer/LineaTransactionSelector.java
@@ -31,7 +31,6 @@ import org.hyperledger.besu.plugin.services.txselection.TransactionSelector;
 @Slf4j
 @RequiredArgsConstructor
 public class LineaTransactionSelector implements TransactionSelector {
-  private final int maxTxCalldataSize;
   private final int maxBlockCalldataSize;
   private int blockCalldataSum;
 
@@ -40,17 +39,10 @@ public class LineaTransactionSelector implements TransactionSelector {
       final Transaction transaction,
       final boolean isSuccessful,
       final List<Log> logs,
-      final long commulativeGasUsed) {
+      final long cumulativeGasUsed) {
 
     final int txCalldataSize = transaction.getPayload().size();
 
-    if (txCalldataSize > maxTxCalldataSize) {
-      log.warn(
-          "Not adding transaction {} because calldata size {} is too big",
-          transaction,
-          txCalldataSize);
-      return TransactionSelectionResult.invalid("Calldata too big");
-    }
     try {
       blockCalldataSum = Math.addExact(blockCalldataSum, txCalldataSize);
     } catch (final ArithmeticException e) {

--- a/src/main/java/net/consensys/linea/sequencer/LineaTransactionSelectorFactory.java
+++ b/src/main/java/net/consensys/linea/sequencer/LineaTransactionSelectorFactory.java
@@ -29,7 +29,6 @@ public class LineaTransactionSelectorFactory implements TransactionSelectorFacto
   @Override
   public TransactionSelector create() {
     final LineaConfiguration lineaConfiguration = options.toDomainObject();
-    return new LineaTransactionSelector(
-        lineaConfiguration.maxTxCalldataSize(), lineaConfiguration.maxBlockCalldataSize());
+    return new LineaTransactionSelector(lineaConfiguration.maxBlockCalldataSize());
   }
 }


### PR DESCRIPTION
Once we use https://github.com/Consensys/linea-besu as base, then every transaction is already validated also for the max size of the calldata field so we can remove this redundant validation during the block selection.