### PR TITLE
fix: SELFDESTRUCT one zero pattern

### DIFF
--- a/src/main/resources/opcodes.yml
+++ b/src/main/resources/opcodes.yml
@@ -1607,7 +1607,7 @@ opcodes:
     value: 0xff
     instructionFamily: HALT
     stackSettings:
-      pattern: TWO_ZERO
+      pattern: ONE_ZERO
       alpha: 0
       delta: 1
       nbAdded: 0


### PR DESCRIPTION
found when running TRM tests
FixedStack UnderflowException was occurring for all SELFDESTRUCT tests
fixes #126 