### PR TITLE
feat: Instead of writing traces to /traces write them to $BESU/data/traces to avoid permission issues

### DIFF
--- a/src/main/java/net/consensys/linea/zktracer/opcode/OpCodes.java
+++ b/src/main/java/net/consensys/linea/zktracer/opcode/OpCodes.java
@@ -38,12 +38,11 @@ public class OpCodes {
   /** Loads all opcode metadata from src/main/resources/opcodes.yml. */
   @SneakyThrows(IOException.class)
   public static void load() {
-    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 
     JsonNode rootNode =
         YAML_CONVERTER
             .getObjectMapper()
-            .readTree(classLoader.getResourceAsStream("opcodes.yml"))
+            .readTree(OpCodes.class.getClassLoader().getResourceAsStream("opcodes.yml"))
             .get("opcodes");
 
     CollectionType typeReference =


### PR DESCRIPTION
While testing the RPC endpoint to conflate traces we realized that the default path to write the traces is `/traces`. As this is causing issues with permissions, this PR changes the default to a sub directory of besu's data directory.