### PR TITLE
fix: use a default value for null RamSettings in OpCodeData

### DIFF
--- a/src/main/java/net/consensys/linea/zktracer/module/hub/Signals.java
+++ b/src/main/java/net/consensys/linea/zktracer/module/hub/Signals.java
@@ -181,9 +181,7 @@ public class Signals {
   }
 
   private boolean canMmu() {
-    // TODO: not enabled in the instruction decoding
-    // return opCodeData.ramSettings().enabled() &&
-    return hub.exceptions().none();
+    return opCodeData.ramSettings().enabled() && hub.exceptions().none();
   }
 
   private boolean canMxp() {

--- a/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
+++ b/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
@@ -15,6 +15,8 @@
 
 package net.consensys.linea.zktracer.opcode;
 
+import java.util.Optional;
+
 import net.consensys.linea.zktracer.opcode.gas.Billing;
 import net.consensys.linea.zktracer.opcode.gas.MxpType;
 import net.consensys.linea.zktracer.opcode.stack.StackSettings;
@@ -45,6 +47,10 @@ public record OpCodeData(
    */
   public int numberOfArguments() {
     return this.stackSettings.nbRemoved();
+  }
+
+  public RamSettings ramSettings() {
+    return Optional.ofNullable(this.ramSettings).orElse(RamSettings.DEFAULT);
   }
 
   /**

--- a/src/main/java/net/consensys/linea/zktracer/opcode/RamSettings.java
+++ b/src/main/java/net/consensys/linea/zktracer/opcode/RamSettings.java
@@ -16,6 +16,8 @@
 package net.consensys.linea.zktracer.opcode;
 
 public record RamSettings(boolean enabled, DataLocation source, DataLocation target) {
+  public static final RamSettings DEFAULT = new RamSettings();
+
   public RamSettings() {
     this(false, DataLocation.NONE, DataLocation.NONE);
   }


### PR DESCRIPTION
Fix #244 