### PR TITLE
Use a simple "for" loop instead of a stream to improve performance

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/State.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/State.java
@@ -65,7 +65,11 @@ public class State implements StackedContainer {
    * @return the cumulated line numbers for all currently traced transactions
    */
   int lineCount() {
-    return this.state.stream().mapToInt(s -> s.txTrace.lineCount()).sum();
+    int sum = 0;
+    for (TxState s : this.state) {
+      sum += s.txTrace.lineCount();
+    }
+    return sum;
   }
 
   @Override


### PR DESCRIPTION
We noticed from CPU profiling during block production, i.e transaction evaluation in order to include them in a block that State.lineCount consumes a significant amount of CPU, related to the usage of a stream.

<img width="1721" alt="image" src="https://github.com/Consensys/besu-sequencer-plugins/assets/5099602/b7344c55-522a-4e1f-9622-b147a9045270">

JMH Microbenchmarking confirmed that a simple loop is much better in this use case on a collection with 100k elements

```
Benchmark                            Mode  Cnt      Score     Error  Units
TestStreamsVsLoops.testMethodLoop    avgt   50   9976.233 ± 138.659  ns/op
TestStreamsVsLoops.testMethodStream  avgt   50  64048.445 ± 386.111  ns/op
```