### PR TITLE
Different performance optimizations 

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/stacked/set/StackedSet.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/stacked/set/StackedSet.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class StackedSet<E> implements StackedContainer, java.util.Set<E> {
   private final Deque<Set<E>> sets = new ArrayDeque<>();
-  private Set<E> collapsed;
+  private Set<E> collapsed = new HashSet<>();
 
   @Override
   public void enter() {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/stacked/set/StackedSet.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/stacked/set/StackedSet.java
@@ -89,6 +89,7 @@ public class StackedSet<E> implements StackedContainer, java.util.Set<E> {
 
   @NotNull
   @Override
+  @SuppressWarnings("unchecked")
   public E[] toArray() {
     return occurences.entrySet().stream()
             .filter(entry -> entry.getValue() > 0)

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/stacked/set/StackedSet.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/stacked/set/StackedSet.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class StackedSet<E> implements StackedContainer, java.util.Set<E> {
   private final Deque<Set<E>> sets = new ArrayDeque<>();
-  private Map<E, Integer> occurences = new HashMap<>();
+  private final Map<E, Integer> occurences = new HashMap<>();
 
   @Override
   public void enter() {
@@ -47,11 +47,11 @@ public class StackedSet<E> implements StackedContainer, java.util.Set<E> {
   @Override
   public void pop() {
     Set<E> set = this.sets.pop();
-    for (E e:set) {
+    for (E e : set) {
       Integer count = occurences.get(e);
-      if (count > 0) occurences.put(e, count-1);
+      if (count > 0) occurences.put(e, count - 1);
       else throw new IllegalStateException("asymetric element removal !");
-    };
+    }
   }
 
   @Override
@@ -78,23 +78,23 @@ public class StackedSet<E> implements StackedContainer, java.util.Set<E> {
   @NotNull
   @Override
   public Iterator<E> iterator() {
-      List<E> list = new ArrayList<>();
-      for (Map.Entry<E, Integer> entry : occurences.entrySet()) {
-        if (entry.getValue() > 0) {
-          list.add(entry.getKey());
-        }
+    List<E> list = new ArrayList<>();
+    for (Map.Entry<E, Integer> entry : occurences.entrySet()) {
+      if (entry.getValue() > 0) {
+        list.add(entry.getKey());
       }
-      return list.iterator();
     }
+    return list.iterator();
+  }
 
   @NotNull
   @Override
   @SuppressWarnings("unchecked")
   public E[] toArray() {
     return occurences.entrySet().stream()
-            .filter(entry -> entry.getValue() > 0)
-            .map(Map.Entry::getKey)
-            .toArray(size -> (E[]) new Object[size]);
+        .filter(entry -> entry.getValue() > 0)
+        .map(Map.Entry::getKey)
+        .toArray(size -> (E[]) new Object[size]);
   }
 
   @NotNull

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/Mxp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/Mxp.java
@@ -150,7 +150,11 @@ public class Mxp implements Module {
 
   @Override
   public int lineCount() {
-    return this.chunks.stream().mapToInt(MxpData::maxCt).sum();
+    int sum = 0;
+    for (MxpData chunk : this.chunks) {
+      sum += chunk.maxCt();
+    }
+    return sum;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Shf.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Shf.java
@@ -21,7 +21,6 @@ import java.util.List;
 import net.consensys.linea.zktracer.ColumnHeader;
 import net.consensys.linea.zktracer.container.stacked.set.StackedSet;
 import net.consensys.linea.zktracer.module.Module;
-import net.consensys.linea.zktracer.module.wcp.WcpOperation;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.types.UnsignedByte;
 import org.apache.tuweni.bytes.Bytes;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Shf.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Shf.java
@@ -21,6 +21,7 @@ import java.util.List;
 import net.consensys.linea.zktracer.ColumnHeader;
 import net.consensys.linea.zktracer.container.stacked.set.StackedSet;
 import net.consensys.linea.zktracer.module.Module;
+import net.consensys.linea.zktracer.module.wcp.WcpOperation;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.types.UnsignedByte;
 import org.apache.tuweni.bytes.Bytes;
@@ -139,6 +140,10 @@ public class Shf implements Module {
 
   @Override
   public int lineCount() {
-    return this.operations.stream().mapToInt(ShfOperation::maxCt).sum();
+    int sum = 0;
+    for (ShfOperation shfOperation : this.operations) {
+      sum += shfOperation.maxCt();
+    }
+    return sum;
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Wcp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Wcp.java
@@ -23,6 +23,7 @@ import net.consensys.linea.zktracer.ColumnHeader;
 import net.consensys.linea.zktracer.container.stacked.set.StackedSet;
 import net.consensys.linea.zktracer.module.Module;
 import net.consensys.linea.zktracer.module.hub.Hub;
+import net.consensys.linea.zktracer.module.mxp.MxpData;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.types.Bytes16;
 import net.consensys.linea.zktracer.types.UnsignedByte;
@@ -127,7 +128,11 @@ public class Wcp implements Module {
 
   @Override
   public int lineCount() {
-    return this.operations.stream().mapToInt(WcpOperation::maxCt).sum();
+    int sum = 0;
+    for (WcpOperation wcpOperation : this.operations) {
+      sum += wcpOperation.maxCt();
+    }
+    return sum;
   }
 
   public boolean callLT(Bytes32 arg1, Bytes32 arg2) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Wcp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Wcp.java
@@ -23,7 +23,6 @@ import net.consensys.linea.zktracer.ColumnHeader;
 import net.consensys.linea.zktracer.container.stacked.set.StackedSet;
 import net.consensys.linea.zktracer.module.Module;
 import net.consensys.linea.zktracer.module.hub.Hub;
-import net.consensys.linea.zktracer.module.mxp.MxpData;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.types.Bytes16;
 import net.consensys.linea.zktracer.types.UnsignedByte;


### PR DESCRIPTION
The primary enhancement in this PR pertains to StackedSet, where we've replaced the underlying data structure, Stack, with Deque. This change significantly improves performance by eliminating the need for synchronization.

Additionally, we've revamped the construction of the collapsed stack. Rather than using an isDirty flag and rebuilding the entire collapsed set each time there's a modification, we've opted for an incremental approach. Now, the collapsed set is built each time the stacked set is altered, thereby avoiding the need to recreate the collapsed stack entirely.

We've also optimized the 'lineCount' method in some modules. Instead of using a stream and calling the 'mapToInt' method, which carries a significant overhead, we've chosen to use a simple 'for' loop. This change enhances performance by reducing unnecessary complexity.

We can find below the CPU profiling before and after this PR

**Before this PR**
<img width="1725" alt="image" src="https://github.com/Consensys/besu-sequencer-plugins/assets/5099602/4953995a-2d45-4774-8c2f-0a66838cda12">



**After this PR**
<img width="1725" alt="image" src="https://github.com/Consensys/besu-sequencer-plugins/assets/5099602/e48ee504-d079-4e24-bd9e-79c34d98febb">


