### PR TITLE
perf: delay computations at trace time

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/Add.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/Add.java
@@ -20,28 +20,15 @@ import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 import net.consensys.linea.zktracer.ColumnHeader;
-import net.consensys.linea.zktracer.bytestheta.BaseBytes;
 import net.consensys.linea.zktracer.container.stacked.set.StackedSet;
 import net.consensys.linea.zktracer.module.Module;
 import net.consensys.linea.zktracer.module.hub.Hub;
-import net.consensys.linea.zktracer.opcode.OpCode;
-import net.consensys.linea.zktracer.opcode.OpCodeData;
-import net.consensys.linea.zktracer.opcode.OpCodes;
-import net.consensys.linea.zktracer.types.Bytes16;
-import net.consensys.linea.zktracer.types.UnsignedByte;
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 /** Implementation of a {@link Module} for addition/subtraction. */
 @RequiredArgsConstructor
 public class Add implements Module {
-  private static final UInt256 TWO_TO_THE_128 = UInt256.ONE.shiftLeft(128);
-
   private final Hub hub;
-
-  private int stamp = 0;
 
   /** A set of the operations to trace */
   private final StackedSet<AddOperation> chunks = new StackedSet<>();
@@ -63,100 +50,7 @@ public class Add implements Module {
 
   @Override
   public void tracePreOpcode(MessageFrame frame) {
-    final Bytes32 arg1 = Bytes32.leftPad(frame.getStackItem(0));
-    final Bytes32 arg2 = Bytes32.leftPad(frame.getStackItem(1));
-
-    this.chunks.add(new AddOperation(hub.opCode(), arg1, arg2));
-  }
-
-  /**
-   * Returns the appropriate state of the overflow bit depending on the position within the cycle.
-   *
-   * @param counter current position within the tracing cycle
-   * @param overflowHi putative overflow bit of the high part
-   * @param overflowLo putative overflow bit of the high part
-   * @return the overflow bit to trace
-   */
-  private static boolean overflowBit(
-      final int counter, final boolean overflowHi, final boolean overflowLo) {
-    if (counter == 14) {
-      return overflowHi;
-    }
-
-    if (counter == 15) {
-      return overflowLo;
-    }
-
-    return false;
-  }
-
-  /**
-   * Generates the trace for a single instance of an operation.
-   *
-   * @param opCode the operations, ADD or SUB
-   * @param arg1 first operand
-   * @param arg2 second operand
-   */
-  private void traceAddOperation(OpCode opCode, Bytes32 arg1, Bytes32 arg2, Trace trace) {
-    this.stamp++;
-
-    final Bytes16 arg1Hi = Bytes16.wrap(arg1.slice(0, 16));
-    final Bytes32 arg1Lo = Bytes32.leftPad(arg1.slice(16));
-    final Bytes16 arg2Hi = Bytes16.wrap(arg2.slice(0, 16));
-    final Bytes16 arg2Lo = Bytes16.wrap(arg2.slice(16));
-
-    boolean overflowHi = false;
-    boolean overflowLo;
-
-    final OpCodeData opCodeData = OpCodes.of(opCode);
-
-    final BaseBytes res = Adder.addSub(opCode, arg1, arg2);
-
-    final Bytes16 resHi = res.getHigh();
-    final Bytes16 resLo = res.getLow();
-
-    UInt256 arg1Int = UInt256.fromBytes(arg1);
-    UInt256 arg2Int = UInt256.fromBytes(arg2);
-    UInt256 resultBytes;
-
-    if (opCode == OpCode.ADD) {
-      resultBytes = arg1Int.add(arg2Int);
-      if (resultBytes.compareTo(arg1Int) < 0) {
-        overflowHi = true;
-      }
-    } else if (opCode == OpCode.SUB) {
-      if (arg1Int.compareTo(arg2Int) < 0) {
-        overflowHi = true;
-      }
-    }
-
-    for (int i = 0; i < 16; i++) {
-      Bytes32 addRes;
-      if (opCode == OpCode.ADD) {
-        addRes = Bytes32.wrap((UInt256.fromBytes(arg1Lo)).add(UInt256.fromBytes(arg2Lo)));
-      } else {
-        addRes = Bytes32.wrap((UInt256.fromBytes(resLo)).add(UInt256.fromBytes(arg2Lo)));
-      }
-
-      overflowLo = (addRes.compareTo(TWO_TO_THE_128) >= 0);
-
-      trace
-          .acc1(resHi.slice(0, 1 + i))
-          .acc2(resLo.slice(0, 1 + i))
-          .arg1Hi(arg1Hi)
-          .arg1Lo(arg1Lo)
-          .arg2Hi(arg2Hi)
-          .arg2Lo(arg2Lo)
-          .byte1(UnsignedByte.of(resHi.get(i)))
-          .byte2(UnsignedByte.of(resLo.get(i)))
-          .ct(Bytes.of(i))
-          .inst(Bytes.of(opCodeData.value()))
-          .overflow(overflowBit(i, overflowHi, overflowLo))
-          .resHi(resHi)
-          .resLo(resLo)
-          .stamp(Bytes.ofUnsignedLong(stamp))
-          .validateRow();
-    }
+    this.chunks.add(new AddOperation(hub.opCode(), frame.getStackItem(0), frame.getStackItem(1)));
   }
 
   @Override
@@ -167,8 +61,10 @@ public class Add implements Module {
   @Override
   public void commit(List<MappedByteBuffer> buffers) {
     final Trace trace = new Trace(buffers);
+    int stamp = 0;
     for (AddOperation op : this.chunks) {
-      this.traceAddOperation(op.opCodem(), op.arg1(), op.arg2(), trace);
+      stamp++;
+      op.trace(stamp, trace);
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/AddOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/AddOperation.java
@@ -30,8 +30,8 @@ public final class AddOperation {
   private static final UInt256 TWO_TO_THE_128 = UInt256.ONE.shiftLeft(128);
 
   private final OpCode opCode;
-  private final Bytes rawArg1;
-  private final Bytes rawArg2;
+  private final Bytes32 arg1;
+  private final Bytes32 arg2;
 
   /**
    * Returns the appropriate state of the overflow bit depending on the position within the cycle.
@@ -56,14 +56,11 @@ public final class AddOperation {
 
   public AddOperation(OpCode opCode, Bytes arg1, Bytes arg2) {
     this.opCode = opCode;
-    this.rawArg1 = arg1;
-    this.rawArg2 = arg2;
+    this.arg1 = Bytes32.leftPad(arg1);
+    this.arg2 = Bytes32.leftPad(arg2);
   }
 
   void trace(int stamp, Trace trace) {
-    final Bytes32 arg1 = Bytes32.leftPad(this.rawArg1);
-    final Bytes32 arg2 = Bytes32.leftPad(this.rawArg2);
-
     final Bytes16 arg1Hi = Bytes16.wrap(arg1.slice(0, 16));
     final Bytes32 arg1Lo = Bytes32.leftPad(arg1.slice(16));
     final Bytes16 arg2Hi = Bytes16.wrap(arg2.slice(0, 16));
@@ -122,7 +119,7 @@ public final class AddOperation {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.opCode, this.rawArg1, this.rawArg2);
+    return Objects.hashCode(this.opCode, this.arg1, this.arg2);
   }
 
   @Override
@@ -131,7 +128,7 @@ public final class AddOperation {
     if (o == null || getClass() != o.getClass()) return false;
     final AddOperation that = (AddOperation) o;
     return java.util.Objects.equals(this.opCode, that.opCode)
-        && java.util.Objects.equals(this.rawArg1, that.rawArg1)
-        && java.util.Objects.equals(this.rawArg2, that.rawArg2);
+        && java.util.Objects.equals(this.arg1, that.arg1)
+        && java.util.Objects.equals(this.arg2, that.arg2);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/AddOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/AddOperation.java
@@ -32,8 +32,6 @@ public final class AddOperation {
   private final OpCode opCode;
   private final Bytes rawArg1;
   private final Bytes rawArg2;
-  private Bytes32 arg1;
-  private Bytes32 arg2;
 
   /**
    * Returns the appropriate state of the overflow bit depending on the position within the cycle.
@@ -63,8 +61,8 @@ public final class AddOperation {
   }
 
   void trace(int stamp, Trace trace) {
-    this.arg1 = Bytes32.leftPad(this.rawArg1);
-    this.arg2 = Bytes32.leftPad(this.rawArg2);
+    final Bytes32 arg1 = Bytes32.leftPad(this.rawArg1);
+    final Bytes32 arg2 = Bytes32.leftPad(this.rawArg2);
 
     final Bytes16 arg1Hi = Bytes16.wrap(arg1.slice(0, 16));
     final Bytes32 arg1Lo = Bytes32.leftPad(arg1.slice(16));
@@ -72,7 +70,6 @@ public final class AddOperation {
     final Bytes16 arg2Lo = Bytes16.wrap(arg2.slice(16));
 
     boolean overflowHi = false;
-    boolean overflowLo;
 
     final OpCodeData opCodeData = OpCodes.of(opCode);
 
@@ -81,12 +78,11 @@ public final class AddOperation {
     final Bytes16 resHi = res.getHigh();
     final Bytes16 resLo = res.getLow();
 
-    UInt256 arg1Int = UInt256.fromBytes(arg1);
-    UInt256 arg2Int = UInt256.fromBytes(arg2);
-    UInt256 resultBytes;
+    final UInt256 arg1Int = UInt256.fromBytes(arg1);
+    final UInt256 arg2Int = UInt256.fromBytes(arg2);
 
     if (opCode == OpCode.ADD) {
-      resultBytes = arg1Int.add(arg2Int);
+      final UInt256 resultBytes = arg1Int.add(arg2Int);
       if (resultBytes.compareTo(arg1Int) < 0) {
         overflowHi = true;
       }
@@ -103,8 +99,7 @@ public final class AddOperation {
       } else {
         addRes = Bytes32.wrap((UInt256.fromBytes(resLo)).add(UInt256.fromBytes(arg2Lo)));
       }
-
-      overflowLo = (addRes.compareTo(TWO_TO_THE_128) >= 0);
+      final boolean overflowLo = (addRes.compareTo(TWO_TO_THE_128) >= 0);
 
       trace
           .acc1(resHi.slice(0, 1 + i))

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/AddOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/AddOperation.java
@@ -127,7 +127,7 @@ public final class AddOperation {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(opCode, arg1, arg2);
+    return Objects.hashCode(this.opCode, this.rawArg1, this.rawArg2);
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/AddOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/AddOperation.java
@@ -15,7 +15,128 @@
 
 package net.consensys.linea.zktracer.module.add;
 
+import com.google.common.base.Objects;
+import net.consensys.linea.zktracer.bytestheta.BaseBytes;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
+import net.consensys.linea.zktracer.opcode.OpCodes;
+import net.consensys.linea.zktracer.types.Bytes16;
+import net.consensys.linea.zktracer.types.UnsignedByte;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 
-public record AddOperation(OpCode opCodem, Bytes32 arg1, Bytes32 arg2) {}
+public final class AddOperation {
+  private static final UInt256 TWO_TO_THE_128 = UInt256.ONE.shiftLeft(128);
+
+  private final OpCode opCode;
+  private final Bytes rawArg1;
+  private final Bytes rawArg2;
+  private Bytes32 arg1;
+  private Bytes32 arg2;
+
+  /**
+   * Returns the appropriate state of the overflow bit depending on the position within the cycle.
+   *
+   * @param counter current position within the tracing cycle
+   * @param overflowHi putative overflow bit of the high part
+   * @param overflowLo putative overflow bit of the high part
+   * @return the overflow bit to trace
+   */
+  private static boolean overflowBit(
+      final int counter, final boolean overflowHi, final boolean overflowLo) {
+    if (counter == 14) {
+      return overflowHi;
+    }
+
+    if (counter == 15) {
+      return overflowLo;
+    }
+
+    return false;
+  }
+
+  public AddOperation(OpCode opCode, Bytes arg1, Bytes arg2) {
+    this.opCode = opCode;
+    this.rawArg1 = arg1;
+    this.rawArg2 = arg2;
+  }
+
+  void trace(int stamp, Trace trace) {
+    this.arg1 = Bytes32.leftPad(this.rawArg1);
+    this.arg2 = Bytes32.leftPad(this.rawArg2);
+
+    final Bytes16 arg1Hi = Bytes16.wrap(arg1.slice(0, 16));
+    final Bytes32 arg1Lo = Bytes32.leftPad(arg1.slice(16));
+    final Bytes16 arg2Hi = Bytes16.wrap(arg2.slice(0, 16));
+    final Bytes16 arg2Lo = Bytes16.wrap(arg2.slice(16));
+
+    boolean overflowHi = false;
+    boolean overflowLo;
+
+    final OpCodeData opCodeData = OpCodes.of(opCode);
+
+    final BaseBytes res = Adder.addSub(opCode, arg1, arg2);
+
+    final Bytes16 resHi = res.getHigh();
+    final Bytes16 resLo = res.getLow();
+
+    UInt256 arg1Int = UInt256.fromBytes(arg1);
+    UInt256 arg2Int = UInt256.fromBytes(arg2);
+    UInt256 resultBytes;
+
+    if (opCode == OpCode.ADD) {
+      resultBytes = arg1Int.add(arg2Int);
+      if (resultBytes.compareTo(arg1Int) < 0) {
+        overflowHi = true;
+      }
+    } else if (opCode == OpCode.SUB) {
+      if (arg1Int.compareTo(arg2Int) < 0) {
+        overflowHi = true;
+      }
+    }
+
+    for (int i = 0; i < 16; i++) {
+      Bytes32 addRes;
+      if (opCode == OpCode.ADD) {
+        addRes = Bytes32.wrap((UInt256.fromBytes(arg1Lo)).add(UInt256.fromBytes(arg2Lo)));
+      } else {
+        addRes = Bytes32.wrap((UInt256.fromBytes(resLo)).add(UInt256.fromBytes(arg2Lo)));
+      }
+
+      overflowLo = (addRes.compareTo(TWO_TO_THE_128) >= 0);
+
+      trace
+          .acc1(resHi.slice(0, 1 + i))
+          .acc2(resLo.slice(0, 1 + i))
+          .arg1Hi(arg1Hi)
+          .arg1Lo(arg1Lo)
+          .arg2Hi(arg2Hi)
+          .arg2Lo(arg2Lo)
+          .byte1(UnsignedByte.of(resHi.get(i)))
+          .byte2(UnsignedByte.of(resLo.get(i)))
+          .ct(Bytes.of(i))
+          .inst(Bytes.of(opCodeData.value()))
+          .overflow(overflowBit(i, overflowHi, overflowLo))
+          .resHi(resHi)
+          .resLo(resLo)
+          .stamp(Bytes.ofUnsignedLong(stamp))
+          .validateRow();
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(opCode, arg1, arg2);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final AddOperation that = (AddOperation) o;
+    return java.util.Objects.equals(this.opCode, that.opCode)
+        && java.util.Objects.equals(this.rawArg1, that.rawArg1)
+        && java.util.Objects.equals(this.rawArg2, that.rawArg2);
+  }
+}

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Exceptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Exceptions.java
@@ -297,7 +297,7 @@ public final class Exceptions {
    */
   public void prepare(final MessageFrame frame, GasProjector gp) {
     OpCode opCode = hub.opCode();
-    OpCodeData opCodeData = opCode.getData();
+    OpCodeData opCodeData = hub.opCodeData();
 
     this.reset();
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/TraceSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/TraceSection.java
@@ -63,7 +63,7 @@ public abstract class TraceSection {
   private int nonStackRowsCounter;
 
   /** A list of {@link TraceLine} representing the trace lines associated with this section. */
-  @Getter List<TraceLine> lines = new ArrayList<>(16);
+  @Getter List<TraceLine> lines = new ArrayList<>(32);
 
   /**
    * Fill the columns shared by all operations.

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mod/Mod.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mod/Mod.java
@@ -24,16 +24,12 @@ import net.consensys.linea.zktracer.module.Module;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.opcode.OpCodes;
-import net.consensys.linea.zktracer.types.UnsignedByte;
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.worldstate.WorldView;
 
 public class Mod implements Module {
-  private int stamp = 0;
-
   @Override
   public String moduleKey() {
     return "MOD";
@@ -65,83 +61,13 @@ public class Mod implements Module {
     this.chunks.enter();
   }
 
-  public void traceModOperation(ModOperation op, Trace trace) {
-    this.stamp++;
-
-    for (int i = 0; i < op.maxCounter(); i++) {
-      final int accLength = i + 1;
-      trace
-          .stamp(Bytes.ofUnsignedLong(stamp))
-          .oli(op.isOli())
-          .ct(Bytes.of(i))
-          .inst(Bytes.of(op.getOpCode().byteValue()))
-          .decSigned(op.isSigned())
-          .decOutput(op.isDiv())
-          .arg1Hi(op.getArg1().getHigh())
-          .arg1Lo(op.getArg1().getLow())
-          .arg2Hi(op.getArg2().getHigh())
-          .arg2Lo(op.getArg2().getLow())
-          .resHi(op.getResult().getHigh())
-          .resLo(op.getResult().getLow())
-          .acc12(op.getArg1().getBytes32().slice(8, i + 1))
-          .acc13(op.getArg1().getBytes32().slice(0, i + 1))
-          .acc22(op.getArg2().getBytes32().slice(8, i + 1))
-          .acc23(op.getArg2().getBytes32().slice(0, i + 1))
-          .accB0(op.getBBytes().get(0).slice(0, accLength))
-          .accB1(op.getBBytes().get(1).slice(0, accLength))
-          .accB2(op.getBBytes().get(2).slice(0, accLength))
-          .accB3(op.getBBytes().get(3).slice(0, accLength))
-          .accR0(op.getRBytes().get(0).slice(0, accLength))
-          .accR1(op.getRBytes().get(1).slice(0, accLength))
-          .accR2(op.getRBytes().get(2).slice(0, accLength))
-          .accR3(op.getRBytes().get(3).slice(0, accLength))
-          .accQ0(op.getQBytes().get(0).slice(0, accLength))
-          .accQ1(op.getQBytes().get(1).slice(0, accLength))
-          .accQ2(op.getQBytes().get(2).slice(0, accLength))
-          .accQ3(op.getQBytes().get(3).slice(0, accLength))
-          .accDelta0(op.getDBytes().get(0).slice(0, accLength))
-          .accDelta1(op.getDBytes().get(1).slice(0, accLength))
-          .accDelta2(op.getDBytes().get(2).slice(0, accLength))
-          .accDelta3(op.getDBytes().get(3).slice(0, accLength))
-          .byte22(UnsignedByte.of(op.getArg2().getByte(i + 8)))
-          .byte23(UnsignedByte.of(op.getArg2().getByte(i)))
-          .byte12(UnsignedByte.of(op.getArg1().getByte(i + 8)))
-          .byte13(UnsignedByte.of(op.getArg1().getByte(i)))
-          .byteB0(UnsignedByte.of(op.getBBytes().get(0).get(i)))
-          .byteB1(UnsignedByte.of(op.getBBytes().get(1).get(i)))
-          .byteB2(UnsignedByte.of(op.getBBytes().get(2).get(i)))
-          .byteB3(UnsignedByte.of(op.getBBytes().get(3).get(i)))
-          .byteR0(UnsignedByte.of(op.getRBytes().get(0).get(i)))
-          .byteR1(UnsignedByte.of(op.getRBytes().get(1).get(i)))
-          .byteR2(UnsignedByte.of(op.getRBytes().get(2).get(i)))
-          .byteR3(UnsignedByte.of(op.getRBytes().get(3).get(i)))
-          .byteQ0(UnsignedByte.of(op.getQBytes().get(0).get(i)))
-          .byteQ1(UnsignedByte.of(op.getQBytes().get(1).get(i)))
-          .byteQ2(UnsignedByte.of(op.getQBytes().get(2).get(i)))
-          .byteQ3(UnsignedByte.of(op.getQBytes().get(3).get(i)))
-          .byteDelta0(UnsignedByte.of(op.getDBytes().get(0).get(i)))
-          .byteDelta1(UnsignedByte.of(op.getDBytes().get(1).get(i)))
-          .byteDelta2(UnsignedByte.of(op.getDBytes().get(2).get(i)))
-          .byteDelta3(UnsignedByte.of(op.getDBytes().get(3).get(i)))
-          .byteH0(UnsignedByte.of(op.getHBytes().get(0).get(i)))
-          .byteH1(UnsignedByte.of(op.getHBytes().get(1).get(i)))
-          .byteH2(UnsignedByte.of(op.getHBytes().get(2).get(i)))
-          .accH0(Bytes.wrap(op.getHBytes().get(0)).slice(0, i + 1))
-          .accH1(Bytes.wrap(op.getHBytes().get(1)).slice(0, i + 1))
-          .accH2(Bytes.wrap(op.getHBytes().get(2)).slice(0, i + 1))
-          .cmp1(op.getCmp1()[i])
-          .cmp2(op.getCmp2()[i])
-          .msb1(op.getMsb1()[i])
-          .msb2(op.getMsb2()[i])
-          .validateRow();
-    }
-  }
-
   @Override
   public void commit(List<MappedByteBuffer> buffers) {
     final Trace trace = new Trace(buffers);
+    int stamp = 0;
     for (ModOperation op : this.chunks) {
-      this.traceModOperation(op, trace);
+      stamp++;
+      op.trace(trace, stamp);
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/Mxp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/Mxp.java
@@ -26,6 +26,7 @@ import net.consensys.linea.zktracer.module.Module;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.opcode.gas.BillingRate;
 import net.consensys.linea.zktracer.opcode.gas.MxpType;
+import net.consensys.linea.zktracer.types.EWord;
 import net.consensys.linea.zktracer.types.UnsignedByte;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -59,85 +60,6 @@ public class Mxp implements Module {
     //    sanityCheck(opCode, scope, mxpData);
   }
 
-  final void traceChunk(final MxpData chunk, int stamp, Trace trace) {
-    Bytes32 acc1Bytes32 = Bytes32.leftPad(bigIntegerToBytes(chunk.getAcc1()));
-    Bytes32 acc2Bytes32 = Bytes32.leftPad(bigIntegerToBytes(chunk.getAcc2()));
-    Bytes32 acc3Bytes32 = Bytes32.leftPad(bigIntegerToBytes(chunk.getAcc3()));
-    Bytes32 acc4Bytes32 = Bytes32.leftPad(bigIntegerToBytes(chunk.getAcc4()));
-    Bytes32 accABytes32 = Bytes32.leftPad(bigIntegerToBytes(chunk.getAccA()));
-    Bytes32 accWBytes32 = Bytes32.leftPad(bigIntegerToBytes(chunk.getAccW()));
-    Bytes32 accQBytes32 = Bytes32.leftPad(bigIntegerToBytes(chunk.getAccQ()));
-
-    int maxCt = chunk.maxCt();
-    int maxCtComplement = 32 - maxCt;
-
-    for (int i = 0; i < maxCt; i++) {
-      trace
-          .stamp(Bytes.ofUnsignedLong(stamp))
-          .cn(Bytes.ofUnsignedLong(chunk.getContextNumber()))
-          .ct(Bytes.of(i))
-          .roob(chunk.isRoob())
-          .noop(chunk.isNoOperation())
-          .mxpx(chunk.isMxpx())
-          .inst(Bytes.of(chunk.getOpCodeData().value()))
-          .mxpType1(chunk.getOpCodeData().billing().type() == MxpType.TYPE_1)
-          .mxpType2(chunk.getOpCodeData().billing().type() == MxpType.TYPE_2)
-          .mxpType3(chunk.getOpCodeData().billing().type() == MxpType.TYPE_3)
-          .mxpType4(chunk.getOpCodeData().billing().type() == MxpType.TYPE_4)
-          .mxpType5(chunk.getOpCodeData().billing().type() == MxpType.TYPE_5)
-          .gword(
-              Bytes.ofUnsignedLong(
-                  chunk.getOpCodeData().billing().billingRate() == BillingRate.BY_WORD
-                      ? chunk.getOpCodeData().billing().perUnit().cost()
-                      : 0))
-          .gbyte(
-              Bytes.ofUnsignedLong(
-                  chunk.getOpCodeData().billing().billingRate() == BillingRate.BY_BYTE
-                      ? chunk.getOpCodeData().billing().perUnit().cost()
-                      : 0))
-          .deploys(chunk.isDeploys())
-          .offset1Hi(chunk.getOffset1().hi())
-          .offset1Lo(chunk.getOffset1().lo())
-          .offset2Hi(chunk.getOffset2().hi())
-          .offset2Lo(chunk.getOffset2().lo())
-          .size1Hi(chunk.getSize1().hi())
-          .size1Lo(chunk.getSize1().lo())
-          .size2Hi(chunk.getSize2().hi())
-          .size2Lo(chunk.getSize2().lo())
-          .maxOffset1(bigIntegerToBytes(chunk.getMaxOffset1()))
-          .maxOffset2(bigIntegerToBytes(chunk.getMaxOffset2()))
-          .maxOffset(bigIntegerToBytes(chunk.getMaxOffset()))
-          .comp(chunk.isComp())
-          .acc1(acc1Bytes32.slice(maxCtComplement, 1 + i))
-          .acc2(acc2Bytes32.slice(maxCtComplement, 1 + i))
-          .acc3(acc3Bytes32.slice(maxCtComplement, 1 + i))
-          .acc4(acc4Bytes32.slice(maxCtComplement, 1 + i))
-          .accA(accABytes32.slice(maxCtComplement, 1 + i))
-          .accW(accWBytes32.slice(maxCtComplement, 1 + i))
-          .accQ(accQBytes32.slice(maxCtComplement, 1 + i))
-          .byte1(UnsignedByte.of(acc1Bytes32.get(maxCtComplement + i)))
-          .byte2(UnsignedByte.of(acc2Bytes32.get(maxCtComplement + i)))
-          .byte3(UnsignedByte.of(acc3Bytes32.get(maxCtComplement + i)))
-          .byte4(UnsignedByte.of(acc4Bytes32.get(maxCtComplement + i)))
-          .byteA(UnsignedByte.of(accABytes32.get(maxCtComplement + i)))
-          .byteW(UnsignedByte.of(accWBytes32.get(maxCtComplement + i)))
-          .byteQ(UnsignedByte.of(accQBytes32.get(maxCtComplement + i)))
-          .byteQq(Bytes.ofUnsignedLong(chunk.getByteQQ()[i].toInteger()))
-          .byteR(Bytes.ofUnsignedLong(chunk.getByteR()[i].toInteger()))
-          .words(Bytes.ofUnsignedLong(chunk.getWords()))
-          .wordsNew(
-              Bytes.ofUnsignedLong(
-                  chunk.getWordsNew())) // TODO: Could (should?) be set in tracePostOp?
-          .cMem(Bytes.ofUnsignedLong(chunk.getCMem())) // Returns current memory size in EVM words
-          .cMemNew(Bytes.ofUnsignedLong(chunk.getCMemNew()))
-          .quadCost(Bytes.ofUnsignedLong(chunk.getQuadCost()))
-          .linCost(Bytes.ofUnsignedLong(chunk.getLinCost()))
-          .gasMxp(Bytes.ofUnsignedLong(chunk.getQuadCost() + chunk.getEffectiveLinCost()))
-          .expands(chunk.isExpands())
-          .validateRow();
-    }
-  }
-
   @Override
   public void enterTransaction() {
     this.chunks.enter();
@@ -166,7 +88,7 @@ public class Mxp implements Module {
   public void commit(List<MappedByteBuffer> buffers) {
     final Trace trace = new Trace(buffers);
     for (int i = 0; i < this.chunks.size(); i++) {
-      this.traceChunk(this.chunks.get(i), i + 1, trace);
+      this.chunks.get(i).trace(i + 1, trace);
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/Mxp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/Mxp.java
@@ -15,8 +15,6 @@
 
 package net.consensys.linea.zktracer.module.mxp;
 
-import static net.consensys.linea.zktracer.types.Conversions.bigIntegerToBytes;
-
 import java.nio.MappedByteBuffer;
 import java.util.List;
 
@@ -24,12 +22,6 @@ import net.consensys.linea.zktracer.ColumnHeader;
 import net.consensys.linea.zktracer.container.stacked.list.StackedList;
 import net.consensys.linea.zktracer.module.Module;
 import net.consensys.linea.zktracer.module.hub.Hub;
-import net.consensys.linea.zktracer.opcode.gas.BillingRate;
-import net.consensys.linea.zktracer.opcode.gas.MxpType;
-import net.consensys.linea.zktracer.types.EWord;
-import net.consensys.linea.zktracer.types.UnsignedByte;
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 /** Implementation of a {@link Module} for memory expansion. */

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/MxpData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/MxpData.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.mxp;
 
 import static net.consensys.linea.zktracer.module.Util.max;
+import static net.consensys.linea.zktracer.types.Conversions.bigIntegerToBytes;
 import static org.hyperledger.besu.evm.internal.Words.clampedAdd;
 import static org.hyperledger.besu.evm.internal.Words.clampedMultiply;
 
@@ -33,6 +34,7 @@ import net.consensys.linea.zktracer.opcode.gas.GasConstants;
 import net.consensys.linea.zktracer.opcode.gas.MxpType;
 import net.consensys.linea.zktracer.types.EWord;
 import net.consensys.linea.zktracer.types.UnsignedByte;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -85,7 +87,7 @@ public class MxpData {
   private final boolean deploys;
 
   public MxpData(final MessageFrame frame, final Hub hub) {
-    this.opCodeData = OpCodes.of(frame.getCurrentOperation().getOpcode());
+    this.opCodeData = hub.opCodeData();
     this.contextNumber = hub.currentFrame().contextNumber();
     this.typeMxp = opCodeData.billing().type();
 
@@ -100,12 +102,14 @@ public class MxpData {
     setNoOperation();
     setMaxOffset1and2();
     setMaxOffsetAndMxpx();
-
     setInitializeByteArrays();
-
     setAccAAndFirstTwoBytesOfByteR();
     setExpands();
-    setWordsAndCMem(frame);
+    setWordsNew(frame);
+  }
+
+  void compute() {
+    setCMemNew();
     setComp();
     setAcc1and2();
     setAcc3();
@@ -248,7 +252,7 @@ public class MxpData {
   }
 
   // This is a copy and past from FrontierGasCalculator.java
-  private long memoryCost(final long length) {
+  private static long memoryCost(final long length) {
     final long lengthSquare = clampedMultiply(length, length);
     final long base =
         (lengthSquare == Long.MAX_VALUE)
@@ -407,7 +411,6 @@ public class MxpData {
     Bytes32 bW = UInt256.valueOf(accW);
     Bytes32 bQ = UInt256.valueOf(accQ);
     for (int i = 0; i < maxCt; i++) {
-
       byte1[i] = UnsignedByte.of(b1.get(b1.size() - 1 - maxCt + i));
       byte2[i] = UnsignedByte.of(b2.get(b2.size() - 1 - maxCt + i));
       byte3[i] = UnsignedByte.of(b3.get(b3.size() - 1 - maxCt + i));
@@ -416,11 +419,6 @@ public class MxpData {
       byteW[i] = UnsignedByte.of(bW.get(bW.size() - 1 - maxCt + i));
       byteQ[i] = UnsignedByte.of(bQ.get(bQ.size() - 1 - maxCt + i));
     }
-  }
-
-  private void setWordsAndCMem(final MessageFrame frame) {
-    setWordsNew(frame);
-    setCMemNew();
   }
 
   private void setWordsNew(final MessageFrame frame) {
@@ -467,6 +465,92 @@ public class MxpData {
       } else {
         return 0;
       }
+    }
+  }
+
+  final void trace(int stamp, Trace trace) {
+    this.compute();
+
+    Bytes32 acc1Bytes32 = Bytes32.leftPad(bigIntegerToBytes(this.getAcc1()));
+    Bytes32 acc2Bytes32 = Bytes32.leftPad(bigIntegerToBytes(this.getAcc2()));
+    Bytes32 acc3Bytes32 = Bytes32.leftPad(bigIntegerToBytes(this.getAcc3()));
+    Bytes32 acc4Bytes32 = Bytes32.leftPad(bigIntegerToBytes(this.getAcc4()));
+    Bytes32 accABytes32 = Bytes32.leftPad(bigIntegerToBytes(this.getAccA()));
+    Bytes32 accWBytes32 = Bytes32.leftPad(bigIntegerToBytes(this.getAccW()));
+    Bytes32 accQBytes32 = Bytes32.leftPad(bigIntegerToBytes(this.getAccQ()));
+    final EWord eOffset1 = EWord.of(this.offset1);
+    final EWord eOffset2 = EWord.of(this.offset2);
+    final EWord eSize1 = EWord.of(this.size1);
+    final EWord eSize2 = EWord.of(this.size2);
+
+
+    int maxCt = this.maxCt();
+    int maxCtComplement = 32 - maxCt;
+
+    for (int i = 0; i < maxCt; i++) {
+      trace
+        .stamp(Bytes.ofUnsignedLong(stamp))
+        .cn(Bytes.ofUnsignedLong(this.getContextNumber()))
+        .ct(Bytes.of(i))
+        .roob(this.isRoob())
+        .noop(this.isNoOperation())
+        .mxpx(this.isMxpx())
+        .inst(Bytes.of(this.getOpCodeData().value()))
+        .mxpType1(this.getOpCodeData().billing().type() == MxpType.TYPE_1)
+        .mxpType2(this.getOpCodeData().billing().type() == MxpType.TYPE_2)
+        .mxpType3(this.getOpCodeData().billing().type() == MxpType.TYPE_3)
+        .mxpType4(this.getOpCodeData().billing().type() == MxpType.TYPE_4)
+        .mxpType5(this.getOpCodeData().billing().type() == MxpType.TYPE_5)
+        .gword(
+          Bytes.ofUnsignedLong(
+            this.getOpCodeData().billing().billingRate() == BillingRate.BY_WORD
+              ? this.getOpCodeData().billing().perUnit().cost()
+              : 0))
+        .gbyte(
+          Bytes.ofUnsignedLong(
+            this.getOpCodeData().billing().billingRate() == BillingRate.BY_BYTE
+              ? this.getOpCodeData().billing().perUnit().cost()
+              : 0))
+        .deploys(this.isDeploys())
+        .offset1Hi(eOffset1.hi())
+        .offset1Lo(eOffset1.lo())
+        .offset2Hi(eOffset2.hi())
+        .offset2Lo(eOffset2.lo())
+        .size1Hi(eSize1.hi())
+        .size1Lo(eSize1.lo())
+        .size2Hi(eSize2.hi())
+        .size2Lo(eSize2.lo())
+        .maxOffset1(bigIntegerToBytes(this.getMaxOffset1()))
+        .maxOffset2(bigIntegerToBytes(this.getMaxOffset2()))
+        .maxOffset(bigIntegerToBytes(this.getMaxOffset()))
+        .comp(this.isComp())
+        .acc1(acc1Bytes32.slice(maxCtComplement, 1 + i))
+        .acc2(acc2Bytes32.slice(maxCtComplement, 1 + i))
+        .acc3(acc3Bytes32.slice(maxCtComplement, 1 + i))
+        .acc4(acc4Bytes32.slice(maxCtComplement, 1 + i))
+        .accA(accABytes32.slice(maxCtComplement, 1 + i))
+        .accW(accWBytes32.slice(maxCtComplement, 1 + i))
+        .accQ(accQBytes32.slice(maxCtComplement, 1 + i))
+        .byte1(UnsignedByte.of(acc1Bytes32.get(maxCtComplement + i)))
+        .byte2(UnsignedByte.of(acc2Bytes32.get(maxCtComplement + i)))
+        .byte3(UnsignedByte.of(acc3Bytes32.get(maxCtComplement + i)))
+        .byte4(UnsignedByte.of(acc4Bytes32.get(maxCtComplement + i)))
+        .byteA(UnsignedByte.of(accABytes32.get(maxCtComplement + i)))
+        .byteW(UnsignedByte.of(accWBytes32.get(maxCtComplement + i)))
+        .byteQ(UnsignedByte.of(accQBytes32.get(maxCtComplement + i)))
+        .byteQq(Bytes.ofUnsignedLong(this.getByteQQ()[i].toInteger()))
+        .byteR(Bytes.ofUnsignedLong(this.getByteR()[i].toInteger()))
+        .words(Bytes.ofUnsignedLong(this.getWords()))
+        .wordsNew(
+          Bytes.ofUnsignedLong(
+            this.getWordsNew())) // TODO: Could (should?) be set in tracePostOp?
+        .cMem(Bytes.ofUnsignedLong(this.getCMem())) // Returns current memory size in EVM words
+        .cMemNew(Bytes.ofUnsignedLong(this.getCMemNew()))
+        .quadCost(Bytes.ofUnsignedLong(this.getQuadCost()))
+        .linCost(Bytes.ofUnsignedLong(this.getLinCost()))
+        .gasMxp(Bytes.ofUnsignedLong(this.getQuadCost() + this.getEffectiveLinCost()))
+        .expands(this.isExpands())
+        .validateRow();
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/MxpData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/MxpData.java
@@ -28,7 +28,6 @@ import lombok.Getter;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
-import net.consensys.linea.zktracer.opcode.OpCodes;
 import net.consensys.linea.zktracer.opcode.gas.BillingRate;
 import net.consensys.linea.zktracer.opcode.gas.GasConstants;
 import net.consensys.linea.zktracer.opcode.gas.MxpType;
@@ -483,74 +482,73 @@ public class MxpData {
     final EWord eSize1 = EWord.of(this.size1);
     final EWord eSize2 = EWord.of(this.size2);
 
-
     int maxCt = this.maxCt();
     int maxCtComplement = 32 - maxCt;
 
     for (int i = 0; i < maxCt; i++) {
       trace
-        .stamp(Bytes.ofUnsignedLong(stamp))
-        .cn(Bytes.ofUnsignedLong(this.getContextNumber()))
-        .ct(Bytes.of(i))
-        .roob(this.isRoob())
-        .noop(this.isNoOperation())
-        .mxpx(this.isMxpx())
-        .inst(Bytes.of(this.getOpCodeData().value()))
-        .mxpType1(this.getOpCodeData().billing().type() == MxpType.TYPE_1)
-        .mxpType2(this.getOpCodeData().billing().type() == MxpType.TYPE_2)
-        .mxpType3(this.getOpCodeData().billing().type() == MxpType.TYPE_3)
-        .mxpType4(this.getOpCodeData().billing().type() == MxpType.TYPE_4)
-        .mxpType5(this.getOpCodeData().billing().type() == MxpType.TYPE_5)
-        .gword(
-          Bytes.ofUnsignedLong(
-            this.getOpCodeData().billing().billingRate() == BillingRate.BY_WORD
-              ? this.getOpCodeData().billing().perUnit().cost()
-              : 0))
-        .gbyte(
-          Bytes.ofUnsignedLong(
-            this.getOpCodeData().billing().billingRate() == BillingRate.BY_BYTE
-              ? this.getOpCodeData().billing().perUnit().cost()
-              : 0))
-        .deploys(this.isDeploys())
-        .offset1Hi(eOffset1.hi())
-        .offset1Lo(eOffset1.lo())
-        .offset2Hi(eOffset2.hi())
-        .offset2Lo(eOffset2.lo())
-        .size1Hi(eSize1.hi())
-        .size1Lo(eSize1.lo())
-        .size2Hi(eSize2.hi())
-        .size2Lo(eSize2.lo())
-        .maxOffset1(bigIntegerToBytes(this.getMaxOffset1()))
-        .maxOffset2(bigIntegerToBytes(this.getMaxOffset2()))
-        .maxOffset(bigIntegerToBytes(this.getMaxOffset()))
-        .comp(this.isComp())
-        .acc1(acc1Bytes32.slice(maxCtComplement, 1 + i))
-        .acc2(acc2Bytes32.slice(maxCtComplement, 1 + i))
-        .acc3(acc3Bytes32.slice(maxCtComplement, 1 + i))
-        .acc4(acc4Bytes32.slice(maxCtComplement, 1 + i))
-        .accA(accABytes32.slice(maxCtComplement, 1 + i))
-        .accW(accWBytes32.slice(maxCtComplement, 1 + i))
-        .accQ(accQBytes32.slice(maxCtComplement, 1 + i))
-        .byte1(UnsignedByte.of(acc1Bytes32.get(maxCtComplement + i)))
-        .byte2(UnsignedByte.of(acc2Bytes32.get(maxCtComplement + i)))
-        .byte3(UnsignedByte.of(acc3Bytes32.get(maxCtComplement + i)))
-        .byte4(UnsignedByte.of(acc4Bytes32.get(maxCtComplement + i)))
-        .byteA(UnsignedByte.of(accABytes32.get(maxCtComplement + i)))
-        .byteW(UnsignedByte.of(accWBytes32.get(maxCtComplement + i)))
-        .byteQ(UnsignedByte.of(accQBytes32.get(maxCtComplement + i)))
-        .byteQq(Bytes.ofUnsignedLong(this.getByteQQ()[i].toInteger()))
-        .byteR(Bytes.ofUnsignedLong(this.getByteR()[i].toInteger()))
-        .words(Bytes.ofUnsignedLong(this.getWords()))
-        .wordsNew(
-          Bytes.ofUnsignedLong(
-            this.getWordsNew())) // TODO: Could (should?) be set in tracePostOp?
-        .cMem(Bytes.ofUnsignedLong(this.getCMem())) // Returns current memory size in EVM words
-        .cMemNew(Bytes.ofUnsignedLong(this.getCMemNew()))
-        .quadCost(Bytes.ofUnsignedLong(this.getQuadCost()))
-        .linCost(Bytes.ofUnsignedLong(this.getLinCost()))
-        .gasMxp(Bytes.ofUnsignedLong(this.getQuadCost() + this.getEffectiveLinCost()))
-        .expands(this.isExpands())
-        .validateRow();
+          .stamp(Bytes.ofUnsignedLong(stamp))
+          .cn(Bytes.ofUnsignedLong(this.getContextNumber()))
+          .ct(Bytes.of(i))
+          .roob(this.isRoob())
+          .noop(this.isNoOperation())
+          .mxpx(this.isMxpx())
+          .inst(Bytes.of(this.getOpCodeData().value()))
+          .mxpType1(this.getOpCodeData().billing().type() == MxpType.TYPE_1)
+          .mxpType2(this.getOpCodeData().billing().type() == MxpType.TYPE_2)
+          .mxpType3(this.getOpCodeData().billing().type() == MxpType.TYPE_3)
+          .mxpType4(this.getOpCodeData().billing().type() == MxpType.TYPE_4)
+          .mxpType5(this.getOpCodeData().billing().type() == MxpType.TYPE_5)
+          .gword(
+              Bytes.ofUnsignedLong(
+                  this.getOpCodeData().billing().billingRate() == BillingRate.BY_WORD
+                      ? this.getOpCodeData().billing().perUnit().cost()
+                      : 0))
+          .gbyte(
+              Bytes.ofUnsignedLong(
+                  this.getOpCodeData().billing().billingRate() == BillingRate.BY_BYTE
+                      ? this.getOpCodeData().billing().perUnit().cost()
+                      : 0))
+          .deploys(this.isDeploys())
+          .offset1Hi(eOffset1.hi())
+          .offset1Lo(eOffset1.lo())
+          .offset2Hi(eOffset2.hi())
+          .offset2Lo(eOffset2.lo())
+          .size1Hi(eSize1.hi())
+          .size1Lo(eSize1.lo())
+          .size2Hi(eSize2.hi())
+          .size2Lo(eSize2.lo())
+          .maxOffset1(bigIntegerToBytes(this.getMaxOffset1()))
+          .maxOffset2(bigIntegerToBytes(this.getMaxOffset2()))
+          .maxOffset(bigIntegerToBytes(this.getMaxOffset()))
+          .comp(this.isComp())
+          .acc1(acc1Bytes32.slice(maxCtComplement, 1 + i))
+          .acc2(acc2Bytes32.slice(maxCtComplement, 1 + i))
+          .acc3(acc3Bytes32.slice(maxCtComplement, 1 + i))
+          .acc4(acc4Bytes32.slice(maxCtComplement, 1 + i))
+          .accA(accABytes32.slice(maxCtComplement, 1 + i))
+          .accW(accWBytes32.slice(maxCtComplement, 1 + i))
+          .accQ(accQBytes32.slice(maxCtComplement, 1 + i))
+          .byte1(UnsignedByte.of(acc1Bytes32.get(maxCtComplement + i)))
+          .byte2(UnsignedByte.of(acc2Bytes32.get(maxCtComplement + i)))
+          .byte3(UnsignedByte.of(acc3Bytes32.get(maxCtComplement + i)))
+          .byte4(UnsignedByte.of(acc4Bytes32.get(maxCtComplement + i)))
+          .byteA(UnsignedByte.of(accABytes32.get(maxCtComplement + i)))
+          .byteW(UnsignedByte.of(accWBytes32.get(maxCtComplement + i)))
+          .byteQ(UnsignedByte.of(accQBytes32.get(maxCtComplement + i)))
+          .byteQq(Bytes.ofUnsignedLong(this.getByteQQ()[i].toInteger()))
+          .byteR(Bytes.ofUnsignedLong(this.getByteR()[i].toInteger()))
+          .words(Bytes.ofUnsignedLong(this.getWords()))
+          .wordsNew(
+              Bytes.ofUnsignedLong(
+                  this.getWordsNew())) // TODO: Could (should?) be set in tracePostOp?
+          .cMem(Bytes.ofUnsignedLong(this.getCMem())) // Returns current memory size in EVM words
+          .cMemNew(Bytes.ofUnsignedLong(this.getCMemNew()))
+          .quadCost(Bytes.ofUnsignedLong(this.getQuadCost()))
+          .linCost(Bytes.ofUnsignedLong(this.getLinCost()))
+          .gasMxp(Bytes.ofUnsignedLong(this.getQuadCost() + this.getEffectiveLinCost()))
+          .expands(this.isExpands())
+          .validateRow();
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romLex/RomChunk.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romLex/RomChunk.java
@@ -30,7 +30,7 @@ public record RomChunk(
     Bytes byteCode) {
   @Override
   public int hashCode() {
-    return Objects.hash(this.address, this.deploymentNumber, this.deploymentStatus);
+    return Objects.hash(this.address, this.deploymentNumber, this.deploymentStatus, this.id);
   }
 
   @Override
@@ -40,6 +40,7 @@ public record RomChunk(
     final RomChunk that = (RomChunk) o;
     return Objects.equals(this.address, that.address)
         && Objects.equals(this.deploymentNumber, that.deploymentNumber)
-        && Objects.equals(this.deploymentStatus, that.deploymentStatus);
+        && Objects.equals(this.deploymentStatus, that.deploymentStatus)
+        && Objects.equals(this.id, that.id);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romLex/RomChunk.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romLex/RomChunk.java
@@ -32,4 +32,14 @@ public record RomChunk(
   public int hashCode() {
     return Objects.hash(this.address, this.deploymentNumber, this.deploymentStatus);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final RomChunk that = (RomChunk) o;
+    return Objects.equals(this.address, that.address)
+        && Objects.equals(this.deploymentNumber, that.deploymentNumber)
+        && Objects.equals(this.deploymentStatus, that.deploymentStatus);
+  }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romLex/RomChunk.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romLex/RomChunk.java
@@ -30,7 +30,7 @@ public record RomChunk(
     Bytes byteCode) {
   @Override
   public int hashCode() {
-    return Objects.hash(this.address, this.deploymentNumber, this.deploymentStatus, this.id);
+    return Objects.hash(this.id);
   }
 
   @Override
@@ -38,9 +38,6 @@ public record RomChunk(
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     final RomChunk that = (RomChunk) o;
-    return Objects.equals(this.address, that.address)
-        && Objects.equals(this.deploymentNumber, that.deploymentNumber)
-        && Objects.equals(this.deploymentStatus, that.deploymentStatus)
-        && Objects.equals(this.id, that.id);
+    return Objects.equals(this.id, that.id);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Shf.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Shf.java
@@ -22,8 +22,6 @@ import net.consensys.linea.zktracer.ColumnHeader;
 import net.consensys.linea.zktracer.container.stacked.set.StackedSet;
 import net.consensys.linea.zktracer.module.Module;
 import net.consensys.linea.zktracer.opcode.OpCode;
-import net.consensys.linea.zktracer.types.UnsignedByte;
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Shf.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Shf.java
@@ -28,7 +28,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 public class Shf implements Module {
-  private int stamp = 0;
   private final StackedSet<ShfOperation> operations = new StackedSet<>();
 
   @Override
@@ -54,75 +53,6 @@ public class Shf implements Module {
         new ShfOperation(OpCode.of(frame.getCurrentOperation().getOpcode()), arg1, arg2));
   }
 
-  private void traceShfOperation(ShfOperation op, Trace trace) {
-    this.stamp++;
-
-    for (int i = 0; i < op.maxCt(); i++) {
-      final ByteChunks arg2HiByteChunks =
-          ByteChunks.fromBytes(UnsignedByte.of(op.arg2Hi().get(i)), op.mshp());
-      final ByteChunks arg2LoByteChunks =
-          ByteChunks.fromBytes(UnsignedByte.of(op.arg2Lo().get(i)), op.mshp());
-
-      trace
-          .acc1(op.arg1Lo().slice(0, 1 + i))
-          .acc2(op.arg2Hi().slice(0, 1 + i))
-          .acc3(op.arg2Lo().slice(0, 1 + i))
-          .acc4(op.res().getResHi().slice(0, 1 + i))
-          .acc5(op.res().getResLo().slice(0, 1 + i))
-          .arg1Hi(op.arg1Hi())
-          .arg1Lo(op.arg1Lo())
-          .arg2Hi(op.arg2Hi())
-          .arg2Lo(op.arg2Lo());
-
-      if (op.isShiftRight()) {
-        trace.bit1(i >= 1).bit2(i >= 2).bit3(i >= 4).bit4(i >= 8);
-      } else {
-        trace.bit1(i >= (16 - 1)).bit2(i >= (16 - 2)).bit3(i >= (16 - 4)).bit4(i >= (16 - 8));
-      }
-
-      trace
-          .bitB3(op.isBitB3())
-          .bitB4(op.isBitB4())
-          .bitB5(op.isBitB5())
-          .bitB6(op.isBitB6())
-          .bitB7(op.isBitB7())
-          .byte1(UnsignedByte.of(op.arg1Lo().get(i)))
-          .byte2(UnsignedByte.of(op.arg2Hi().get(i)))
-          .byte3(UnsignedByte.of(op.arg2Lo().get(i)))
-          .byte4(UnsignedByte.of(op.res().getResHi().get(i)))
-          .byte5(UnsignedByte.of(op.res().getResLo().get(i)))
-          .bits(op.bits().get(i))
-          .counter(Bytes.of(i))
-          .inst(Bytes.of(op.opCode().byteValue()))
-          .known(op.isKnown())
-          .neg(op.isNegative())
-          .oneLineInstruction(op.isOneLineInstruction())
-          .low3(Bytes.of(op.low3().toInteger()))
-          .microShiftParameter(Bytes.ofUnsignedInt(op.mshp().toInteger()))
-          .resHi(op.res().getResHi())
-          .resLo(op.res().getResLo())
-          .leftAlignedSuffixHigh(Bytes.ofUnsignedShort(arg2HiByteChunks.la().toInteger()))
-          .rightAlignedPrefixHigh(Bytes.ofUnsignedInt(arg2HiByteChunks.ra().toInteger()))
-          .ones(Bytes.ofUnsignedInt(arg2HiByteChunks.ones().toInteger()))
-          .leftAlignedSuffixLow(Bytes.ofUnsignedInt(arg2LoByteChunks.la().toInteger()))
-          .rightAlignedPrefixLow(Bytes.ofUnsignedInt(arg2LoByteChunks.ra().toInteger()))
-          .shb3Hi(Bytes.ofUnsignedInt(op.shb().getShbHi()[0][i].toInteger()))
-          .shb3Lo(Bytes.ofUnsignedInt(op.shb().getShbLo()[0][i].toInteger()))
-          .shb4Hi(Bytes.ofUnsignedInt(op.shb().getShbHi()[4 - 3][i].toInteger()))
-          .shb4Lo(Bytes.ofUnsignedInt(op.shb().getShbLo()[4 - 3][i].toInteger()))
-          .shb5Hi(Bytes.ofUnsignedInt(op.shb().getShbHi()[5 - 3][i].toInteger()))
-          .shb5Lo(Bytes.ofUnsignedInt(op.shb().getShbLo()[5 - 3][i].toInteger()))
-          .shb6Hi(Bytes.ofUnsignedInt(op.shb().getShbHi()[6 - 3][i].toInteger()))
-          .shb6Lo(Bytes.ofUnsignedInt(op.shb().getShbLo()[6 - 3][i].toInteger()))
-          .shb7Hi(Bytes.ofUnsignedInt(op.shb().getShbHi()[7 - 3][i].toInteger()))
-          .shb7Lo(Bytes.ofUnsignedInt(op.shb().getShbLo()[7 - 3][i].toInteger()))
-          .shiftDirection(op.isShiftRight())
-          .isData(stamp != 0)
-          .shiftStamp(Bytes.ofUnsignedInt(stamp))
-          .validateRow();
-    }
-  }
-
   @Override
   public List<ColumnHeader> columnsHeaders() {
     return Trace.headers(this.lineCount());
@@ -131,9 +61,11 @@ public class Shf implements Module {
   @Override
   public void commit(List<MappedByteBuffer> buffers) {
     final Trace trace = new Trace(buffers);
+    int stamp = 0;
 
     for (ShfOperation op : this.operations) {
-      this.traceShfOperation(op, trace);
+      stamp++;
+      op.trace(trace, stamp);
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/ShfOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/ShfOperation.java
@@ -22,39 +22,54 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import lombok.Getter;
-import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.types.Bytes16;
 import net.consensys.linea.zktracer.types.UnsignedByte;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
-@Accessors(fluent = true)
 final class ShfOperation {
   private static final int LIMB_SIZE = 16;
 
-  @Getter private final OpCode opCode;
-  @Getter private final Bytes32 arg1;
-  @Getter private final Bytes32 arg2;
-  @Getter private final boolean isOneLineInstruction;
-  @Getter private boolean isNegative;
-  @Getter private boolean isShiftRight;
-  @Getter private boolean isKnown;
-  @Getter private UnsignedByte msb;
-  @Getter private UnsignedByte lsb;
-  @Getter private UnsignedByte low3;
-  @Getter private UnsignedByte mshp;
-  @Getter private Boolean[] lsbBits;
-  @Getter private Boolean[] msbBits;
-  @Getter private List<Boolean> bits;
-  @Getter private Shb shb;
-  @Getter private Res res;
-  @Getter private boolean isBitB3;
-  @Getter private boolean isBitB4;
-  @Getter private boolean isBitB5;
-  @Getter private boolean isBitB6;
-  @Getter private boolean isBitB7;
+  private final OpCode opCode;
+  private final Bytes32 arg1;
+  private final Bytes32 arg2;
+  private final boolean isOneLineInstruction;
+  private boolean isNegative;
+  private boolean isShiftRight;
+  private boolean isKnown;
+  private UnsignedByte low3;
+  private UnsignedByte mshp;
+  private List<Boolean> bits;
+  private Shb shb;
+  private Res res;
+  private boolean isBitB3;
+  private boolean isBitB4;
+  private boolean isBitB5;
+  private boolean isBitB6;
+  private boolean isBitB7;
+
+  private static boolean isOneLineInstruction(final OpCode opCode, final Bytes16 arg1Hi) {
+    return (opCode == OpCode.SHR || opCode == OpCode.SHL) && !arg1Hi.isZero();
+  }
+
+  private static boolean isKnown(final OpCode opCode, final Bytes16 arg1Hi, final Bytes16 arg1Lo) {
+    if (opCode.equals(OpCode.SAR) && !arg1Hi.isZero()) {
+      return true;
+    }
+
+    return !allButLastByteZero(arg1Lo);
+  }
+
+  private static boolean allButLastByteZero(final Bytes16 bytes) {
+    for (int i = 0; i < 15; i++) {
+      if (bytes.get(i) != 0) {
+        return false;
+      }
+    }
+
+    return true;
+  }
 
   public ShfOperation(OpCode opCode, Bytes32 arg1, Bytes32 arg2) {
     this.opCode = opCode;
@@ -68,8 +83,8 @@ final class ShfOperation {
     this.isShiftRight = List.of(OpCode.SAR, OpCode.SHR).contains(opCode);
     this.isKnown = isKnown(opCode, arg1Hi(), arg1Lo());
 
-    this.msb = UnsignedByte.of(arg2Hi().get(0));
-    this.lsb = UnsignedByte.of(arg1Lo().get(15));
+    UnsignedByte msb = UnsignedByte.of(arg2Hi().get(0));
+    UnsignedByte lsb = UnsignedByte.of(arg1Lo().get(15));
     this.low3 = lsb.shiftLeft(5).shiftRight(5);
 
     if (isShiftRight) {
@@ -78,8 +93,8 @@ final class ShfOperation {
       this.mshp = UnsignedByte.of(8 - low3.toInteger());
     }
 
-    this.lsbBits = byteBits(lsb);
-    this.msbBits = byteBits(msb);
+    Boolean[] lsbBits = byteBits(lsb);
+    Boolean[] msbBits = byteBits(msb);
 
     this.bits = new ArrayList<>(lsbBits.length + msbBits.length);
     Collections.addAll(this.bits, msbBits);
@@ -111,28 +126,6 @@ final class ShfOperation {
     return Bytes16.wrap(arg2.slice(16));
   }
 
-  private static boolean isOneLineInstruction(final OpCode opCode, final Bytes16 arg1Hi) {
-    return (opCode == OpCode.SHR || opCode == OpCode.SHL) && !arg1Hi.isZero();
-  }
-
-  private static boolean isKnown(final OpCode opCode, final Bytes16 arg1Hi, final Bytes16 arg1Lo) {
-    if (opCode.equals(OpCode.SAR) && !arg1Hi.isZero()) {
-      return true;
-    }
-
-    return !allButLastByteZero(arg1Lo);
-  }
-
-  private static boolean allButLastByteZero(final Bytes16 bytes) {
-    for (int i = 0; i < 15; i++) {
-      if (bytes.get(i) != 0) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
   @Override
   public int hashCode() {
     return Objects.hash(this.opCode, this.arg1, this.arg2);
@@ -157,64 +150,64 @@ final class ShfOperation {
 
     for (int i = 0; i < this.maxCt(); i++) {
       final ByteChunks arg2HiByteChunks =
-          ByteChunks.fromBytes(UnsignedByte.of(this.arg2Hi().get(i)), this.mshp());
+          ByteChunks.fromBytes(UnsignedByte.of(this.arg2Hi().get(i)), this.mshp);
       final ByteChunks arg2LoByteChunks =
-          ByteChunks.fromBytes(UnsignedByte.of(this.arg2Lo().get(i)), this.mshp());
+          ByteChunks.fromBytes(UnsignedByte.of(this.arg2Lo().get(i)), this.mshp);
 
       trace
           .acc1(this.arg1Lo().slice(0, 1 + i))
           .acc2(this.arg2Hi().slice(0, 1 + i))
           .acc3(this.arg2Lo().slice(0, 1 + i))
-          .acc4(this.res().getResHi().slice(0, 1 + i))
-          .acc5(this.res().getResLo().slice(0, 1 + i))
+          .acc4(this.res.getResHi().slice(0, 1 + i))
+          .acc5(this.res.getResLo().slice(0, 1 + i))
           .arg1Hi(this.arg1Hi())
           .arg1Lo(this.arg1Lo())
           .arg2Hi(this.arg2Hi())
           .arg2Lo(this.arg2Lo());
 
-      if (this.isShiftRight()) {
+      if (this.isShiftRight) {
         trace.bit1(i >= 1).bit2(i >= 2).bit3(i >= 4).bit4(i >= 8);
       } else {
         trace.bit1(i >= (16 - 1)).bit2(i >= (16 - 2)).bit3(i >= (16 - 4)).bit4(i >= (16 - 8));
       }
 
       trace
-          .bitB3(this.isBitB3())
-          .bitB4(this.isBitB4())
-          .bitB5(this.isBitB5())
-          .bitB6(this.isBitB6())
-          .bitB7(this.isBitB7())
+          .bitB3(this.isBitB3)
+          .bitB4(this.isBitB4)
+          .bitB5(this.isBitB5)
+          .bitB6(this.isBitB6)
+          .bitB7(this.isBitB7)
           .byte1(UnsignedByte.of(this.arg1Lo().get(i)))
           .byte2(UnsignedByte.of(this.arg2Hi().get(i)))
           .byte3(UnsignedByte.of(this.arg2Lo().get(i)))
-          .byte4(UnsignedByte.of(this.res().getResHi().get(i)))
-          .byte5(UnsignedByte.of(this.res().getResLo().get(i)))
-          .bits(this.bits().get(i))
+          .byte4(UnsignedByte.of(this.res.getResHi().get(i)))
+          .byte5(UnsignedByte.of(this.res.getResLo().get(i)))
+          .bits(this.bits.get(i))
           .counter(Bytes.of(i))
-          .inst(Bytes.of(this.opCode().byteValue()))
-          .known(this.isKnown())
-          .neg(this.isNegative())
-          .oneLineInstruction(this.isOneLineInstruction())
-          .low3(Bytes.of(this.low3().toInteger()))
-          .microShiftParameter(Bytes.ofUnsignedInt(this.mshp().toInteger()))
-          .resHi(this.res().getResHi())
-          .resLo(this.res().getResLo())
+          .inst(Bytes.of(this.opCode.byteValue()))
+          .known(this.isKnown)
+          .neg(this.isNegative)
+          .oneLineInstruction(this.isOneLineInstruction)
+          .low3(Bytes.of(this.low3.toInteger()))
+          .microShiftParameter(Bytes.ofUnsignedInt(this.mshp.toInteger()))
+          .resHi(this.res.getResHi())
+          .resLo(this.res.getResLo())
           .leftAlignedSuffixHigh(Bytes.ofUnsignedShort(arg2HiByteChunks.la().toInteger()))
           .rightAlignedPrefixHigh(Bytes.ofUnsignedInt(arg2HiByteChunks.ra().toInteger()))
           .ones(Bytes.ofUnsignedInt(arg2HiByteChunks.ones().toInteger()))
           .leftAlignedSuffixLow(Bytes.ofUnsignedInt(arg2LoByteChunks.la().toInteger()))
           .rightAlignedPrefixLow(Bytes.ofUnsignedInt(arg2LoByteChunks.ra().toInteger()))
-          .shb3Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[0][i].toInteger()))
-          .shb3Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[0][i].toInteger()))
-          .shb4Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[4 - 3][i].toInteger()))
-          .shb4Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[4 - 3][i].toInteger()))
-          .shb5Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[5 - 3][i].toInteger()))
-          .shb5Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[5 - 3][i].toInteger()))
-          .shb6Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[6 - 3][i].toInteger()))
-          .shb6Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[6 - 3][i].toInteger()))
-          .shb7Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[7 - 3][i].toInteger()))
-          .shb7Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[7 - 3][i].toInteger()))
-          .shiftDirection(this.isShiftRight())
+          .shb3Hi(Bytes.ofUnsignedInt(this.shb.getShbHi()[0][i].toInteger()))
+          .shb3Lo(Bytes.ofUnsignedInt(this.shb.getShbLo()[0][i].toInteger()))
+          .shb4Hi(Bytes.ofUnsignedInt(this.shb.getShbHi()[4 - 3][i].toInteger()))
+          .shb4Lo(Bytes.ofUnsignedInt(this.shb.getShbLo()[4 - 3][i].toInteger()))
+          .shb5Hi(Bytes.ofUnsignedInt(this.shb.getShbHi()[5 - 3][i].toInteger()))
+          .shb5Lo(Bytes.ofUnsignedInt(this.shb.getShbLo()[5 - 3][i].toInteger()))
+          .shb6Hi(Bytes.ofUnsignedInt(this.shb.getShbHi()[6 - 3][i].toInteger()))
+          .shb6Lo(Bytes.ofUnsignedInt(this.shb.getShbLo()[6 - 3][i].toInteger()))
+          .shb7Hi(Bytes.ofUnsignedInt(this.shb.getShbHi()[7 - 3][i].toInteger()))
+          .shb7Lo(Bytes.ofUnsignedInt(this.shb.getShbLo()[7 - 3][i].toInteger()))
+          .shiftDirection(this.isShiftRight)
           .isData(stamp != 0)
           .shiftStamp(Bytes.ofUnsignedInt(stamp))
           .validateRow();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/ShfOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/ShfOperation.java
@@ -27,6 +27,7 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.types.Bytes16;
 import net.consensys.linea.zktracer.types.UnsignedByte;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
 @Accessors(fluent = true)
@@ -37,30 +38,32 @@ final class ShfOperation {
   @Getter private final Bytes32 arg1;
   @Getter private final Bytes32 arg2;
   @Getter private final boolean isOneLineInstruction;
-  @Getter private final boolean isNegative;
-  @Getter private final boolean isShiftRight;
-  @Getter private final boolean isKnown;
-  @Getter private final UnsignedByte msb;
-  @Getter private final UnsignedByte lsb;
-  @Getter private final UnsignedByte low3;
-  @Getter private final UnsignedByte mshp;
-  @Getter private final Boolean[] lsbBits;
-  @Getter private final Boolean[] msbBits;
-  @Getter private final List<Boolean> bits;
-  @Getter private final Shb shb;
-  @Getter private final Res res;
-  @Getter private final boolean isBitB3;
-  @Getter private final boolean isBitB4;
-  @Getter private final boolean isBitB5;
-  @Getter private final boolean isBitB6;
-  @Getter private final boolean isBitB7;
+  @Getter private boolean isNegative;
+  @Getter private boolean isShiftRight;
+  @Getter private boolean isKnown;
+  @Getter private UnsignedByte msb;
+  @Getter private UnsignedByte lsb;
+  @Getter private UnsignedByte low3;
+  @Getter private UnsignedByte mshp;
+  @Getter private Boolean[] lsbBits;
+  @Getter private Boolean[] msbBits;
+  @Getter private List<Boolean> bits;
+  @Getter private Shb shb;
+  @Getter private Res res;
+  @Getter private boolean isBitB3;
+  @Getter private boolean isBitB4;
+  @Getter private boolean isBitB5;
+  @Getter private boolean isBitB6;
+  @Getter private boolean isBitB7;
 
   public ShfOperation(OpCode opCode, Bytes32 arg1, Bytes32 arg2) {
     this.opCode = opCode;
     this.arg1 = arg1;
     this.arg2 = arg2;
-
     this.isOneLineInstruction = isOneLineInstruction(opCode, arg1Hi());
+  }
+
+  private void compute() {
     this.isNegative = Long.compareUnsigned(arg2Hi().get(0), 128) >= 0;
     this.isShiftRight = List.of(OpCode.SAR, OpCode.SHR).contains(opCode);
     this.isKnown = isKnown(opCode, arg1Hi(), arg1Lo());
@@ -147,5 +150,74 @@ final class ShfOperation {
 
   public int maxCt() {
     return this.isOneLineInstruction ? 1 : LIMB_SIZE;
+  }
+
+  public void trace(Trace trace, int stamp) {
+    this.compute();
+
+    for (int i = 0; i < this.maxCt(); i++) {
+      final ByteChunks arg2HiByteChunks =
+        ByteChunks.fromBytes(UnsignedByte.of(this.arg2Hi().get(i)), this.mshp());
+      final ByteChunks arg2LoByteChunks =
+        ByteChunks.fromBytes(UnsignedByte.of(this.arg2Lo().get(i)), this.mshp());
+
+      trace
+        .acc1(this.arg1Lo().slice(0, 1 + i))
+        .acc2(this.arg2Hi().slice(0, 1 + i))
+        .acc3(this.arg2Lo().slice(0, 1 + i))
+        .acc4(this.res().getResHi().slice(0, 1 + i))
+        .acc5(this.res().getResLo().slice(0, 1 + i))
+        .arg1Hi(this.arg1Hi())
+        .arg1Lo(this.arg1Lo())
+        .arg2Hi(this.arg2Hi())
+        .arg2Lo(this.arg2Lo());
+
+      if (this.isShiftRight()) {
+        trace.bit1(i >= 1).bit2(i >= 2).bit3(i >= 4).bit4(i >= 8);
+      } else {
+        trace.bit1(i >= (16 - 1)).bit2(i >= (16 - 2)).bit3(i >= (16 - 4)).bit4(i >= (16 - 8));
+      }
+
+      trace
+        .bitB3(this.isBitB3())
+        .bitB4(this.isBitB4())
+        .bitB5(this.isBitB5())
+        .bitB6(this.isBitB6())
+        .bitB7(this.isBitB7())
+        .byte1(UnsignedByte.of(this.arg1Lo().get(i)))
+        .byte2(UnsignedByte.of(this.arg2Hi().get(i)))
+        .byte3(UnsignedByte.of(this.arg2Lo().get(i)))
+        .byte4(UnsignedByte.of(this.res().getResHi().get(i)))
+        .byte5(UnsignedByte.of(this.res().getResLo().get(i)))
+        .bits(this.bits().get(i))
+        .counter(Bytes.of(i))
+        .inst(Bytes.of(this.opCode().byteValue()))
+        .known(this.isKnown())
+        .neg(this.isNegative())
+        .oneLineInstruction(this.isOneLineInstruction())
+        .low3(Bytes.of(this.low3().toInteger()))
+        .microShiftParameter(Bytes.ofUnsignedInt(this.mshp().toInteger()))
+        .resHi(this.res().getResHi())
+        .resLo(this.res().getResLo())
+        .leftAlignedSuffixHigh(Bytes.ofUnsignedShort(arg2HiByteChunks.la().toInteger()))
+        .rightAlignedPrefixHigh(Bytes.ofUnsignedInt(arg2HiByteChunks.ra().toInteger()))
+        .ones(Bytes.ofUnsignedInt(arg2HiByteChunks.ones().toInteger()))
+        .leftAlignedSuffixLow(Bytes.ofUnsignedInt(arg2LoByteChunks.la().toInteger()))
+        .rightAlignedPrefixLow(Bytes.ofUnsignedInt(arg2LoByteChunks.ra().toInteger()))
+        .shb3Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[0][i].toInteger()))
+        .shb3Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[0][i].toInteger()))
+        .shb4Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[4 - 3][i].toInteger()))
+        .shb4Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[4 - 3][i].toInteger()))
+        .shb5Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[5 - 3][i].toInteger()))
+        .shb5Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[5 - 3][i].toInteger()))
+        .shb6Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[6 - 3][i].toInteger()))
+        .shb6Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[6 - 3][i].toInteger()))
+        .shb7Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[7 - 3][i].toInteger()))
+        .shb7Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[7 - 3][i].toInteger()))
+        .shiftDirection(this.isShiftRight())
+        .isData(stamp != 0)
+        .shiftStamp(Bytes.ofUnsignedInt(stamp))
+        .validateRow();
+    }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/ShfOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/ShfOperation.java
@@ -157,20 +157,20 @@ final class ShfOperation {
 
     for (int i = 0; i < this.maxCt(); i++) {
       final ByteChunks arg2HiByteChunks =
-        ByteChunks.fromBytes(UnsignedByte.of(this.arg2Hi().get(i)), this.mshp());
+          ByteChunks.fromBytes(UnsignedByte.of(this.arg2Hi().get(i)), this.mshp());
       final ByteChunks arg2LoByteChunks =
-        ByteChunks.fromBytes(UnsignedByte.of(this.arg2Lo().get(i)), this.mshp());
+          ByteChunks.fromBytes(UnsignedByte.of(this.arg2Lo().get(i)), this.mshp());
 
       trace
-        .acc1(this.arg1Lo().slice(0, 1 + i))
-        .acc2(this.arg2Hi().slice(0, 1 + i))
-        .acc3(this.arg2Lo().slice(0, 1 + i))
-        .acc4(this.res().getResHi().slice(0, 1 + i))
-        .acc5(this.res().getResLo().slice(0, 1 + i))
-        .arg1Hi(this.arg1Hi())
-        .arg1Lo(this.arg1Lo())
-        .arg2Hi(this.arg2Hi())
-        .arg2Lo(this.arg2Lo());
+          .acc1(this.arg1Lo().slice(0, 1 + i))
+          .acc2(this.arg2Hi().slice(0, 1 + i))
+          .acc3(this.arg2Lo().slice(0, 1 + i))
+          .acc4(this.res().getResHi().slice(0, 1 + i))
+          .acc5(this.res().getResLo().slice(0, 1 + i))
+          .arg1Hi(this.arg1Hi())
+          .arg1Lo(this.arg1Lo())
+          .arg2Hi(this.arg2Hi())
+          .arg2Lo(this.arg2Lo());
 
       if (this.isShiftRight()) {
         trace.bit1(i >= 1).bit2(i >= 2).bit3(i >= 4).bit4(i >= 8);
@@ -179,45 +179,45 @@ final class ShfOperation {
       }
 
       trace
-        .bitB3(this.isBitB3())
-        .bitB4(this.isBitB4())
-        .bitB5(this.isBitB5())
-        .bitB6(this.isBitB6())
-        .bitB7(this.isBitB7())
-        .byte1(UnsignedByte.of(this.arg1Lo().get(i)))
-        .byte2(UnsignedByte.of(this.arg2Hi().get(i)))
-        .byte3(UnsignedByte.of(this.arg2Lo().get(i)))
-        .byte4(UnsignedByte.of(this.res().getResHi().get(i)))
-        .byte5(UnsignedByte.of(this.res().getResLo().get(i)))
-        .bits(this.bits().get(i))
-        .counter(Bytes.of(i))
-        .inst(Bytes.of(this.opCode().byteValue()))
-        .known(this.isKnown())
-        .neg(this.isNegative())
-        .oneLineInstruction(this.isOneLineInstruction())
-        .low3(Bytes.of(this.low3().toInteger()))
-        .microShiftParameter(Bytes.ofUnsignedInt(this.mshp().toInteger()))
-        .resHi(this.res().getResHi())
-        .resLo(this.res().getResLo())
-        .leftAlignedSuffixHigh(Bytes.ofUnsignedShort(arg2HiByteChunks.la().toInteger()))
-        .rightAlignedPrefixHigh(Bytes.ofUnsignedInt(arg2HiByteChunks.ra().toInteger()))
-        .ones(Bytes.ofUnsignedInt(arg2HiByteChunks.ones().toInteger()))
-        .leftAlignedSuffixLow(Bytes.ofUnsignedInt(arg2LoByteChunks.la().toInteger()))
-        .rightAlignedPrefixLow(Bytes.ofUnsignedInt(arg2LoByteChunks.ra().toInteger()))
-        .shb3Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[0][i].toInteger()))
-        .shb3Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[0][i].toInteger()))
-        .shb4Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[4 - 3][i].toInteger()))
-        .shb4Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[4 - 3][i].toInteger()))
-        .shb5Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[5 - 3][i].toInteger()))
-        .shb5Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[5 - 3][i].toInteger()))
-        .shb6Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[6 - 3][i].toInteger()))
-        .shb6Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[6 - 3][i].toInteger()))
-        .shb7Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[7 - 3][i].toInteger()))
-        .shb7Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[7 - 3][i].toInteger()))
-        .shiftDirection(this.isShiftRight())
-        .isData(stamp != 0)
-        .shiftStamp(Bytes.ofUnsignedInt(stamp))
-        .validateRow();
+          .bitB3(this.isBitB3())
+          .bitB4(this.isBitB4())
+          .bitB5(this.isBitB5())
+          .bitB6(this.isBitB6())
+          .bitB7(this.isBitB7())
+          .byte1(UnsignedByte.of(this.arg1Lo().get(i)))
+          .byte2(UnsignedByte.of(this.arg2Hi().get(i)))
+          .byte3(UnsignedByte.of(this.arg2Lo().get(i)))
+          .byte4(UnsignedByte.of(this.res().getResHi().get(i)))
+          .byte5(UnsignedByte.of(this.res().getResLo().get(i)))
+          .bits(this.bits().get(i))
+          .counter(Bytes.of(i))
+          .inst(Bytes.of(this.opCode().byteValue()))
+          .known(this.isKnown())
+          .neg(this.isNegative())
+          .oneLineInstruction(this.isOneLineInstruction())
+          .low3(Bytes.of(this.low3().toInteger()))
+          .microShiftParameter(Bytes.ofUnsignedInt(this.mshp().toInteger()))
+          .resHi(this.res().getResHi())
+          .resLo(this.res().getResLo())
+          .leftAlignedSuffixHigh(Bytes.ofUnsignedShort(arg2HiByteChunks.la().toInteger()))
+          .rightAlignedPrefixHigh(Bytes.ofUnsignedInt(arg2HiByteChunks.ra().toInteger()))
+          .ones(Bytes.ofUnsignedInt(arg2HiByteChunks.ones().toInteger()))
+          .leftAlignedSuffixLow(Bytes.ofUnsignedInt(arg2LoByteChunks.la().toInteger()))
+          .rightAlignedPrefixLow(Bytes.ofUnsignedInt(arg2LoByteChunks.ra().toInteger()))
+          .shb3Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[0][i].toInteger()))
+          .shb3Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[0][i].toInteger()))
+          .shb4Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[4 - 3][i].toInteger()))
+          .shb4Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[4 - 3][i].toInteger()))
+          .shb5Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[5 - 3][i].toInteger()))
+          .shb5Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[5 - 3][i].toInteger()))
+          .shb6Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[6 - 3][i].toInteger()))
+          .shb6Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[6 - 3][i].toInteger()))
+          .shb7Hi(Bytes.ofUnsignedInt(this.shb().getShbHi()[7 - 3][i].toInteger()))
+          .shb7Lo(Bytes.ofUnsignedInt(this.shb().getShbLo()[7 - 3][i].toInteger()))
+          .shiftDirection(this.isShiftRight())
+          .isData(stamp != 0)
+          .shiftStamp(Bytes.ofUnsignedInt(stamp))
+          .validateRow();
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Wcp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Wcp.java
@@ -24,17 +24,13 @@ import net.consensys.linea.zktracer.container.stacked.set.StackedSet;
 import net.consensys.linea.zktracer.module.Module;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.opcode.OpCode;
-import net.consensys.linea.zktracer.types.Bytes16;
-import net.consensys.linea.zktracer.types.UnsignedByte;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 @RequiredArgsConstructor
 public class Wcp implements Module {
-
   private final StackedSet<WcpOperation> operations = new StackedSet<>();
-  private int stamp = 0;
 
   private final Hub hub;
 
@@ -63,54 +59,6 @@ public class Wcp implements Module {
     this.operations.add(new WcpOperation(opcode, arg1, arg2));
   }
 
-  public void traceWcpOperation(WcpOperation op, Trace trace) {
-    this.stamp++;
-    final Bytes resHi = op.getResHi() ? Bytes.of(1) : Bytes.EMPTY;
-    final Bytes resLo = op.getResLo() ? Bytes.of(1) : Bytes.EMPTY;
-    final List<Boolean> bits = op.getBits();
-    final boolean neg1 = op.getNeg1();
-    final boolean neg2 = op.getNeg2();
-    final Bytes16 adjHi = op.getAdjHi();
-    final Bytes16 adjLo = op.getAdjLo();
-    final boolean bit1 = op.getBit1();
-    final boolean bit2 = op.getBit2();
-    final boolean bit3 = op.getBit3();
-    final boolean bit4 = op.getBit4();
-    for (int i = 0; i < op.maxCt(); i++) {
-      trace
-          .wordComparisonStamp(Bytes.ofUnsignedInt(stamp))
-          .oneLineInstruction(op.isOneLineInstruction())
-          .counter(Bytes.of(i))
-          .inst(Bytes.of(op.getOpCode().byteValue()))
-          .argument1Hi(op.getArg1Hi())
-          .argument1Lo(op.getArg1Lo())
-          .argument2Hi(op.getArg2Hi())
-          .argument2Lo(op.getArg2Lo())
-          .resultHi(resHi)
-          .resultLo(resLo)
-          .bits(bits.get(i))
-          .neg1(neg1)
-          .neg2(neg2)
-          .byte1(UnsignedByte.of(op.getArg1Hi().get(i)))
-          .byte2(UnsignedByte.of(op.getArg1Lo().get(i)))
-          .byte3(UnsignedByte.of(op.getArg2Hi().get(i)))
-          .byte4(UnsignedByte.of(op.getArg2Lo().get(i)))
-          .byte5(UnsignedByte.of(adjHi.get(i)))
-          .byte6(UnsignedByte.of(adjLo.get(i)))
-          .acc1(op.getArg1Hi().slice(0, 1 + i))
-          .acc2(op.getArg1Lo().slice(0, 1 + i))
-          .acc3(op.getArg2Hi().slice(0, 1 + i))
-          .acc4(op.getArg2Lo().slice(0, 1 + i))
-          .acc5(adjHi.slice(0, 1 + i))
-          .acc6(adjLo.slice(0, 1 + i))
-          .bit1(bit1)
-          .bit2(bit2)
-          .bit3(bit3)
-          .bit4(bit4)
-          .validateRow();
-    }
-  }
-
   @Override
   public List<ColumnHeader> columnsHeaders() {
     return Trace.headers(this.lineCount());
@@ -120,8 +68,10 @@ public class Wcp implements Module {
   public void commit(List<MappedByteBuffer> buffers) {
     final Trace trace = new Trace(buffers);
 
+    int stamp = 0;
     for (WcpOperation operation : this.operations) {
-      this.traceWcpOperation(operation, trace);
+      stamp++;
+      operation.trace(trace, stamp);
     }
   }
 


### PR DESCRIPTION
Many potentially costly computations are not required for line counting, and can thus be delayed to tracing time, optimizing sequencing performances.