### PR TITLE
Log ZkTracer counters for every produced block

### DIFF
--- a/arithmetization/src/test/resources/log4j2.xml
+++ b/arithmetization/src/test/resources/log4j2.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Properties>
+        <Property name="root.log.level">INFO</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="Console">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSSZZZ} | %t | %-5level | %c{1} | %msg%n" />
+        </Console>
+        <Routing name="Router">
+            <Routes pattern="$${event:Marker}">
+                <Route key="BLOCK_LINE_COUNT">
+                    <Console name="ConsoleBLC" target="SYSTEM_OUT">
+                        <PatternLayout pattern='{"blockNumber":%X{blockNumber},"blockHash":"%X{blockHash}","traceCounts":{%X{traceCounts}}}%n'/>
+                    </Console>
+                </Route>
+                <Route ref="Console" />
+            </Routes>
+        </Routing>
+    </Appenders>
+    <Loggers>
+        <Logger name="net.consensys.linea.sequencer.txselection.selectors.TraceLineLimitTransactionSelector" level="TRACE">
+            <AppenderRef ref="Router" />
+        </Logger>
+        <Root level="${sys:root.log.level}">
+            <AppenderRef ref="Console" />
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
sample output:
```
{"blockNumber":1190297,"blockHash":"0x883acaafae7eeac77625ae4ee15ae5a30f0bdce41749ccec67d3715bade24b33","traceCounts":{"ADD":18658,"BIN":2592,"BLOCK_KECCAK":229,"BLOCK_L1SIZE":8464,"BLOCK_L2L1LOGS":0,"BLOCK_TX":12,"EC_DATA":20,"EXT":9,"HUB":58439,"MMU":10,"MOD":1040,"MUL":320,"MXP":8571,"PRECOMPILE_BLAKE2F":0,"PRECOMPILE_ECADD":0,"PRECOMPILE_ECMUL":0,"PRECOMPILE_ECPAIRING":0,"PRECOMPILE_ECPAIRING_WEIGHTED":0,"PRECOMPILE_ECRECOVER":1,"PRECOMPILE_MODEXP":0,"PRECOMPILE_RIPEMD":0,"PRECOMPILE_SHA2":0,"PUB_LOG":62,"PUB_LOG_INFO":89,"RLP_ADDR":7,"RLP_TXN":7076,"RLP_TXRCPT":1572,"ROM":578418,"ROM_LEX":67,"SHF":1952,"TRM":439,"TXN_DATA":109,"WCP":14028}}
```

using a log4j2 configuration like this one:

```
<?xml version="1.0" encoding="UTF-8"?>
<Configuration status="INFO">
    <Properties>
        <Property name="root.log.level">INFO</Property>
    </Properties>

    <Appenders>
        <Console name="Console">
            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSSZZZ} | %t | %-5level | %c{1} | %msg%n" />
        </Console>
        <Routing name="Router">
            <Routes pattern="$${event:Marker}">
                <Route key="BLOCK_LINE_COUNT">
                    <Console name="ConsoleBLC" target="SYSTEM_OUT">
                        <PatternLayout pattern='{"blockNumber":%X{blockNumber},"blockHash":"%X{blockHash}","traceCounts":{%X{traceCounts}}}%n'/>
                    </Console>
                </Route>
                <Route ref="Console" />
            </Routes>
        </Routing>
    </Appenders>
    <Loggers>
        <Logger name="net.consensys.linea.sequencer.txselection.selectors.TraceLineLimitTransactionSelector" level="TRACE" additivity="false">
            <AppenderRef ref="Router" />
        </Logger>
        <Root level="${sys:root.log.level}">
            <AppenderRef ref="Console" />
        </Root>
    </Loggers>
</Configuration>
```