### PR TITLE
fix: the hub should trace its transactions in the correct order

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/Module.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/Module.java
@@ -45,7 +45,7 @@ public interface Module {
   default void traceEndTx(
       WorldView worldView,
       Transaction tx,
-      boolean status,
+      boolean isSuccessful,
       Bytes output,
       List<Log> logs,
       long gasUsed) {}

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -662,14 +662,19 @@ public class Hub implements Module {
 
   @Override
   public void traceEndTx(
-      WorldView world, Transaction tx, boolean status, Bytes output, List<Log> logs, long gasUsed) {
+      WorldView world,
+      Transaction tx,
+      boolean isSuccessful,
+      Bytes output,
+      List<Log> logs,
+      long gasUsed) {
     if (this.tx.state() != TxState.TX_SKIP) {
       this.tx.state(TxState.TX_FINAL);
     }
-    this.tx.status(status);
+    this.tx.status(!isSuccessful);
 
     if (this.tx.state() != TxState.TX_SKIP) {
-      this.processStateFinal(world, tx, status);
+      this.processStateFinal(world, tx, isSuccessful);
     }
 
     this.defers.runPostTx(this, world, tx);
@@ -677,7 +682,7 @@ public class Hub implements Module {
     this.state.currentTxTrace().postTxRetcon(this);
 
     for (Module m : this.modules) {
-      m.traceEndTx(world, tx, status, output, logs, gasUsed);
+      m.traceEndTx(world, tx, isSuccessful, output, logs, gasUsed);
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/State.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/State.java
@@ -17,6 +17,7 @@ package net.consensys.linea.zktracer.module.hub;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Iterator;
 
 import lombok.Getter;
 import lombok.experimental.Accessors;
@@ -55,7 +56,8 @@ public class State implements StackedContainer {
    * @return the trace builder
    */
   Trace commit(Trace hubTrace) {
-    for (TxState txState : this.state) {
+    for (Iterator<TxState> it = this.state.descendingIterator(); it.hasNext(); ) {
+      final TxState txState = it.next();
       txState.txTrace().commit(hubTrace);
     }
     return hubTrace;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2Block.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2Block.java
@@ -139,7 +139,7 @@ public class L2Block implements Module {
   public void traceEndTx(
       WorldView worldView,
       Transaction tx,
-      boolean status,
+      boolean isSuccessful,
       Bytes output,
       List<Log> logs,
       long gasUsed) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlp/txrcpt/RlpTxrcpt.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlp/txrcpt/RlpTxrcpt.java
@@ -72,11 +72,11 @@ public class RlpTxrcpt implements Module {
   public void traceEndTx(
       WorldView worldView,
       Transaction tx,
-      boolean status,
+      boolean isSuccessful,
       Bytes output,
       List<Log> logList,
       long gasUsed) {
-    RlpTxrcptChunk chunk = new RlpTxrcptChunk(tx.getType(), status, gasUsed, logList);
+    RlpTxrcptChunk chunk = new RlpTxrcptChunk(tx.getType(), isSuccessful, gasUsed, logList);
     this.chunkList.add(chunk);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txn_data/TxnData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txn_data/TxnData.java
@@ -113,13 +113,13 @@ public class TxnData implements Module {
   public void traceEndTx(
       WorldView worldView,
       Transaction tx,
-      boolean status,
+      boolean isSuccessful,
       Bytes output,
       List<Log> logs,
       long cumulativeGasUsed) {
     final long refundCounter = hub.refundedGas();
     final long leftoverGas = hub.remainingGas();
-    this.currentBlock().endTx(cumulativeGasUsed, leftoverGas, refundCounter, status);
+    this.currentBlock().endTx(cumulativeGasUsed, leftoverGas, refundCounter, isSuccessful);
 
     // Call the wcp module:
     if (!this.currentBlock().getTxs().isEmpty()) {


### PR DESCRIPTION
Minor: avoid ambiguity in status boolean.