### PR TITLE
Fix log of line counts in case of block limit reached + minor changes

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
@@ -31,8 +31,8 @@ import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationCon
 @Slf4j
 public class LineaTransactionSelector implements PluginTransactionSelector {
 
-  private static TraceLineLimitTransactionSelector traceLineLimitTransactionSelector;
-  List<PluginTransactionSelector> selectors;
+  private TraceLineLimitTransactionSelector traceLineLimitTransactionSelector;
+  private List<PluginTransactionSelector> selectors;
 
   public LineaTransactionSelector(
       LineaTransactionSelectorConfiguration lineaConfiguration,
@@ -47,7 +47,7 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
    * @param limitsMapSupplier The supplier for the limits map.
    * @return A list of selectors.
    */
-  private static List<PluginTransactionSelector> createTransactionSelectors(
+  private List<PluginTransactionSelector> createTransactionSelectors(
       final LineaTransactionSelectorConfiguration lineaConfiguration,
       final Supplier<Map<String, Integer>> limitsMapSupplier) {
 

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelector.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelector.java
@@ -69,7 +69,7 @@ public class ProfitableTransactionSelector implements PluginTransactionSelector 
 
       if (margin < minMargin) {
         log(
-            log.atInfo(),
+            log.atDebug(),
             transaction,
             margin,
             effectiveGasPrice,


### PR DESCRIPTION
In case we hit one of the module limits, then the summary log at the end is wrong since it contains also the last not selected tx, we just need to use prevCumulatedLineCount instead of currCumulatedLineCount, since it the var that contains the counts of the selected txs. prevCumulatedLineCount renamed to consolidatedCumulatedLineCount to reflect that.