### PR TITLE
Add the possibility to adjust the tx size in the profitability formula

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorCliOptions.java
@@ -30,6 +30,7 @@ public class LineaTransactionSelectorCliOptions {
   public static final int DEFAULT_VERIFICATION_CAPACITY = 90_000;
   public static final int DEFAULT_GAS_PRICE_RATIO = 15;
   public static final BigDecimal DEFAULT_MIN_MARGIN = BigDecimal.ONE;
+  public static final int DEFAULT_ADJUST_TX_SIZE = -45;
   private static final String MAX_BLOCK_CALLDATA_SIZE = "--plugin-linea-max-block-calldata-size";
   private static final String MODULE_LIMIT_FILE_PATH = "--plugin-linea-module-limit-file-path";
   private static final String MAX_GAS_PER_BLOCK = "--plugin-linea-max-block-gas";
@@ -37,6 +38,7 @@ public class LineaTransactionSelectorCliOptions {
   private static final String VERIFICATION_CAPACITY = "--plugin-linea-verification-capacity";
   private static final String GAS_PRICE_RATIO = "--plugin-linea-gas-price-ratio";
   private static final String MIN_MARGIN = "--plugin-linea-min-margin";
+  private static final String ADJUST_TX_SIZE = "--plugin-linea-adjust-tx-size";
 
   @Positive
   @CommandLine.Option(
@@ -94,6 +96,15 @@ public class LineaTransactionSelectorCliOptions {
       description = "Minimum margin of a transaction to be selected (default: ${DEFAULT-VALUE})")
   private BigDecimal minMargin = DEFAULT_MIN_MARGIN;
 
+  @Positive
+  @CommandLine.Option(
+      names = {ADJUST_TX_SIZE},
+      hidden = true,
+      paramLabel = "<INTEGER>",
+      description =
+          "Adjust transaction size for profitability calculation (default: ${DEFAULT-VALUE})")
+  private int adjustTxSize = DEFAULT_ADJUST_TX_SIZE;
+
   private LineaTransactionSelectorCliOptions() {}
 
   /**
@@ -121,6 +132,7 @@ public class LineaTransactionSelectorCliOptions {
     options.verificationCapacity = config.getVerificationCapacity();
     options.gasPriceRatio = config.getGasPriceRatio();
     options.minMargin = BigDecimal.valueOf(config.getMinMargin());
+    options.adjustTxSize = config.getAdjustTxSize();
     return options;
   }
 
@@ -138,6 +150,7 @@ public class LineaTransactionSelectorCliOptions {
         .verificationCapacity(verificationCapacity)
         .gasPriceRatio(gasPriceRatio)
         .minMargin(minMargin.doubleValue())
+        .adjustTxSize(adjustTxSize)
         .build();
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorConfiguration.java
@@ -24,6 +24,7 @@ public final class LineaTransactionSelectorConfiguration {
   private final int verificationCapacity;
   private final int gasPriceRatio;
   private final double minMargin;
+  private final int adjustTxSize;
 
   private LineaTransactionSelectorConfiguration(
       final int maxBlockCallDataSize,
@@ -32,7 +33,8 @@ public final class LineaTransactionSelectorConfiguration {
       final int verificationGasCost,
       final int verificationCapacity,
       final int gasPriceRatio,
-      final double minMargin) {
+      final double minMargin,
+      final int adjustTxSize) {
     this.maxBlockCallDataSize = maxBlockCallDataSize;
     this.moduleLimitsFilePath = moduleLimitsFilePath;
     this.maxGasPerBlock = maxGasPerBlock;
@@ -40,6 +42,7 @@ public final class LineaTransactionSelectorConfiguration {
     this.verificationCapacity = verificationCapacity;
     this.gasPriceRatio = gasPriceRatio;
     this.minMargin = minMargin;
+    this.adjustTxSize = adjustTxSize;
   }
 
   public int maxBlockCallDataSize() {
@@ -70,6 +73,10 @@ public final class LineaTransactionSelectorConfiguration {
     return minMargin;
   }
 
+  public int getAdjustTxSize() {
+    return adjustTxSize;
+  }
+
   public static class Builder {
     private int maxBlockCallDataSize;
     private String moduleLimitsFilePath;
@@ -78,6 +85,7 @@ public final class LineaTransactionSelectorConfiguration {
     private int verificationCapacity;
     private int gasPriceRatio;
     private double minMargin;
+    private int adjustTxSize;
 
     public Builder maxBlockCallDataSize(final int maxBlockCallDataSize) {
       this.maxBlockCallDataSize = maxBlockCallDataSize;
@@ -114,6 +122,11 @@ public final class LineaTransactionSelectorConfiguration {
       return this;
     }
 
+    public Builder adjustTxSize(final int adjustTxSize) {
+      this.adjustTxSize = adjustTxSize;
+      return this;
+    }
+
     public LineaTransactionSelectorConfiguration build() {
       return new LineaTransactionSelectorConfiguration(
           maxBlockCallDataSize,
@@ -122,7 +135,8 @@ public final class LineaTransactionSelectorConfiguration {
           verificationGasCost,
           verificationCapacity,
           gasPriceRatio,
-          minMargin);
+          minMargin,
+          adjustTxSize);
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
@@ -62,7 +62,8 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
             lineaConfiguration.getVerificationGasCost(),
             lineaConfiguration.getVerificationCapacity(),
             lineaConfiguration.getGasPriceRatio(),
-            lineaConfiguration.getMinMargin()),
+            lineaConfiguration.getMinMargin(),
+            lineaConfiguration.getAdjustTxSize()),
         traceLineLimitTransactionSelector);
   }
 

--- a/arithmetization/src/test/java/net/consensys/linea/sequencer/txselection/ProfitableTransactionSelectorTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/sequencer/txselection/ProfitableTransactionSelectorTest.java
@@ -35,6 +35,7 @@ public class ProfitableTransactionSelectorTest {
   private static final int VERIFICATION_CAPACITY = 90_000;
   private static final int GAS_PRICE_RATIO = 15;
   private static final double MIN_MARGIN = 1.0;
+  private static final int ADJUST_TX_SIZE = -45;
 
   private PluginTransactionSelector transactionSelector;
 
@@ -42,7 +43,11 @@ public class ProfitableTransactionSelectorTest {
   public void initialize() {
     transactionSelector =
         new ProfitableTransactionSelector(
-            VERIFICATION_GAS_COST, VERIFICATION_CAPACITY, GAS_PRICE_RATIO, MIN_MARGIN);
+            VERIFICATION_GAS_COST,
+            VERIFICATION_CAPACITY,
+            GAS_PRICE_RATIO,
+            MIN_MARGIN,
+            ADJUST_TX_SIZE);
   }
 
   @Test
@@ -51,6 +56,16 @@ public class ProfitableTransactionSelectorTest {
     verifyTransactionSelection(
         transactionSelector,
         mockEvaluationContext(false, 100, Wei.of(1_100_000_000), Wei.of(1_000_000_000)),
+        mockTransactionProcessingResult,
+        SELECTED);
+  }
+
+  @Test
+  public void shouldSelectWhenProfitableWithAdjustedSize() {
+    var mockTransactionProcessingResult = mockTransactionProcessingResult(21000);
+    verifyTransactionSelection(
+        transactionSelector,
+        mockEvaluationContext(false, 150, Wei.of(1_100_000_000), Wei.of(1_000_000_000)),
         mockTransactionProcessingResult,
         SELECTED);
   }


### PR DESCRIPTION
Add the `--plugin-linea-adjust-tx-size` option to adjust the tx size used to calculate the profitability of a tx during block creation.
By default the value is `-45`