### PR TITLE
Linea estimate gas endpoint

### DIFF
--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/LineaPluginTestBase.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/LineaPluginTestBase.java
@@ -65,8 +65,8 @@ public class LineaPluginTestBase extends AcceptanceTestBase {
   @BeforeEach
   public void setup() throws Exception {
     minerNode =
-        besu.createCliqueNodeWithExtraCliOptions(
-            "miner1", LINEA_CLIQUE_OPTIONS, getTestCliOptions());
+        besu.createCliqueNodeWithExtraCliOptionsAndRpcApis(
+            "miner1", LINEA_CLIQUE_OPTIONS, getTestCliOptions(), Set.of("LINEA"));
     minerNode.setTransactionPoolConfiguration(
         ImmutableTransactionPoolConfiguration.builder()
             .from(TransactionPoolConfiguration.DEFAULT)

--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/ProfitableTransactionTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/ProfitableTransactionTest.java
@@ -42,6 +42,7 @@ public class ProfitableTransactionTest extends LineaPluginTestBase {
         .set("--plugin-linea-verification-capacity=", String.valueOf(VERIFICATION_CAPACITY))
         .set("--plugin-linea-gas-price-ratio=", String.valueOf(GAS_PRICE_RATIO))
         .set("--plugin-linea-min-margin=", String.valueOf(MIN_MARGIN))
+        .set("--plugin-linea-deny-list-path=", getResourcePath("/denyList.txt"))
         .build();
   }
 

--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/ProfitableTransactionTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/ProfitableTransactionTest.java
@@ -42,7 +42,6 @@ public class ProfitableTransactionTest extends LineaPluginTestBase {
         .set("--plugin-linea-verification-capacity=", String.valueOf(VERIFICATION_CAPACITY))
         .set("--plugin-linea-gas-price-ratio=", String.valueOf(GAS_PRICE_RATIO))
         .set("--plugin-linea-min-margin=", String.valueOf(MIN_MARGIN))
-        .set("--plugin-linea-deny-list-path=", getResourcePath("/denyList.txt"))
         .build();
   }
 

--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package linea.plugin.acc.test.rpc.linea;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.List;
+
+import linea.plugin.acc.test.LineaPluginTestBase;
+import linea.plugin.acc.test.TestCommandLineOptionsBuilder;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.NodeRequests;
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.Transaction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.web3j.protocol.core.Request;
+
+public class EstimateGasTest extends LineaPluginTestBase {
+  private static final int VERIFICATION_GAS_COST = 1_200_000;
+  private static final int VERIFICATION_CAPACITY = 90_000;
+  private static final int GAS_PRICE_RATIO = 15;
+  private static final double MIN_MARGIN = 1.0;
+  private static final Wei MIN_GAS_PRICE = Wei.of(1_000_000_000);
+  public static final int MAX_TRANSACTION_GAS_LIMIT = 30_000_000;
+
+  @Override
+  public List<String> getTestCliOptions() {
+    return new TestCommandLineOptionsBuilder()
+        .set("--plugin-linea-verification-gas-cost=", String.valueOf(VERIFICATION_GAS_COST))
+        .set("--plugin-linea-verification-capacity=", String.valueOf(VERIFICATION_CAPACITY))
+        .set("--plugin-linea-gas-price-ratio=", String.valueOf(GAS_PRICE_RATIO))
+        .set("--plugin-linea-min-margin=", String.valueOf(MIN_MARGIN))
+        .set("--plugin-linea-max-tx-gas-limit=", String.valueOf(MAX_TRANSACTION_GAS_LIMIT))
+        .build();
+  }
+
+  @BeforeEach
+  public void setMinGasPrice() {
+    minerNode.getMiningParameters().setMinTransactionGasPrice(MIN_GAS_PRICE);
+  }
+
+  @Test
+  public void estimateGas() {
+
+    final Account sender = accounts.getSecondaryBenefactor();
+    final Account recipient = accounts.createAccount("recipient");
+    final org.web3j.protocol.core.methods.request.Transaction txTransfer =
+        org.web3j.protocol.core.methods.request.Transaction.createEtherTransaction(
+            sender.getAddress(),
+            BigInteger.ZERO,
+            BigInteger.valueOf(1_000_000_000),
+            BigInteger.TEN,
+            recipient.getAddress(),
+            BigInteger.ONE);
+
+    final var req = new LineaEstimateGasRequest(txTransfer);
+    final var resp = req.execute(minerNode.nodeRequests());
+    assertThat(resp.gasLimit()).isEqualTo("0x5208");
+  }
+
+  class LineaEstimateGasRequest implements Transaction<LineaEstimateGasRequest.Response> {
+    private final org.web3j.protocol.core.methods.request.Transaction transaction;
+
+    public LineaEstimateGasRequest(
+        final org.web3j.protocol.core.methods.request.Transaction transaction) {
+      this.transaction = transaction;
+    }
+
+    @Override
+    public LineaEstimateGasRequest.Response execute(final NodeRequests nodeRequests) {
+      try {
+        return new Request<>(
+                "linea_estimateGas",
+                List.of(transaction),
+                nodeRequests.getWeb3jService(),
+                LineaEstimateGasResponse.class)
+            .send()
+            .getResult();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    static class LineaEstimateGasResponse extends org.web3j.protocol.core.Response<Response> {}
+
+    record Response(String gasLimit, String baseFeePerGas, String priorityFeePerGas) {}
+  }
+}

--- a/arithmetization/build.gradle
+++ b/arithmetization/build.gradle
@@ -43,6 +43,7 @@ dependencies {
   implementation "${besuArtifactGroup}:evm"
   implementation "${besuArtifactGroup}:plugin-api"
   implementation "${besuArtifactGroup}:besu-datatypes"
+  implementation "${besuArtifactGroup}.internal:api:${besuVersion}"
   implementation "${besuArtifactGroup}.internal:core:${besuVersion}"
   implementation "${besuArtifactGroup}.internal:rlp:${besuVersion}"
   implementation "${besuArtifactGroup}.internal:algorithms:${besuVersion}"

--- a/arithmetization/src/main/java/net/consensys/linea/AbstractLineaRequiredPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/AbstractLineaRequiredPlugin.java
@@ -20,7 +20,7 @@ import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
 
 @Slf4j
-public abstract class AbstractLineaRequiredPlugin implements BesuPlugin {
+public abstract class AbstractLineaRequiredPlugin extends AbstractLineaSharedOptionsPlugin {
 
   /**
    * Linea plugins extending this class will halt startup of Besu in case of exception during
@@ -32,6 +32,7 @@ public abstract class AbstractLineaRequiredPlugin implements BesuPlugin {
    */
   @Override
   public void register(final BesuContext context) {
+    super.register(context);
     try {
       log.info("Registering Linea plugin " + this.getClass().getName());
 
@@ -44,17 +45,4 @@ public abstract class AbstractLineaRequiredPlugin implements BesuPlugin {
       System.exit(1);
     }
   }
-
-  /**
-   * Linea plugins need to implement this method. Called by {@link BesuPlugin} register method
-   *
-   * @param context
-   */
-  public abstract void doRegister(final BesuContext context);
-
-  @Override
-  public void start() {}
-
-  @Override
-  public void stop() {}
 }

--- a/arithmetization/src/main/java/net/consensys/linea/AbstractLineaSharedOptionsPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/AbstractLineaSharedOptionsPlugin.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea;
+
+import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.config.LineaTransactionSelectorCliOptions;
+import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
+import net.consensys.linea.config.LineaTransactionValidatorCliOptions;
+import net.consensys.linea.config.LineaTransactionValidatorConfiguration;
+import org.hyperledger.besu.plugin.BesuContext;
+import org.hyperledger.besu.plugin.BesuPlugin;
+import org.hyperledger.besu.plugin.services.PicoCLIOptions;
+
+@Slf4j
+public abstract class AbstractLineaSharedOptionsPlugin implements BesuPlugin {
+  private static String CLI_OPTIONS_PREFIX = "linea";
+  private static boolean cliOptionsRegistered = false;
+  private static LineaTransactionSelectorCliOptions transactionSelectorCliOptions;
+  private static LineaTransactionValidatorCliOptions transactionValidatorCliOptions;
+  protected static LineaTransactionSelectorConfiguration transactionSelectorConfiguration;
+  protected static LineaTransactionValidatorConfiguration transactionValidatorConfiguration;
+
+  @Override
+  public synchronized void register(final BesuContext context) {
+    if (!cliOptionsRegistered) {
+      final PicoCLIOptions cmdlineOptions =
+          context
+              .getService(PicoCLIOptions.class)
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "Failed to obtain PicoCLI options from the BesuContext"));
+      transactionSelectorCliOptions = LineaTransactionSelectorCliOptions.create();
+      transactionValidatorCliOptions = LineaTransactionValidatorCliOptions.create();
+
+      cmdlineOptions.addPicoCLIOptions(CLI_OPTIONS_PREFIX, transactionSelectorCliOptions);
+      cmdlineOptions.addPicoCLIOptions(CLI_OPTIONS_PREFIX, transactionValidatorCliOptions);
+      cliOptionsRegistered = true;
+    }
+  }
+
+  @Override
+  public void beforeExternalServices() {
+    log.debug(
+        "Starting plugin {} with transaction selector configuration: {}",
+        getName(),
+        transactionSelectorCliOptions);
+    transactionSelectorConfiguration = transactionSelectorCliOptions.toDomainObject();
+
+    log.debug(
+        "Starting plugin {} with transaction validator configuration: {}",
+        getName(),
+        transactionValidatorCliOptions);
+    transactionValidatorConfiguration = transactionValidatorCliOptions.toDomainObject();
+  }
+
+  /**
+   * Linea plugins need to implement this method. Called by {@link BesuPlugin} register method
+   *
+   * @param context
+   */
+  public abstract void doRegister(final BesuContext context);
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {}
+}

--- a/arithmetization/src/main/java/net/consensys/linea/AbstractLineaSharedOptionsPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/AbstractLineaSharedOptionsPlugin.java
@@ -55,13 +55,13 @@ public abstract class AbstractLineaSharedOptionsPlugin implements BesuPlugin {
   @Override
   public void beforeExternalServices() {
     log.debug(
-        "Starting plugin {} with transaction selector configuration: {}",
+        "Configuring plugin {} with transaction selector configuration: {}",
         getName(),
         transactionSelectorCliOptions);
     transactionSelectorConfiguration = transactionSelectorCliOptions.toDomainObject();
 
     log.debug(
-        "Starting plugin {} with transaction validator configuration: {}",
+        "Configuring plugin {} with transaction validator configuration: {}",
         getName(),
         transactionValidatorCliOptions);
     transactionValidatorConfiguration = transactionValidatorCliOptions.toDomainObject();

--- a/arithmetization/src/main/java/net/consensys/linea/bl/TransactionProfitabilityCalculator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/bl/TransactionProfitabilityCalculator.java
@@ -1,0 +1,130 @@
+package net.consensys.linea.bl;
+
+import java.math.BigDecimal;
+
+import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
+import org.hyperledger.besu.datatypes.Transaction;
+import org.hyperledger.besu.datatypes.Wei;
+import org.slf4j.spi.LoggingEventBuilder;
+
+@Slf4j
+public class TransactionProfitabilityCalculator {
+
+  private final LineaTransactionSelectorConfiguration conf;
+  private final double preComputedValue;
+
+  public TransactionProfitabilityCalculator(final LineaTransactionSelectorConfiguration conf) {
+    this.conf = conf;
+    this.preComputedValue =
+        conf.getEstimateGasMinMargin() * conf.getGasPriceRatio() * conf.getVerificationGasCost();
+  }
+
+  public Wei profitablePriorityFeePerGas(
+      final Transaction transaction, final Wei minGasPrice, final long gas) {
+    final double txSize = Math.max(0, transaction.getSize() + conf.getAdjustTxSize());
+    final double compressedSerializedSize = txSize / conf.getTxCompressionRatio();
+
+    final var profitAt =
+        preComputedValue
+            * txSize
+            * minGasPrice.getAsBigInteger().doubleValue()
+            / (gas * conf.getVerificationCapacity());
+
+    final var profitAtWei = Wei.ofNumber(BigDecimal.valueOf(profitAt).toBigInteger());
+
+    log.atDebug()
+        .setMessage(
+            "Estimated profitable priorityFeePerGas: {}; estimateGasMinMargin={}, gasPriceRatio={}, "
+                + "verificationGasCost={}, txSize={}, compressedTxSize={}, minGasPrice={}, gas={}, verificationCapacity={}")
+        .addArgument(profitAtWei::toHumanReadableString)
+        .addArgument(conf.getEstimateGasMinMargin())
+        .addArgument(conf.getGasPriceRatio())
+        .addArgument(conf.getVerificationGasCost())
+        .addArgument(txSize)
+        .addArgument(compressedSerializedSize)
+        .addArgument(minGasPrice::toHumanReadableString)
+        .addArgument(gas)
+        .addArgument(conf.getVerificationCapacity())
+        .log();
+
+    return Wei.ofNumber(BigDecimal.valueOf(profitAt).toBigInteger());
+  }
+
+  public boolean isProfitable(
+      final String step,
+      final Transaction transaction,
+      final double minGasPrice,
+      final double effectiveGasPrice,
+      final long gas) {
+    final double revenue = effectiveGasPrice * gas;
+
+    final double l1GasPrice = minGasPrice * conf.getGasPriceRatio();
+    final int serializedSize = Math.max(0, transaction.getSize() + conf.getAdjustTxSize());
+    final double verificationGasCostSlice =
+        (((double) serializedSize) / conf.getVerificationCapacity())
+            * conf.getVerificationGasCost();
+    final double cost = l1GasPrice * verificationGasCostSlice;
+
+    final double margin = revenue / cost;
+
+    if (margin < conf.getMinMargin()) {
+      log(
+          log.atDebug(),
+          step,
+          transaction,
+          margin,
+          effectiveGasPrice,
+          gas,
+          minGasPrice,
+          l1GasPrice,
+          serializedSize,
+          conf.getAdjustTxSize());
+      return false;
+    } else {
+      log(
+          log.atTrace(),
+          step,
+          transaction,
+          margin,
+          effectiveGasPrice,
+          gas,
+          minGasPrice,
+          l1GasPrice,
+          serializedSize,
+          conf.getAdjustTxSize());
+      return true;
+    }
+  }
+
+  private void log(
+      final LoggingEventBuilder leb,
+      final String context,
+      final Transaction transaction,
+      final double margin,
+      final double effectiveGasPrice,
+      final long gasUsed,
+      final double minGasPrice,
+      final double l1GasPrice,
+      final int serializedSize,
+      final int adjustTxSize) {
+    leb.setMessage(
+            "Context {}. Transaction {} has a margin of {}, minMargin={}, verificationCapacity={}, "
+                + "verificationGasCost={}, gasPriceRatio={}, effectiveGasPrice={}, gasUsed={}, minGasPrice={}, "
+                + "l1GasPrice={}, serializedSize={}, adjustTxSize={}")
+        .addArgument(context)
+        .addArgument(transaction::getHash)
+        .addArgument(margin)
+        .addArgument(conf.getMinMargin())
+        .addArgument(conf.getVerificationCapacity())
+        .addArgument(conf.getVerificationGasCost())
+        .addArgument(conf.getGasPriceRatio())
+        .addArgument(effectiveGasPrice)
+        .addArgument(gasUsed)
+        .addArgument(minGasPrice)
+        .addArgument(l1GasPrice)
+        .addArgument(serializedSize)
+        .addArgument(adjustTxSize)
+        .log();
+  }
+}

--- a/arithmetization/src/main/java/net/consensys/linea/bl/TransactionProfitabilityCalculator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/bl/TransactionProfitabilityCalculator.java
@@ -62,7 +62,7 @@ public class TransactionProfitabilityCalculator {
         .addArgument(conf.verificationCapacity())
         .log();
 
-    return Wei.ofNumber(BigDecimal.valueOf(profitAt).toBigInteger());
+    return profitAtWei;
   }
 
   public boolean isProfitable(

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaTransactionSelectorCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaTransactionSelectorCliOptions.java
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.sequencer.txselection;
+package net.consensys.linea.config;
 
 import java.math.BigDecimal;
 
@@ -30,7 +30,9 @@ public class LineaTransactionSelectorCliOptions {
   public static final int DEFAULT_VERIFICATION_CAPACITY = 90_000;
   public static final int DEFAULT_GAS_PRICE_RATIO = 15;
   public static final BigDecimal DEFAULT_MIN_MARGIN = BigDecimal.ONE;
+  public static final BigDecimal DEFAULT_ESTIMATE_GAS_MIN_MARGIN = BigDecimal.ONE;
   public static final int DEFAULT_ADJUST_TX_SIZE = -45;
+  public static final int DEFAULT_TX_COMPRESSION_RATIO = 5;
   public static final int DEFAULT_UNPROFITABLE_CACHE_SIZE = 100_000;
   public static final int DEFAULT_UNPROFITABLE_RETRY_LIMIT = 10;
   private static final String MAX_BLOCK_CALLDATA_SIZE = "--plugin-linea-max-block-calldata-size";
@@ -40,7 +42,9 @@ public class LineaTransactionSelectorCliOptions {
   private static final String VERIFICATION_CAPACITY = "--plugin-linea-verification-capacity";
   private static final String GAS_PRICE_RATIO = "--plugin-linea-gas-price-ratio";
   private static final String MIN_MARGIN = "--plugin-linea-min-margin";
+  private static final String ESTIMATE_GAS_MIN_MARGIN = "--plugin-linea-estimate-gas-min-margin";
   private static final String ADJUST_TX_SIZE = "--plugin-linea-adjust-tx-size";
+  private static final String TX_COMPRESSION_RATIO = "--plugin-linea-tx-compression-ratio";
   private static final String UNPROFITABLE_CACHE_SIZE = "--plugin-linea-unprofitable-cache-size";
   private static final String UNPROFITABLE_RETRY_LIMIT = "--plugin-linea-unprofitable-retry-limit";
 
@@ -102,12 +106,30 @@ public class LineaTransactionSelectorCliOptions {
 
   @Positive
   @CommandLine.Option(
+      names = {ESTIMATE_GAS_MIN_MARGIN},
+      hidden = true,
+      paramLabel = "<FLOAT>",
+      description =
+          "Recommend a specific gas price when using linea_estimateGas (default: ${DEFAULT-VALUE})")
+  private BigDecimal estimageGasMinMargin = DEFAULT_ESTIMATE_GAS_MIN_MARGIN;
+
+  @Positive
+  @CommandLine.Option(
       names = {ADJUST_TX_SIZE},
       hidden = true,
       paramLabel = "<INTEGER>",
       description =
           "Adjust transaction size for profitability calculation (default: ${DEFAULT-VALUE})")
   private int adjustTxSize = DEFAULT_ADJUST_TX_SIZE;
+
+  @Positive
+  @CommandLine.Option(
+      names = {TX_COMPRESSION_RATIO},
+      hidden = true,
+      paramLabel = "<INTEGER>",
+      description =
+          "The ratio between tx serialized size and its compressed size (default: ${DEFAULT-VALUE})")
+  private int txCompressionRatio = DEFAULT_TX_COMPRESSION_RATIO;
 
   @Positive
   @CommandLine.Option(
@@ -154,7 +176,9 @@ public class LineaTransactionSelectorCliOptions {
     options.verificationCapacity = config.getVerificationCapacity();
     options.gasPriceRatio = config.getGasPriceRatio();
     options.minMargin = BigDecimal.valueOf(config.getMinMargin());
+    options.estimageGasMinMargin = BigDecimal.valueOf(config.getEstimateGasMinMargin());
     options.adjustTxSize = config.getAdjustTxSize();
+    options.txCompressionRatio = config.getTxCompressionRatio();
     options.unprofitableCacheSize = config.getUnprofitableCacheSize();
     options.unprofitableRetryLimit = config.getUnprofitableRetryLimit();
     return options;
@@ -174,7 +198,9 @@ public class LineaTransactionSelectorCliOptions {
         .verificationCapacity(verificationCapacity)
         .gasPriceRatio(gasPriceRatio)
         .minMargin(minMargin.doubleValue())
+        .estimateGasMinMargin((estimageGasMinMargin.doubleValue()))
         .adjustTxSize(adjustTxSize)
+        .txCompressionRatio(txCompressionRatio)
         .unprofitableCacheSize(unprofitableCacheSize)
         .unprofitableRetryLimit(unprofitableRetryLimit)
         .build();
@@ -190,7 +216,9 @@ public class LineaTransactionSelectorCliOptions {
         .add(VERIFICATION_CAPACITY, verificationCapacity)
         .add(GAS_PRICE_RATIO, gasPriceRatio)
         .add(MIN_MARGIN, minMargin)
+        .add(ESTIMATE_GAS_MIN_MARGIN, estimageGasMinMargin)
         .add(ADJUST_TX_SIZE, adjustTxSize)
+        .add(TX_COMPRESSION_RATIO, txCompressionRatio)
         .add(UNPROFITABLE_CACHE_SIZE, unprofitableCacheSize)
         .add(UNPROFITABLE_RETRY_LIMIT, unprofitableRetryLimit)
         .toString();

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaTransactionSelectorConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaTransactionSelectorConfiguration.java
@@ -13,14 +13,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.sequencer.txselection;
+package net.consensys.linea.config;
 
 import lombok.Builder;
 import lombok.Getter;
 
 /** The Linea configuration. */
 @Getter
-@Builder
+@Builder(toBuilder = true)
 public final class LineaTransactionSelectorConfiguration {
   private final int maxBlockCallDataSize;
   private final String moduleLimitsFilePath;
@@ -29,7 +29,9 @@ public final class LineaTransactionSelectorConfiguration {
   private final int verificationCapacity;
   private final int gasPriceRatio;
   private final double minMargin;
+  private final double estimateGasMinMargin;
   private final int adjustTxSize;
+  private final int txCompressionRatio;
   private final int unprofitableCacheSize;
   private final int unprofitableRetryLimit;
 }

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaTransactionValidatorCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaTransactionValidatorCliOptions.java
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.sequencer.txvalidation;
+package net.consensys.linea.config;
 
 import com.google.common.base.MoreObjects;
 import picocli.CommandLine;

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaTransactionValidatorConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaTransactionValidatorConfiguration.java
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.sequencer.txvalidation;
+package net.consensys.linea.config;
 
 /**
  * The Linea configuration.

--- a/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEndpointServicePlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEndpointServicePlugin.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.rpc.linea;
+
+import com.google.auto.service.AutoService;
+import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.AbstractLineaRequiredPlugin;
+import org.hyperledger.besu.plugin.BesuContext;
+import org.hyperledger.besu.plugin.BesuPlugin;
+import org.hyperledger.besu.plugin.services.BesuConfiguration;
+import org.hyperledger.besu.plugin.services.BlockchainService;
+import org.hyperledger.besu.plugin.services.RpcEndpointService;
+import org.hyperledger.besu.plugin.services.TransactionSimulationService;
+
+/** Registers RPC endpoints. This class provides RPC endpoints under the 'linea' namespace. */
+@AutoService(BesuPlugin.class)
+@Slf4j
+public class LineaEndpointServicePlugin extends AbstractLineaRequiredPlugin {
+  private BesuConfiguration besuConfiguration;
+  private RpcEndpointService rpcEndpointService;
+  private TransactionSimulationService transactionSimulationService;
+  private BlockchainService blockchainService;
+  private LineaEstimateGas lineaEstimateGasMethod;
+
+  /**
+   * Register the RPC service.
+   *
+   * @param context the BesuContext to be used.
+   */
+  @Override
+  public void doRegister(final BesuContext context) {
+    besuConfiguration =
+        context
+            .getService(BesuConfiguration.class)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Failed to obtain BesuConfiguration from the BesuContext."));
+
+    rpcEndpointService =
+        context
+            .getService(RpcEndpointService.class)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Failed to obtain RpcEndpointService from the BesuContext."));
+
+    transactionSimulationService =
+        context
+            .getService(TransactionSimulationService.class)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Failed to obtain TransactionSimulatorService from the BesuContext."));
+
+    blockchainService =
+        context
+            .getService(BlockchainService.class)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Failed to obtain BlockchainService from the BesuContext."));
+
+    lineaEstimateGasMethod =
+        new LineaEstimateGas(besuConfiguration, transactionSimulationService, blockchainService);
+
+    rpcEndpointService.registerRPCEndpoint(
+        lineaEstimateGasMethod.getNamespace(),
+        lineaEstimateGasMethod.getName(),
+        lineaEstimateGasMethod::execute);
+  }
+
+  @Override
+  public void beforeExternalServices() {
+    super.beforeExternalServices();
+    lineaEstimateGasMethod.init(
+        transactionValidatorConfiguration, transactionSelectorConfiguration);
+  }
+}

--- a/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
+++ b/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
@@ -137,7 +137,10 @@ public class LineaEstimateGas {
                     .addArgument(transaction::toTraceLog)
                     .addArgument(r.result())
                     .log();
-                throw new RuntimeException("Invalid or unsuccessful transaction");
+                final var invalidReason = r.result().getInvalidReason();
+                throw new RuntimeException(
+                    "Invalid or unsuccessful transaction"
+                        + invalidReason.map(ir -> ", reason: " + ir).orElse(""));
               }
 
               final var lowGasEstimation = r.result().getEstimateGasUsedByTransaction();

--- a/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
+++ b/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
@@ -43,14 +43,20 @@ import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
 @Slf4j
 public class LineaEstimateGas {
   private static final double SUB_CALL_REMAINING_GAS_RATIO = 65D / 64D;
-  private static final SECPSignature FAKE_SIGNATURE_FOR_SIZE;
+  private static final SECPSignature FAKE_SIGNATURE_FOR_SIZE_CALCULATION;
 
   static {
     final X9ECParameters params = SECNamedCurves.getByName("secp256k1");
     final ECDomainParameters curve =
         new ECDomainParameters(params.getCurve(), params.getG(), params.getN(), params.getH());
-    FAKE_SIGNATURE_FOR_SIZE =
-        SECPSignature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0, curve.getN());
+    FAKE_SIGNATURE_FOR_SIZE_CALCULATION =
+        SECPSignature.create(
+            new BigInteger(
+                "66397251408932042429874251838229702988618145381408295790259650671563847073199"),
+            new BigInteger(
+                "24729624138373455972486746091821238755870276413282629437244319694880507882088"),
+            (byte) 0,
+            curve.getN());
   }
 
   private final JsonRpcParameter parameterParser = new JsonRpcParameter();
@@ -214,7 +220,7 @@ public class LineaEstimateGas {
                 callParameters.getPayload() == null ? Bytes.EMPTY : callParameters.getPayload())
             .gasPrice(callParameters.getGasPrice())
             .value(callParameters.getValue())
-            .signature(FAKE_SIGNATURE_FOR_SIZE);
+            .signature(FAKE_SIGNATURE_FOR_SIZE_CALCULATION);
 
     callParameters.getMaxFeePerGas().ifPresent(txBuilder::maxFeePerGas);
     callParameters.getMaxPriorityFeePerGas().ifPresent(txBuilder::maxPriorityFeePerGas);

--- a/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
+++ b/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.rpc.linea;
+
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity.create;
+
+import java.math.BigInteger;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.bl.TransactionProfitabilityCalculator;
+import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
+import net.consensys.linea.config.LineaTransactionValidatorConfiguration;
+import org.apache.tuweni.bytes.Bytes;
+import org.bouncycastle.asn1.sec.SECNamedCurves;
+import org.bouncycastle.asn1.x9.X9ECParameters;
+import org.bouncycastle.crypto.params.ECDomainParameters;
+import org.hyperledger.besu.crypto.SECPSignature;
+import org.hyperledger.besu.datatypes.Transaction;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonCallParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
+import org.hyperledger.besu.evm.tracing.EstimateGasOperationTracer;
+import org.hyperledger.besu.plugin.services.BesuConfiguration;
+import org.hyperledger.besu.plugin.services.BlockchainService;
+import org.hyperledger.besu.plugin.services.TransactionSimulationService;
+import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
+
+@Slf4j
+public class LineaEstimateGas {
+  private static final double SUB_CALL_REMAINING_GAS_RATIO = 65D / 64D;
+  private static final SECPSignature FAKE_SIGNATURE_FOR_SIZE;
+
+  static {
+    final X9ECParameters params = SECNamedCurves.getByName("secp256k1");
+    final ECDomainParameters curve =
+        new ECDomainParameters(params.getCurve(), params.getG(), params.getN(), params.getH());
+    FAKE_SIGNATURE_FOR_SIZE =
+        SECPSignature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0, curve.getN());
+  }
+
+  private final JsonRpcParameter parameterParser = new JsonRpcParameter();
+  private final BesuConfiguration besuConfiguration;
+  private final TransactionSimulationService transactionSimulationService;
+  private final BlockchainService blockchainService;
+  private LineaTransactionValidatorConfiguration txValidatorConf;
+  private LineaTransactionSelectorConfiguration txSelectorConf;
+  private TransactionProfitabilityCalculator txProfitabilityCalculator;
+
+  public LineaEstimateGas(
+      final BesuConfiguration besuConfiguration,
+      final TransactionSimulationService transactionSimulationService,
+      final BlockchainService blockchainService) {
+    this.besuConfiguration = besuConfiguration;
+    this.transactionSimulationService = transactionSimulationService;
+    this.blockchainService = blockchainService;
+  }
+
+  public void init(
+      final LineaTransactionValidatorConfiguration transactionValidatorConfiguration,
+      final LineaTransactionSelectorConfiguration transactionSelectorConfiguration) {
+    this.txValidatorConf = transactionValidatorConfiguration;
+    this.txSelectorConf = transactionSelectorConfiguration;
+    this.txProfitabilityCalculator = new TransactionProfitabilityCalculator(txSelectorConf);
+  }
+
+  public String getNamespace() {
+    return "linea";
+  }
+
+  public String getName() {
+    return "estimateGas";
+  }
+
+  public LineaEstimateGas.Response execute(final PluginRpcRequest request) {
+    final var callParameters = parseRequest(request.getParams());
+    final var transaction =
+        createTransactionOverridingGasLimit(callParameters, txValidatorConf.maxTxGasLimit());
+    final var estimateGasUsed = estimateGasUsed(callParameters, transaction);
+
+    final Wei baseFee =
+        blockchainService
+            .getNextBlockBaseFee()
+            .orElseThrow(() -> new IllegalStateException("Not on a baseFee market"));
+
+    final Wei estimatedPriorityFee =
+        txProfitabilityCalculator.profitablePriorityFeePerGas(
+            transaction, besuConfiguration.getMinGasPrice(), estimateGasUsed);
+
+    return new Response(create(estimateGasUsed), create(baseFee), create(estimatedPriorityFee));
+  }
+
+  private Long estimateGasUsed(
+      final JsonCallParameter callParameters, final Transaction transaction) {
+    final var tracer = new EstimateGasOperationTracer();
+    final var chainHeadHash = blockchainService.getChainHeadHash();
+    final var maybeSimulationResults =
+        transactionSimulationService.simulate(transaction, chainHeadHash, tracer);
+
+    return maybeSimulationResults
+        .map(
+            r -> {
+
+              // if the transaction is invalid or doesn't have enough gas with the max it never
+              // will!
+              if (r.isInvalid() || !r.isSuccessful()) {
+                throw new RuntimeException("Invalid or unsuccessful transaction");
+              }
+
+              final var lowGasEstimation = r.result().getEstimateGasUsedByTransaction();
+              final var lowResult =
+                  transactionSimulationService.simulate(
+                      createTransactionOverridingGasLimit(callParameters, lowGasEstimation),
+                      chainHeadHash,
+                      tracer);
+
+              return lowResult
+                  .map(
+                      lr -> {
+                        // if with the low estimation gas is successful the return this
+                        // estimation
+                        if (lr.isSuccessful()) {
+                          return lowGasEstimation;
+                        } else {
+                          // else do a binary search to find the right estimation
+                          var high = highGasEstimation(lr.getGasEstimate(), tracer);
+                          var mid = high;
+                          var low = lowGasEstimation;
+                          while (low + 1 < high) {
+                            mid = (high + low) / 2;
+
+                            final var binarySearchResult =
+                                transactionSimulationService.simulate(
+                                    createTransactionOverridingGasLimit(callParameters, mid),
+                                    chainHeadHash,
+                                    tracer);
+
+                            if (binarySearchResult.isEmpty()
+                                || !binarySearchResult.get().isSuccessful()) {
+                              low = mid;
+                            } else {
+                              high = mid;
+                            }
+                          }
+                          return high;
+                        }
+                      })
+                  .orElseThrow();
+            })
+        .orElseThrow();
+  }
+
+  private JsonCallParameter parseRequest(final Object[] params) {
+    final var callParameters = parameterParser.required(params, 0, JsonCallParameter.class);
+    validateParameters(callParameters);
+    return callParameters;
+  }
+
+  private void validateParameters(final JsonCallParameter callParameters) {
+    if (callParameters.getGasPrice() != null
+        && (callParameters.getMaxFeePerGas().isPresent()
+            || callParameters.getMaxPriorityFeePerGas().isPresent())) {
+      throw new InvalidJsonRpcParameters(
+          "gasPrice cannot be used with maxFeePerGas or maxPriorityFeePerGas");
+    }
+
+    if (callParameters.getGasLimit() > 0
+        && callParameters.getGasLimit() > txValidatorConf.maxTxGasLimit()) {
+      throw new InvalidJsonRpcParameters("gasLimit above maximum");
+    }
+  }
+
+  /**
+   * Estimate gas by adding minimum gas remaining for some operation and the necessary gas for sub
+   * calls
+   *
+   * @param gasEstimation transaction gas estimation
+   * @param operationTracer estimate gas operation tracer
+   * @return estimate gas
+   */
+  private long highGasEstimation(
+      final long gasEstimation, final EstimateGasOperationTracer operationTracer) {
+    // no more than 63/64s of the remaining gas can be passed to the sub calls
+    final double subCallMultiplier =
+        Math.pow(SUB_CALL_REMAINING_GAS_RATIO, operationTracer.getMaxDepth());
+    // and minimum gas remaining is necessary for some operation (additionalStipend)
+    final long gasStipend = operationTracer.getStipendNeeded();
+    return ((long) ((gasEstimation + gasStipend) * subCallMultiplier));
+  }
+
+  private Transaction createTransactionOverridingGasLimit(
+      final JsonCallParameter callParameters, final long maxTxGasLimit) {
+
+    final var txBuilder =
+        org.hyperledger.besu.ethereum.core.Transaction.builder()
+            .sender(callParameters.getFrom())
+            .to(callParameters.getTo())
+            .gasLimit(maxTxGasLimit)
+            .payload(
+                callParameters.getPayload() == null ? Bytes.EMPTY : callParameters.getPayload())
+            .gasPrice(callParameters.getGasPrice())
+            .value(callParameters.getValue())
+            .signature(FAKE_SIGNATURE_FOR_SIZE);
+
+    callParameters.getMaxFeePerGas().ifPresent(txBuilder::maxFeePerGas);
+    callParameters.getMaxPriorityFeePerGas().ifPresent(txBuilder::maxPriorityFeePerGas);
+    callParameters.getAccessList().ifPresent(txBuilder::accessList);
+
+    return txBuilder.build();
+  }
+
+  public record Response(
+      @JsonProperty String gasLimit,
+      @JsonProperty String baseFeePerGas,
+      @JsonProperty String priorityFeePerGas) {}
+}

--- a/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
+++ b/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
@@ -123,7 +123,7 @@ public class LineaEstimateGas {
     final var tracer = new EstimateGasOperationTracer();
     final var chainHeadHash = blockchainService.getChainHeadHash();
     final var maybeSimulationResults =
-        transactionSimulationService.simulate(transaction, chainHeadHash, tracer);
+        transactionSimulationService.simulate(transaction, chainHeadHash, tracer, true);
 
     return maybeSimulationResults
         .map(
@@ -148,7 +148,8 @@ public class LineaEstimateGas {
                   transactionSimulationService.simulate(
                       createTransactionOverridingGasLimit(callParameters, lowGasEstimation),
                       chainHeadHash,
-                      tracer);
+                      tracer,
+                      true);
 
               return lowResult
                   .map(
@@ -179,7 +180,8 @@ public class LineaEstimateGas {
                                 transactionSimulationService.simulate(
                                     createTransactionOverridingGasLimit(callParameters, mid),
                                     chainHeadHash,
-                                    tracer);
+                                    tracer,
+                                    true);
 
                             if (binarySearchResult.isEmpty()
                                 || !binarySearchResult.get().isSuccessful()) {

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactory.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactory.java
@@ -16,26 +16,26 @@
 package net.consensys.linea.sequencer.txselection;
 
 import java.util.Map;
-import java.util.function.Supplier;
 
+import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
 import net.consensys.linea.sequencer.txselection.selectors.LineaTransactionSelector;
 import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelector;
 import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelectorFactory;
 
 /** Represents a factory for creating transaction selectors. */
 public class LineaTransactionSelectorFactory implements PluginTransactionSelectorFactory {
-  private final LineaTransactionSelectorCliOptions options;
-  private final Supplier<Map<String, Integer>> limitsMapSupplier;
+  final LineaTransactionSelectorConfiguration txSelectorConfiguration;
+  private final Map<String, Integer> limitsMap;
 
   public LineaTransactionSelectorFactory(
-      final LineaTransactionSelectorCliOptions options,
-      final Supplier<Map<String, Integer>> limitsMapSupplier) {
-    this.options = options;
-    this.limitsMapSupplier = limitsMapSupplier;
+      final LineaTransactionSelectorConfiguration txSelectorConfiguration,
+      final Map<String, Integer> limitsMap) {
+    this.txSelectorConfiguration = txSelectorConfiguration;
+    this.limitsMap = limitsMap;
   }
 
   @Override
   public PluginTransactionSelector create() {
-    return new LineaTransactionSelector(options.toDomainObject(), this.limitsMapSupplier);
+    return new LineaTransactionSelector(txSelectorConfiguration, limitsMap);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorPlugin.java
@@ -20,19 +20,18 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.service.AutoService;
 import com.google.common.io.Resources;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.AbstractLineaRequiredPlugin;
+import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
 import org.apache.tuweni.toml.Toml;
 import org.apache.tuweni.toml.TomlParseResult;
 import org.apache.tuweni.toml.TomlTable;
 import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
-import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 import org.hyperledger.besu.plugin.services.TransactionSelectionService;
 
 /**
@@ -44,13 +43,7 @@ import org.hyperledger.besu.plugin.services.TransactionSelectionService;
 @AutoService(BesuPlugin.class)
 public class LineaTransactionSelectorPlugin extends AbstractLineaRequiredPlugin {
   public static final String NAME = "linea";
-  private final LineaTransactionSelectorCliOptions options;
-  private Optional<TransactionSelectionService> service;
-  private final Map<String, Integer> limitsMap = new ConcurrentHashMap<>();
-
-  public LineaTransactionSelectorPlugin() {
-    options = LineaTransactionSelectorCliOptions.create();
-  }
+  private TransactionSelectionService transactionSelectionService;
 
   @Override
   public Optional<String> getName() {
@@ -59,48 +52,45 @@ public class LineaTransactionSelectorPlugin extends AbstractLineaRequiredPlugin 
 
   @Override
   public void doRegister(final BesuContext context) {
-    final Optional<PicoCLIOptions> cmdlineOptions = context.getService(PicoCLIOptions.class);
-
-    if (cmdlineOptions.isEmpty()) {
-      throw new IllegalStateException("Failed to obtain PicoCLI options from the BesuContext");
-    }
-
-    cmdlineOptions.get().addPicoCLIOptions(getName().get(), options);
-
-    service = context.getService(TransactionSelectionService.class);
-    createAndRegister(
-        service.orElseThrow(
-            () ->
-                new RuntimeException(
-                    "Failed to obtain TransactionSelectionService from the BesuContext.")));
+    transactionSelectionService =
+        context
+            .getService(TransactionSelectionService.class)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Failed to obtain TransactionSelectionService from the BesuContext."));
   }
 
   @Override
-  public void start() {
-    log.debug("Starting {} with configuration: {}", NAME, options);
-    final LineaTransactionSelectorConfiguration lineaConfiguration = options.toDomainObject();
-    ObjectMapper objectMapper = new ObjectMapper();
-
+  public void beforeExternalServices() {
+    super.beforeExternalServices();
     try {
-      URL url = new File(lineaConfiguration.getModuleLimitsFilePath()).toURI().toURL();
+      URL url =
+          new File(transactionSelectorConfiguration.getModuleLimitsFilePath()).toURI().toURL();
       final String tomlString = Resources.toString(url, StandardCharsets.UTF_8);
       TomlParseResult result = Toml.parse(tomlString);
       final TomlTable table = result.getTable("traces-limits");
-      table
-          .toMap()
-          .keySet()
-          .forEach(key -> limitsMap.put(key, Math.toIntExact(table.getLong(key))));
+      final Map<String, Integer> limitsMap =
+          table.toMap().entrySet().stream()
+              .collect(
+                  Collectors.toUnmodifiableMap(
+                      Map.Entry::getKey, e -> Math.toIntExact((Long) e.getValue())));
+
+      createAndRegister(transactionSelectionService, transactionSelectorConfiguration, limitsMap);
     } catch (final Exception e) {
       final String errorMsg =
           "Problem reading the toml file containing the limits for the modules: "
-              + lineaConfiguration.getModuleLimitsFilePath();
+              + transactionSelectorConfiguration.getModuleLimitsFilePath();
       log.error(errorMsg);
       throw new RuntimeException(errorMsg, e);
     }
   }
 
-  private void createAndRegister(final TransactionSelectionService transactionSelectionService) {
+  private void createAndRegister(
+      final TransactionSelectionService transactionSelectionService,
+      final LineaTransactionSelectorConfiguration txSelectorConfiguration,
+      final Map<String, Integer> limitsMap) {
     transactionSelectionService.registerTransactionSelectorFactory(
-        new LineaTransactionSelectorFactory(options, () -> this.limitsMap));
+        new LineaTransactionSelectorFactory(txSelectorConfiguration, limitsMap));
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/LineaTransactionSelector.java
@@ -16,10 +16,9 @@ package net.consensys.linea.sequencer.txselection.selectors;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 import lombok.extern.slf4j.Slf4j;
-import net.consensys.linea.sequencer.txselection.LineaTransactionSelectorConfiguration;
+import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
 import org.hyperledger.besu.datatypes.PendingTransaction;
 import org.hyperledger.besu.plugin.data.TransactionProcessingResult;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
@@ -36,36 +35,29 @@ public class LineaTransactionSelector implements PluginTransactionSelector {
 
   public LineaTransactionSelector(
       LineaTransactionSelectorConfiguration lineaConfiguration,
-      final Supplier<Map<String, Integer>> limitsMapSupplier) {
-    this.selectors = createTransactionSelectors(lineaConfiguration, limitsMapSupplier);
+      final Map<String, Integer> limitsMap) {
+    this.selectors = createTransactionSelectors(lineaConfiguration, limitsMap);
   }
 
   /**
    * Creates a list of selectors based on Linea configuration.
    *
    * @param lineaConfiguration The configuration to use.
-   * @param limitsMapSupplier The supplier for the limits map.
+   * @param limitsMap The limits map.
    * @return A list of selectors.
    */
   private List<PluginTransactionSelector> createTransactionSelectors(
       final LineaTransactionSelectorConfiguration lineaConfiguration,
-      final Supplier<Map<String, Integer>> limitsMapSupplier) {
+      final Map<String, Integer> limitsMap) {
 
     traceLineLimitTransactionSelector =
         new TraceLineLimitTransactionSelector(
-            limitsMapSupplier, lineaConfiguration.getModuleLimitsFilePath());
+            limitsMap, lineaConfiguration.getModuleLimitsFilePath());
 
     return List.of(
         new MaxBlockCallDataTransactionSelector(lineaConfiguration.getMaxBlockCallDataSize()),
         new MaxBlockGasTransactionSelector(lineaConfiguration.getMaxGasPerBlock()),
-        new ProfitableTransactionSelector(
-            lineaConfiguration.getVerificationGasCost(),
-            lineaConfiguration.getVerificationCapacity(),
-            lineaConfiguration.getGasPriceRatio(),
-            lineaConfiguration.getMinMargin(),
-            lineaConfiguration.getAdjustTxSize(),
-            lineaConfiguration.getUnprofitableCacheSize(),
-            lineaConfiguration.getUnprofitableRetryLimit()),
+        new ProfitableTransactionSelector(lineaConfiguration),
         traceLineLimitTransactionSelector);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelector.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelector.java
@@ -24,8 +24,9 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import com.google.common.annotations.VisibleForTesting;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.bl.TransactionProfitabilityCalculator;
+import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.PendingTransaction;
@@ -35,23 +36,22 @@ import org.hyperledger.besu.plugin.data.TransactionProcessingResult;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelector;
 import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext;
-import org.slf4j.spi.LoggingEventBuilder;
 
 @Slf4j
-@RequiredArgsConstructor
 public class ProfitableTransactionSelector implements PluginTransactionSelector {
   @VisibleForTesting protected static Set<Hash> unprofitableCache = new LinkedHashSet<>();
   @VisibleForTesting protected static Wei prevMinGasPrice = Wei.MAX_WEI;
 
-  private final int verificationGasCost;
-  private final int verificationCapacity;
-  private final int gasPriceRatio;
-  private final double minMargin;
-  private final int adjustTxSize;
-  private final int unprofitableCacheSize;
-  private final int unprofitableRetryLimit;
+  private final LineaTransactionSelectorConfiguration conf;
+  private final TransactionProfitabilityCalculator transactionProfitabilityCalculator;
+
   private int unprofitableRetries;
   private MutableBoolean minGasPriceDecreased;
+
+  public ProfitableTransactionSelector(final LineaTransactionSelectorConfiguration conf) {
+    this.conf = conf;
+    this.transactionProfitabilityCalculator = new TransactionProfitabilityCalculator(conf);
+  }
 
   @Override
   public TransactionSelectionResult evaluateTransactionPreProcessing(
@@ -72,7 +72,7 @@ public class ProfitableTransactionSelector implements PluginTransactionSelector 
       final long gasLimit = transaction.getGasLimit();
 
       // check the upfront profitability using the gas limit of the tx
-      if (!isProfitable(
+      if (!transactionProfitabilityCalculator.isProfitable(
           "PreProcessing",
           transaction,
           minGasPrice.getAsBigInteger().doubleValue(),
@@ -85,18 +85,18 @@ public class ProfitableTransactionSelector implements PluginTransactionSelector 
         // only retry unprofitable txs if the min gas price went down
         if (minGasPriceDecreased.isTrue()) {
 
-          if (unprofitableRetries >= unprofitableRetryLimit) {
+          if (unprofitableRetries >= conf.getUnprofitableRetryLimit()) {
             log.atTrace()
                 .setMessage("Limit of unprofitable tx retries reached: {}/{}")
                 .addArgument(unprofitableRetries)
-                .addArgument(unprofitableRetryLimit);
+                .addArgument(conf.getUnprofitableRetryLimit());
             return TX_UNPROFITABLE_RETRY_LIMIT;
           }
 
           log.atTrace()
               .setMessage("Retrying unprofitable tx. Retry: {}/{}")
               .addArgument(unprofitableRetries)
-              .addArgument(unprofitableRetryLimit);
+              .addArgument(conf.getUnprofitableRetryLimit());
           unprofitableCache.remove(transaction.getHash());
           unprofitableRetries++;
 
@@ -127,7 +127,8 @@ public class ProfitableTransactionSelector implements PluginTransactionSelector 
           evaluationContext.getTransactionGasPrice().getAsBigInteger().doubleValue();
       final long gasUsed = processingResult.getEstimateGasUsedByTransaction();
 
-      if (!isProfitable("PostProcessing", transaction, minGasPrice, effectiveGasPrice, gasUsed)) {
+      if (!transactionProfitabilityCalculator.isProfitable(
+          "PostProcessing", transaction, minGasPrice, effectiveGasPrice, gasUsed)) {
         registerAsUnProfitable(transaction);
         return TX_UNPROFITABLE;
       }
@@ -152,53 +153,8 @@ public class ProfitableTransactionSelector implements PluginTransactionSelector 
     }
   }
 
-  private boolean isProfitable(
-      final String step,
-      final Transaction transaction,
-      final double minGasPrice,
-      final double effectiveGasPrice,
-      final long gas) {
-    final double revenue = effectiveGasPrice * gas;
-
-    final double l1GasPrice = minGasPrice * gasPriceRatio;
-    final int serializedSize = Math.max(0, transaction.getSize() + adjustTxSize);
-    final double verificationGasCostSlice =
-        (((double) serializedSize) / verificationCapacity) * verificationGasCost;
-    final double cost = l1GasPrice * verificationGasCostSlice;
-
-    final double margin = revenue / cost;
-
-    if (margin < minMargin) {
-      log(
-          log.atDebug(),
-          step,
-          transaction,
-          margin,
-          effectiveGasPrice,
-          gas,
-          minGasPrice,
-          l1GasPrice,
-          serializedSize,
-          adjustTxSize);
-      return false;
-    } else {
-      log(
-          log.atTrace(),
-          step,
-          transaction,
-          margin,
-          effectiveGasPrice,
-          gas,
-          minGasPrice,
-          l1GasPrice,
-          serializedSize,
-          adjustTxSize);
-      return true;
-    }
-  }
-
   private void registerAsUnProfitable(final Transaction transaction) {
-    if (unprofitableCache.size() >= unprofitableCacheSize) {
+    if (unprofitableCache.size() >= conf.getUnprofitableCacheSize()) {
       final var it = unprofitableCache.iterator();
       if (it.hasNext()) {
         it.next();
@@ -206,36 +162,5 @@ public class ProfitableTransactionSelector implements PluginTransactionSelector 
       }
     }
     unprofitableCache.add(transaction.getHash());
-  }
-
-  private void log(
-      final LoggingEventBuilder leb,
-      final String step,
-      final Transaction transaction,
-      final double margin,
-      final double effectiveGasPrice,
-      final long gasUsed,
-      final double minGasPrice,
-      final double l1GasPrice,
-      final int serializedSize,
-      final int adjustTxSize) {
-    leb.setMessage(
-            "Step {}. Transaction {} has a margin of {}, minMargin={}, verificationCapacity={}, "
-                + "verificationGasCost={}, gasPriceRatio={}, effectiveGasPrice={}, gasUsed={}, minGasPrice={}, "
-                + "l1GasPrice={}, serializedSize={}, adjustTxSize={}")
-        .addArgument(step)
-        .addArgument(transaction::getHash)
-        .addArgument(margin)
-        .addArgument(minMargin)
-        .addArgument(verificationCapacity)
-        .addArgument(verificationGasCost)
-        .addArgument(gasPriceRatio)
-        .addArgument(effectiveGasPrice)
-        .addArgument(gasUsed)
-        .addArgument(minGasPrice)
-        .addArgument(l1GasPrice)
-        .addArgument(serializedSize)
-        .addArgument(adjustTxSize)
-        .log();
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/TraceLineLimitTransactionSelector.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txselection/selectors/TraceLineLimitTransactionSelector.java
@@ -19,7 +19,6 @@ import static net.consensys.linea.sequencer.txselection.LineaTransactionSelectio
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.SELECTED;
 
 import java.util.Map;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -51,8 +50,8 @@ public class TraceLineLimitTransactionSelector implements PluginTransactionSelec
   private Map<String, Integer> currCumulatedLineCount;
 
   public TraceLineLimitTransactionSelector(
-      final Supplier<Map<String, Integer>> moduleLimitsProvider, final String limitFilePath) {
-    moduleLimits = moduleLimitsProvider.get();
+      final Map<String, Integer> moduleLimits, final String limitFilePath) {
+    this.moduleLimits = moduleLimits;
     zkTracer = new ZkTracerWithLog();
     zkTracer.traceStartConflation(1L);
     this.limitFilePath = limitFilePath;

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txvalidation/LineaTransactionValidator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txvalidation/LineaTransactionValidator.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.config.LineaTransactionValidatorConfiguration;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionValidator;

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txvalidation/LineaTransactionValidatorFactory.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txvalidation/LineaTransactionValidatorFactory.java
@@ -17,6 +17,7 @@ package net.consensys.linea.sequencer.txvalidation;
 
 import java.util.Set;
 
+import net.consensys.linea.config.LineaTransactionValidatorConfiguration;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionValidator;
 import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionValidatorFactory;
@@ -24,17 +25,18 @@ import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionValidat
 /** Represents a factory for creating transaction validators. */
 public class LineaTransactionValidatorFactory implements PluginTransactionValidatorFactory {
 
-  private final LineaTransactionValidatorCliOptions options;
+  private final LineaTransactionValidatorConfiguration transactionValidatorConfiguration;
   private final Set<Address> denied;
 
   public LineaTransactionValidatorFactory(
-      final LineaTransactionValidatorCliOptions options, final Set<Address> denied) {
-    this.options = options;
+      final LineaTransactionValidatorConfiguration transactionValidatorConfiguration,
+      final Set<Address> denied) {
+    this.transactionValidatorConfiguration = transactionValidatorConfiguration;
     this.denied = denied;
   }
 
   @Override
   public PluginTransactionValidator create() {
-    return new LineaTransactionValidator(options.toDomainObject(), denied);
+    return new LineaTransactionValidator(transactionValidatorConfiguration, denied);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txvalidation/LineaTransactionValidatorPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txvalidation/LineaTransactionValidatorPlugin.java
@@ -15,8 +15,9 @@
 
 package net.consensys.linea.sequencer.txvalidation;
 
+import java.io.File;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -62,8 +63,9 @@ public class LineaTransactionValidatorPlugin extends AbstractLineaRequiredPlugin
 
   @Override
   public void beforeExternalServices() {
+    super.beforeExternalServices();
     try (Stream<String> lines =
-        Files.lines(Paths.get(transactionValidatorConfiguration.denyListPath()))) {
+        Files.lines(Path.of(new File(transactionValidatorConfiguration.denyListPath()).toURI()))) {
       final Set<Address> denied =
           lines.map(l -> Address.fromHexString(l.trim())).collect(Collectors.toUnmodifiableSet());
       createAndRegister(transactionValidatorService, transactionValidatorConfiguration, denied);

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txvalidation/LineaTransactionValidatorPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txvalidation/LineaTransactionValidatorPlugin.java
@@ -17,18 +17,18 @@ package net.consensys.linea.sequencer.txvalidation;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.auto.service.AutoService;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.AbstractLineaRequiredPlugin;
+import net.consensys.linea.config.LineaTransactionValidatorConfiguration;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
-import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 import org.hyperledger.besu.plugin.services.PluginTransactionValidatorService;
 
 /**
@@ -41,12 +41,7 @@ import org.hyperledger.besu.plugin.services.PluginTransactionValidatorService;
 @AutoService(BesuPlugin.class)
 public class LineaTransactionValidatorPlugin extends AbstractLineaRequiredPlugin {
   public static final String NAME = "linea";
-  private final LineaTransactionValidatorCliOptions options;
-  private final Set<Address> denied = new HashSet<>();
-
-  public LineaTransactionValidatorPlugin() {
-    options = LineaTransactionValidatorCliOptions.create();
-  }
+  private PluginTransactionValidatorService transactionValidatorService;
 
   @Override
   public Optional<String> getName() {
@@ -55,43 +50,33 @@ public class LineaTransactionValidatorPlugin extends AbstractLineaRequiredPlugin
 
   @Override
   public void doRegister(final BesuContext context) {
-    final Optional<PicoCLIOptions> cmdlineOptions = context.getService(PicoCLIOptions.class);
 
-    if (cmdlineOptions.isEmpty()) {
-      throw new IllegalStateException("Failed to obtain PicoCLI options from the BesuContext");
-    }
-
-    cmdlineOptions.get().addPicoCLIOptions(NAME, options);
-
-    Optional<PluginTransactionValidatorService> service =
-        context.getService(PluginTransactionValidatorService.class);
-    createAndRegister(
-        service.orElseThrow(
-            () ->
-                new RuntimeException(
-                    "Failed to obtain TransactionValidationService from the BesuContext.")));
+    transactionValidatorService =
+        context
+            .getService(PluginTransactionValidatorService.class)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Failed to obtain TransactionValidationService from the BesuContext."));
   }
 
   @Override
-  public void start() {
-    final LineaTransactionValidatorConfiguration config = options.toDomainObject();
-
-    try (Stream<String> lines = Files.lines(Paths.get(config.denyListPath()))) {
-      lines.forEach(
-          l -> {
-            final Address address = Address.fromHexString(l.trim());
-            denied.add(address);
-          });
+  public void beforeExternalServices() {
+    try (Stream<String> lines =
+        Files.lines(Paths.get(transactionValidatorConfiguration.denyListPath()))) {
+      final Set<Address> denied =
+          lines.map(l -> Address.fromHexString(l.trim())).collect(Collectors.toUnmodifiableSet());
+      createAndRegister(transactionValidatorService, transactionValidatorConfiguration, denied);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-
-    log.debug("Starting {} with configuration: {}", NAME, options);
   }
 
   private void createAndRegister(
-      final PluginTransactionValidatorService transactionValidationService) {
+      final PluginTransactionValidatorService transactionValidationService,
+      final LineaTransactionValidatorConfiguration transactionValidatorConfiguration,
+      final Set<Address> denied) {
     transactionValidationService.registerTransactionValidatorFactory(
-        new LineaTransactionValidatorFactory(options, denied));
+        new LineaTransactionValidatorFactory(transactionValidatorConfiguration, denied));
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelectorTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelectorTest.java
@@ -23,6 +23,8 @@ import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.SELECT
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import net.consensys.linea.config.LineaTransactionSelectorCliOptions;
+import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.PendingTransaction;
@@ -42,7 +44,16 @@ public class ProfitableTransactionSelectorTest {
   private static final int ADJUST_TX_SIZE = -45;
   private static final int UNPROFITABLE_CACHE_SIZE = 2;
   private static final int UNPROFITABLE_RETRY_LIMIT = 1;
-
+  private final LineaTransactionSelectorConfiguration conf =
+      LineaTransactionSelectorCliOptions.create().toDomainObject().toBuilder()
+          .gasPriceRatio(GAS_PRICE_RATIO)
+          .adjustTxSize(ADJUST_TX_SIZE)
+          .minMargin(MIN_MARGIN)
+          .unprofitableCacheSize(UNPROFITABLE_CACHE_SIZE)
+          .unprofitableRetryLimit(UNPROFITABLE_RETRY_LIMIT)
+          .verificationCapacity(VERIFICATION_CAPACITY)
+          .verificationGasCost(VERIFICATION_GAS_COST)
+          .build();
   private TestableProfitableTransactionSelector transactionSelector;
 
   @BeforeEach
@@ -52,14 +63,7 @@ public class ProfitableTransactionSelectorTest {
   }
 
   private TestableProfitableTransactionSelector newSelectorForNewBlock() {
-    return new TestableProfitableTransactionSelector(
-        VERIFICATION_GAS_COST,
-        VERIFICATION_CAPACITY,
-        GAS_PRICE_RATIO,
-        MIN_MARGIN,
-        ADJUST_TX_SIZE,
-        UNPROFITABLE_CACHE_SIZE,
-        UNPROFITABLE_RETRY_LIMIT);
+    return new TestableProfitableTransactionSelector(conf);
   }
 
   @Test
@@ -423,22 +427,8 @@ public class ProfitableTransactionSelectorTest {
 
   private static class TestableProfitableTransactionSelector extends ProfitableTransactionSelector {
 
-    TestableProfitableTransactionSelector(
-        final int verificationGasCost,
-        final int verificationCapacity,
-        final int gasPriceRatio,
-        final double minMargin,
-        final int adjustTxSize,
-        final int unprofitableCacheSize,
-        final int unprofitableRetryLimit) {
-      super(
-          verificationGasCost,
-          verificationCapacity,
-          gasPriceRatio,
-          minMargin,
-          adjustTxSize,
-          unprofitableCacheSize,
-          unprofitableRetryLimit);
+    TestableProfitableTransactionSelector(final LineaTransactionSelectorConfiguration conf) {
+      super(conf);
     }
 
     boolean isUnprofitableTxCached(final Hash txHash) {

--- a/arithmetization/src/test/java/net/consensys/linea/sequencer/txvalidation/LineaTransactionValidatorTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/sequencer/txvalidation/LineaTransactionValidatorTest.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.config.LineaTransactionValidatorConfiguration;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;


### PR DESCRIPTION
Implements https://github.com/Consensys/protocol-misc/issues/867

This requires the update Linea Besu from this PR https://github.com/Consensys/linea-besu/pull/36

The estimate gas logic is taken from the standard `eth_estimateGas` method.

New options:

- `plugin-linea-estimate-gas-min-margin` implements: MINIMUM_MARGIN_ESTIMATE_GAS to recommend a specific gas price when using linea_estimateGas in the frontend nodes (Default "1.0")
- `plugin-linea-tx-compression-ratio` The ratio between tx serialized size and its compressed size (Default 5)

Some refactor of the way cli options and configuration are managed in the plugin, since now some of the options are used by multiple plugins and so that required to make them shared.
The profitability calculator has been moved to a class so it can be also shared between the new RPC endpoint and the tx selector plugin.
