### PR TITLE
Fix for NoSuchElementException when not passing the gasPrice param

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -54,6 +54,7 @@ tasks.register('acceptanceTests', Test) {
 }
 
 dependencies {
+  testImplementation project(":arithmetization")
   testImplementation "${besuArtifactGroup}.internal:dsl:$besuVersion"
   testImplementation "${besuArtifactGroup}:besu-datatypes:$besuVersion"
   testImplementation "${besuArtifactGroup}.internal:eth:$besuVersion"

--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
@@ -22,6 +22,13 @@ import java.util.List;
 
 import linea.plugin.acc.test.LineaPluginTestBase;
 import linea.plugin.acc.test.TestCommandLineOptionsBuilder;
+import net.consensys.linea.bl.TransactionProfitabilityCalculator;
+import net.consensys.linea.config.LineaTransactionSelectorCliOptions;
+import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
+import net.consensys.linea.rpc.linea.LineaEstimateGas;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt64;
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.NodeRequests;
@@ -35,8 +42,10 @@ public class EstimateGasTest extends LineaPluginTestBase {
   private static final int VERIFICATION_CAPACITY = 90_000;
   private static final int GAS_PRICE_RATIO = 15;
   private static final double MIN_MARGIN = 1.0;
+  private static final double ESTIMATE_GAS_MIN_MARGIN = 1.0;
   private static final Wei MIN_GAS_PRICE = Wei.of(1_000_000_000);
   public static final int MAX_TRANSACTION_GAS_LIMIT = 30_000_000;
+  private LineaTransactionSelectorConfiguration txSelectorConf;
 
   @Override
   public List<String> getTestCliOptions() {
@@ -45,6 +54,7 @@ public class EstimateGasTest extends LineaPluginTestBase {
         .set("--plugin-linea-verification-capacity=", String.valueOf(VERIFICATION_CAPACITY))
         .set("--plugin-linea-gas-price-ratio=", String.valueOf(GAS_PRICE_RATIO))
         .set("--plugin-linea-min-margin=", String.valueOf(MIN_MARGIN))
+        .set("--plugin-linea-estimate-gas-min-margin=", String.valueOf(ESTIMATE_GAS_MIN_MARGIN))
         .set("--plugin-linea-max-tx-gas-limit=", String.valueOf(MAX_TRANSACTION_GAS_LIMIT))
         .build();
   }
@@ -54,31 +64,79 @@ public class EstimateGasTest extends LineaPluginTestBase {
     minerNode.getMiningParameters().setMinTransactionGasPrice(MIN_GAS_PRICE);
   }
 
+  @BeforeEach
+  public void createDefaultConfigurations() {
+    txSelectorConf =
+        LineaTransactionSelectorCliOptions.create().toDomainObject().toBuilder()
+            .verificationCapacity(VERIFICATION_CAPACITY)
+            .verificationGasCost(VERIFICATION_GAS_COST)
+            .gasPriceRatio(GAS_PRICE_RATIO)
+            .minMargin(MIN_MARGIN)
+            .estimateGasMinMargin(ESTIMATE_GAS_MIN_MARGIN)
+            .build();
+  }
+
   @Test
-  public void estimateGas() {
+  public void lineaEstimateGasMatchesEthEstimateGas() {
 
     final Account sender = accounts.getSecondaryBenefactor();
-    final Account recipient = accounts.createAccount("recipient");
-    final org.web3j.protocol.core.methods.request.Transaction txTransfer =
-        org.web3j.protocol.core.methods.request.Transaction.createEtherTransaction(
-            sender.getAddress(),
-            BigInteger.ZERO,
-            BigInteger.valueOf(1_000_000_000),
-            BigInteger.TEN,
-            recipient.getAddress(),
-            BigInteger.ONE);
 
-    final var req = new LineaEstimateGasRequest(txTransfer);
-    final var resp = req.execute(minerNode.nodeRequests());
-    assertThat(resp.gasLimit()).isEqualTo("0x5208");
+    final CallParams callParams = new CallParams(sender.getAddress(), null);
+
+    final var reqEth = new RawEstimateGasRequest(callParams);
+    final var reqLinea = new LineaEstimateGasRequest(callParams);
+    final var respEth = reqEth.execute(minerNode.nodeRequests());
+    final var respLinea = reqLinea.execute(minerNode.nodeRequests());
+    assertThat(respEth).isEqualTo(respLinea.gasLimit());
+  }
+
+  @Test
+  public void lineaEstimateGasIsProfitable() {
+
+    final Account sender = accounts.getSecondaryBenefactor();
+
+    final CallParams callParams = new CallParams(sender.getAddress(), null);
+
+    final var reqLinea = new LineaEstimateGasRequest(callParams);
+    final var respLinea = reqLinea.execute(minerNode.nodeRequests());
+
+    final var gasLimit = UInt64.fromHexString(respLinea.gasLimit()).toLong();
+    final var baseFee = Wei.fromHexString(respLinea.baseFeePerGas());
+    final var priorityFee = Wei.fromHexString(respLinea.priorityFeePerGas());
+    final var maxGasPrice = baseFee.add(priorityFee);
+
+    final var tx =
+        org.hyperledger.besu.ethereum.core.Transaction.builder()
+            .sender(Address.fromHexString(sender.getAddress()))
+            .gasLimit(gasLimit)
+            .maxFeePerGas(maxGasPrice)
+            .maxPriorityFeePerGas(priorityFee)
+            .chainId(BigInteger.valueOf(CHAIN_ID))
+            .value(Wei.ZERO)
+            .payload(Bytes.EMPTY)
+            .signature(LineaEstimateGas.FAKE_SIGNATURE_FOR_SIZE_CALCULATION)
+            .build();
+
+    final var profitabilityCalculator = new TransactionProfitabilityCalculator(txSelectorConf);
+    assertThat(
+            profitabilityCalculator.isProfitable(
+                "Test",
+                tx,
+                minerNode
+                    .getMiningParameters()
+                    .getMinTransactionGasPrice()
+                    .getAsBigInteger()
+                    .doubleValue(),
+                maxGasPrice.getAsBigInteger().doubleValue(),
+                gasLimit))
+        .isTrue();
   }
 
   class LineaEstimateGasRequest implements Transaction<LineaEstimateGasRequest.Response> {
-    private final org.web3j.protocol.core.methods.request.Transaction transaction;
+    private final CallParams callParams;
 
-    public LineaEstimateGasRequest(
-        final org.web3j.protocol.core.methods.request.Transaction transaction) {
-      this.transaction = transaction;
+    public LineaEstimateGasRequest(final CallParams callParams) {
+      this.callParams = callParams;
     }
 
     @Override
@@ -86,7 +144,7 @@ public class EstimateGasTest extends LineaPluginTestBase {
       try {
         return new Request<>(
                 "linea_estimateGas",
-                List.of(transaction),
+                List.of(callParams),
                 nodeRequests.getWeb3jService(),
                 LineaEstimateGasResponse.class)
             .send()
@@ -100,4 +158,31 @@ public class EstimateGasTest extends LineaPluginTestBase {
 
     record Response(String gasLimit, String baseFeePerGas, String priorityFeePerGas) {}
   }
+
+  class RawEstimateGasRequest implements Transaction<String> {
+    private final CallParams callParams;
+
+    public RawEstimateGasRequest(final CallParams callParams) {
+      this.callParams = callParams;
+    }
+
+    @Override
+    public String execute(final NodeRequests nodeRequests) {
+      try {
+        return new Request<>(
+                "eth_estimateGas",
+                List.of(callParams),
+                nodeRequests.getWeb3jService(),
+                RawEstimateGasResponse.class)
+            .send()
+            .getResult();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    static class RawEstimateGasResponse extends org.web3j.protocol.core.Response<String> {}
+  }
+
+  record CallParams(String from, String value) {}
 }

--- a/arithmetization/src/main/java/net/consensys/linea/AbstractLineaSharedOptionsPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/AbstractLineaSharedOptionsPlugin.java
@@ -78,5 +78,7 @@ public abstract class AbstractLineaSharedOptionsPlugin implements BesuPlugin {
   public void start() {}
 
   @Override
-  public void stop() {}
+  public void stop() {
+    cliOptionsRegistered = false;
+  }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaTransactionValidatorConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaTransactionValidatorConfiguration.java
@@ -15,6 +15,8 @@
 
 package net.consensys.linea.config;
 
+import lombok.Builder;
+
 /**
  * The Linea configuration.
  *
@@ -22,5 +24,6 @@ package net.consensys.linea.config;
  * @param maxTxGasLimit the maximum gas limit allowed for transactions
  * @param maxTxCalldataSize the maximum size of calldata allowed for transactions
  */
+@Builder(toBuilder = true)
 public record LineaTransactionValidatorConfiguration(
     String denyListPath, int maxTxGasLimit, int maxTxCalldataSize) {}

--- a/gradle/dist.gradle
+++ b/gradle/dist.gradle
@@ -49,7 +49,10 @@ jar {
     )
   }
 
-  from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+  from {
+    configurations.runtimeClasspath.filter( {! (it.name =~ /log4j.*\.jar/ )} )
+            .collect {it.isDirectory() ? it : zipTree(it) }
+  }
   exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
   duplicatesStrategy(DuplicatesStrategy.INCLUDE)
 }


### PR DESCRIPTION
Fixes https://github.com/Consensys/zkevm-monorepo/issues/2420

now it is the same of the standard eth_estimateGas and you can just pass from, the problem was in the tx size calculation where some fields were null, and I just set them to default values when not present