### PR TITLE
Avoid returing an estimated priority fee that is less than the min gas price

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
+++ b/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
@@ -117,8 +117,23 @@ public class LineaEstimateGas {
             .getNextBlockBaseFee()
             .orElseThrow(() -> new IllegalStateException("Not on a baseFee market"));
 
+    final Wei priorityFeeLowerBound = minGasPrice.subtract(baseFee);
+    final Wei boundedEstimatedPriorityFee;
+    if (estimatedPriorityFee.lessThan(priorityFeeLowerBound)) {
+      boundedEstimatedPriorityFee = priorityFeeLowerBound;
+      log.atDebug()
+          .setMessage(
+              "Estimated priority fee {} is lower that the lower bound {}, returning the latter")
+          .addArgument(estimatedPriorityFee::toHumanReadableString)
+          .addArgument(boundedEstimatedPriorityFee::toHumanReadableString)
+          .log();
+    } else {
+      boundedEstimatedPriorityFee = estimatedPriorityFee;
+    }
+
     final var response =
-        new Response(create(estimatedGasUsed), create(baseFee), create(estimatedPriorityFee));
+        new Response(
+            create(estimatedGasUsed), create(baseFee), create(boundedEstimatedPriorityFee));
     log.debug("Response for call params {} is {}", callParameters, response);
 
     return response;


### PR DESCRIPTION
This is a safe net to avoid that the estimated priority fee + base fee returned can be less than the current min gas price