### PR TITLE
fix: do not prune failing transactions from the replays

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/blockcapture/reapers/AddressReaper.java
+++ b/arithmetization/src/main/java/net/consensys/linea/blockcapture/reapers/AddressReaper.java
@@ -15,39 +15,20 @@
 
 package net.consensys.linea.blockcapture.reapers;
 
-import java.util.ArrayDeque;
-import java.util.Collection;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.hyperledger.besu.datatypes.Address;
 
 public class AddressReaper {
-  private final ArrayDeque<Set<Address>> reaped = new ArrayDeque<>();
-
-  public AddressReaper() {
-    // “Bedrock” address set for block-level gathering.
-    this.reaped.addLast(new HashSet<>());
-  }
-
-  public void enterTransaction() {
-    this.reaped.addLast(new HashSet<>());
-  }
-
-  public void exitTransaction(boolean success) {
-    if (!success) {
-      this.reaped.removeLast();
-    }
-  }
+  private final Set<Address> reaped = new HashSet<>();
 
   public void touch(final Address... addresses) {
-    for (Address address : addresses) {
-      this.reaped.peekLast().add(address);
-    }
+    this.reaped.addAll(Arrays.asList(addresses));
   }
 
   public Set<Address> collapse() {
-    return this.reaped.stream().flatMap(Collection::stream).collect(Collectors.toSet());
+    return this.reaped;
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/blockcapture/reapers/Reaper.java
+++ b/arithmetization/src/main/java/net/consensys/linea/blockcapture/reapers/Reaper.java
@@ -53,17 +53,11 @@ public class Reaper {
   }
 
   public void enterTransaction(Transaction tx) {
-    this.storage.enterTransaction();
-    this.addresses.enterTransaction();
-
     this.touchAddress(tx.getSender());
     tx.getTo().ifPresent(this::touchAddress);
   }
 
-  public void exitTransaction(boolean success) {
-    this.storage.exitTransaction(success);
-    this.addresses.exitTransaction(success);
-  }
+  public void exitTransaction(boolean success) {}
 
   public void touchAddress(final Address address) {
     this.addresses.touch(address);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -58,7 +58,7 @@ public class ZkTracer implements ConflationAwareOperationTracer {
 
   public static final FeeMarket feeMarket = FeeMarket.london(-1);
 
-  @Getter private final Hub hub = new Hub();
+  @Getter private final Hub hub;
   private final Optional<Pin55> pin55;
   private final Map<String, Integer> spillings = new HashMap<>();
   private Hash hashOfLastTransactionTraced = Hash.EMPTY;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -329,7 +329,7 @@ public class Hub implements Module {
                 this.trm,
                 this.txnData,
                 this.wcp,
-              this.l2Block),
+                this.l2Block),
             this.precompileLimitModules.stream())
         .toList();
   }


### PR DESCRIPTION
Dropping failing transactions initial state is plain stupid, as they will fail **due to** their initial state.