### PR TITLE
fix: gather & re-throw tracing exceptions

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -543,8 +543,10 @@ public class Hub implements Module {
   }
 
   void triggerModules(MessageFrame frame) {
-    for (Module precompileLimit : this.precompileLimitModules) {
-      precompileLimit.tracePreOpcode(frame);
+    if (!this.pch.exceptions().stackException()) {
+      for (Module precompileLimit : this.precompileLimitModules) {
+        precompileLimit.tracePreOpcode(frame);
+      }
     }
 
     if (this.pch.signals().romLex()) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -543,7 +543,7 @@ public class Hub implements Module {
   }
 
   void triggerModules(MessageFrame frame) {
-    if (!this.pch.exceptions().stackException()) {
+    if (this.pch.exceptions().none() && this.pch.aborts().none()) {
       for (Module precompileLimit : this.precompileLimitModules) {
         precompileLimit.tracePreOpcode(frame);
       }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/types/MemorySpan.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/types/MemorySpan.java
@@ -61,4 +61,13 @@ public record MemorySpan(long offset, long length) {
   public long absolute() {
     return this.offset;
   }
+
+  public boolean besuOverflow() {
+    return this.offset >= Integer.MAX_VALUE || this.length >= Integer.MAX_VALUE;
+  }
+
+  @Override
+  public String toString() {
+    return "[%d ..+ %d]".formatted(offset, length);
+  }
 }


### PR DESCRIPTION
Fixes #533 

### Before
```
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "tracesEngineVersion": "0.1.4-SNAPSHOT",
    "blockNumber": 296518,
    "tracesCounters": {
      "EXT": 8,
      [...] // many erroneous counters
    }
  }
}
// HTTP/1.1 200 OK
// Content-Type: application/json
```

### After
```
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32603,
    "message": "Plugin internal error",
    "data": "Exceptions triggered while tracing: <exception messages here>"
  }
}
// HTTP/1.1 200 OK
// Content-Type: application/json
```