### PR TITLE
Build native lib on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,14 @@ an [existing implementation in Go](https://github.com/Consensys/zk-evm/).
 brew install openjdk@17
 ```
 
-### Install the relevant CGo compiler for your platform
+### Native Lib Prerequisites
 
-### Install the Go toolchain
+Linux/MacOs
+* Install the relevant CGo compiler for your platform
+* Install the Go toolchain
+
+Windows
+* Requirement [Docker Desktop WSL 2 backend on Windows](https://docs.docker.com/desktop/wsl/)
 
 ### Install Rust
 

--- a/native/Dockerfile-win-dockcross
+++ b/native/Dockerfile-win-dockcross
@@ -1,0 +1,18 @@
+FROM dockcross/windows-shared-x64
+
+ARG GO_VERSION=1.22.1
+ARG GO_ARCHIVE_CHECKSUM=aab8e15785c997ae20f9c88422ee35d962c4562212bb0f879d052a35c8307c7f
+
+ENV DEFAULT_DOCKCROSS_IMAGE native-windows-cross-compile
+
+RUN wget https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz
+RUN echo "$GO_ARCHIVE_CHECKSUM go$GO_VERSION.linux-amd64.tar.gz" | sha256sum --check --status
+RUN tar -C /usr/local -xzf go$GO_VERSION.linux-amd64.tar.gz
+
+ENV PATH="$PATH:/usr/local/go/bin"
+
+# pre-fetch go modules
+COPY compress/compress-jni/go.mod .
+COPY compress/compress-jni/go.sum .
+RUN go mod download
+RUN rm go.mod go.sum

--- a/native/compress/build.gradle
+++ b/native/compress/build.gradle
@@ -33,8 +33,13 @@ test {
 }
 
 tasks.register('buildJNI', Exec) {
-  workingDir buildscript.sourceFile.parentFile
-  commandLine 'sh', '-c', '../build.sh'
+  if(org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+    workingDir buildscript.sourceFile.parentFile.parentFile
+    commandLine 'wsl', './wsl.sh'
+  } else {
+    workingDir buildscript.sourceFile.parentFile
+    commandLine 'sh', '-c', '../build.sh'
+  }
 }
 
 compileJava{
@@ -75,6 +80,12 @@ tasks.register('linuxArm64LibCopy', Copy) {
   into 'build/resources/main/linux-aarch64'
 }
 processResources.dependsOn linuxArm64LibCopy
+
+tasks.register('windowsLibCopy', Copy) {
+  from 'build/native/compress_jni.dll'
+  into 'build/resources/main/win32-x86-64'
+}
+processResources.dependsOn windowsLibCopy
 
 jar {
   archiveBaseName = 'linea-native-compress'

--- a/native/wsl.sh
+++ b/native/wsl.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+docker build -f Dockerfile-win-dockcross -t native-windows-cross-compile .
+
+docker run --rm native-windows-cross-compile > compress/build/native/native-windows-cross-compile
+
+compress/build/native/native-windows-cross-compile \
+  bash -c "cd compress/compress-jni &&
+    CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -buildmode=c-shared -o ../build/native/compress_jni.dll compress-jni.go"
+


### PR DESCRIPTION
Native lib for Windows are built using WSL2 and Docker cross compile images