### PR TITLE
linea_estimateGas compatibility mode multiplier

### DIFF
--- a/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasCompatibilityModeTest.java
+++ b/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasCompatibilityModeTest.java
@@ -16,30 +16,52 @@ package linea.plugin.acc.test.rpc.linea;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
 
 public class EstimateGasCompatibilityModeTest extends EstimateGasTest {
+  private static final BigDecimal PRICE_MULTIPLIER = BigDecimal.valueOf(1.2);
 
   @Override
   public List<String> getTestCliOptions() {
     return getTestCommandLineOptionsBuilder()
         .set("--plugin-linea-estimate-gas-compatibility-mode-enabled=", "true")
+        .set(
+            "--plugin-linea-estimate-gas-compatibility-mode-multiplier=",
+            PRICE_MULTIPLIER.toPlainString())
         .build();
   }
 
   @Override
   protected void assertIsProfitable(
       final Transaction tx,
+      final Wei baseFee,
       final Wei estimatedPriorityFee,
       final Wei estimatedMaxGasPrice,
       final long estimatedGasLimit) {
     final var minGasPrice = minerNode.getMiningParameters().getMinTransactionGasPrice();
+    final var minPriorityFee = minGasPrice.subtract(baseFee);
+    final var compatibilityMinPriorityFee =
+        Wei.of(
+            PRICE_MULTIPLIER
+                .multiply(new BigDecimal(minPriorityFee.getAsBigInteger()))
+                .setScale(0, RoundingMode.CEILING)
+                .toBigInteger());
 
     // since we are in compatibility mode, we want to check that returned profitable priority fee is
-    // the min mineable gas price
-    assertThat(estimatedMaxGasPrice).isEqualTo(minGasPrice);
+    // the min priority fee per gas * multiplier + base fee
+    final var expectedMaxGasPrice = baseFee.add(compatibilityMinPriorityFee);
+    assertThat(estimatedMaxGasPrice).isEqualTo(expectedMaxGasPrice);
+  }
+
+  @Override
+  protected void assertMinGasPriceLowerBound(final Wei baseFee, final Wei estimatedMaxGasPrice) {
+    // since we are in compatibility mode, we want to check that returned profitable priority fee is
+    // the min priority fee per gas * multiplier + base fee
+    assertIsProfitable(null, baseFee, null, estimatedMaxGasPrice, 0);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaRpcCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaRpcCliOptions.java
@@ -15,6 +15,8 @@
 
 package net.consensys.linea.config;
 
+import java.math.BigDecimal;
+
 import com.google.common.base.MoreObjects;
 import picocli.CommandLine;
 
@@ -22,13 +24,27 @@ import picocli.CommandLine;
 public class LineaRpcCliOptions {
   private static final String ESTIMATE_GAS_COMPATIBILITY_MODE_ENABLED =
       "--plugin-linea-estimate-gas-compatibility-mode-enabled";
+  private static final boolean DEFAULT_ESTIMATE_GAS_COMPATIBILITY_MODE_ENABLED = false;
+  private static final String ESTIMATE_GAS_COMPATIBILITY_MODE_MULTIPLIER =
+      "--plugin-linea-estimate-gas-compatibility-mode-multiplier";
+  private static final BigDecimal DEFAULT_ESTIMATE_GAS_COMPATIBILITY_MODE_MULTIPLIER =
+      BigDecimal.valueOf(1.2);
 
   @CommandLine.Option(
       names = {ESTIMATE_GAS_COMPATIBILITY_MODE_ENABLED},
       paramLabel = "<BOOLEAN>",
       description =
-          "Set to true to return the min mineable gas price, instead of the profitable price (default: ${DEFAULT-VALUE})")
-  private boolean estimateGasCompatibilityModeEnabled = false;
+          "Set to true to return the min mineable gas price * multiplier, instead of the profitable price (default: ${DEFAULT-VALUE})")
+  private boolean estimateGasCompatibilityModeEnabled =
+      DEFAULT_ESTIMATE_GAS_COMPATIBILITY_MODE_ENABLED;
+
+  @CommandLine.Option(
+      names = {ESTIMATE_GAS_COMPATIBILITY_MODE_MULTIPLIER},
+      paramLabel = "<FLOAT>",
+      description =
+          "Set to multiplier to apply to the min priority fee per gas when the compatibility mode is enabled (default: ${DEFAULT-VALUE})")
+  private BigDecimal estimateGasCompatibilityMultiplier =
+      DEFAULT_ESTIMATE_GAS_COMPATIBILITY_MODE_MULTIPLIER;
 
   private LineaRpcCliOptions() {}
 
@@ -50,6 +66,7 @@ public class LineaRpcCliOptions {
   public static LineaRpcCliOptions fromConfig(final LineaRpcConfiguration config) {
     final LineaRpcCliOptions options = create();
     options.estimateGasCompatibilityModeEnabled = config.estimateGasCompatibilityModeEnabled();
+    options.estimateGasCompatibilityMultiplier = config.estimateGasCompatibilityMultiplier();
     return options;
   }
 
@@ -61,6 +78,7 @@ public class LineaRpcCliOptions {
   public LineaRpcConfiguration toDomainObject() {
     return LineaRpcConfiguration.builder()
         .estimateGasCompatibilityModeEnabled(estimateGasCompatibilityModeEnabled)
+        .estimateGasCompatibilityMultiplier(estimateGasCompatibilityMultiplier)
         .build();
   }
 
@@ -68,6 +86,7 @@ public class LineaRpcCliOptions {
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add(ESTIMATE_GAS_COMPATIBILITY_MODE_ENABLED, estimateGasCompatibilityModeEnabled)
+        .add(ESTIMATE_GAS_COMPATIBILITY_MODE_MULTIPLIER, estimateGasCompatibilityMultiplier)
         .toString();
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaRpcConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaRpcConfiguration.java
@@ -15,8 +15,11 @@
 
 package net.consensys.linea.config;
 
+import java.math.BigDecimal;
+
 import lombok.Builder;
 
 /** The Linea RPC configuration. */
 @Builder(toBuilder = true)
-public record LineaRpcConfiguration(boolean estimateGasCompatibilityModeEnabled) {}
+public record LineaRpcConfiguration(
+    boolean estimateGasCompatibilityModeEnabled, BigDecimal estimateGasCompatibilityMultiplier) {}

--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -116,7 +116,7 @@ dependencyManagement {
 
     dependency 'com.splunk.logging:splunk-library-javalogging:1.11.5'
 
-    dependency 'io.vertx:vertx-core:4.3.8'
+    dependency 'io.vertx:vertx-core:4.5.4'
 
     dependency 'com.slack.api:slack-api-client:1.32.1'
 


### PR DESCRIPTION
Fixes https://github.com/Consensys/protocol-misc/issues/897

New option `plugin-linea-estimate-gas-compatibility-mode-multiplier` (default `1.2`) that when `plugin-linea-estimate-gas-compatibility-mode-enabled=true` multiply the minPriorityFeePerGas by that value before it is returned
