### PR TITLE
Rename to TransactionPoolValidator to make it clear it only apply to the txpool

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/AbstractLineaSharedOptionsPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/AbstractLineaSharedOptionsPlugin.java
@@ -23,10 +23,10 @@ import net.consensys.linea.config.LineaProfitabilityCliOptions;
 import net.consensys.linea.config.LineaProfitabilityConfiguration;
 import net.consensys.linea.config.LineaRpcCliOptions;
 import net.consensys.linea.config.LineaRpcConfiguration;
+import net.consensys.linea.config.LineaTransactionPoolValidatorCliOptions;
+import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
 import net.consensys.linea.config.LineaTransactionSelectorCliOptions;
 import net.consensys.linea.config.LineaTransactionSelectorConfiguration;
-import net.consensys.linea.config.LineaTransactionValidatorCliOptions;
-import net.consensys.linea.config.LineaTransactionValidatorConfiguration;
 import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.services.PicoCLIOptions;
@@ -37,12 +37,12 @@ public abstract class AbstractLineaSharedOptionsPlugin implements BesuPlugin {
   private static boolean cliOptionsRegistered = false;
   private static boolean configured = false;
   private static LineaTransactionSelectorCliOptions transactionSelectorCliOptions;
-  private static LineaTransactionValidatorCliOptions transactionValidatorCliOptions;
+  private static LineaTransactionPoolValidatorCliOptions transactionPoolValidatorCliOptions;
   private static LineaL1L2BridgeCliOptions l1L2BridgeCliOptions;
   private static LineaRpcCliOptions rpcCliOptions;
   private static LineaProfitabilityCliOptions profitabilityCliOptions;
   protected static LineaTransactionSelectorConfiguration transactionSelectorConfiguration;
-  protected static LineaTransactionValidatorConfiguration transactionValidatorConfiguration;
+  protected static LineaTransactionPoolValidatorConfiguration transactionPoolValidatorConfiguration;
   protected static LineaL1L2BridgeConfiguration l1L2BridgeConfiguration;
   protected static LineaRpcConfiguration rpcConfiguration;
   protected static LineaProfitabilityConfiguration profitabilityConfiguration;
@@ -63,13 +63,13 @@ public abstract class AbstractLineaSharedOptionsPlugin implements BesuPlugin {
                       new IllegalStateException(
                           "Failed to obtain PicoCLI options from the BesuContext"));
       transactionSelectorCliOptions = LineaTransactionSelectorCliOptions.create();
-      transactionValidatorCliOptions = LineaTransactionValidatorCliOptions.create();
+      transactionPoolValidatorCliOptions = LineaTransactionPoolValidatorCliOptions.create();
       l1L2BridgeCliOptions = LineaL1L2BridgeCliOptions.create();
       rpcCliOptions = LineaRpcCliOptions.create();
       profitabilityCliOptions = LineaProfitabilityCliOptions.create();
 
       cmdlineOptions.addPicoCLIOptions(CLI_OPTIONS_PREFIX, transactionSelectorCliOptions);
-      cmdlineOptions.addPicoCLIOptions(CLI_OPTIONS_PREFIX, transactionValidatorCliOptions);
+      cmdlineOptions.addPicoCLIOptions(CLI_OPTIONS_PREFIX, transactionPoolValidatorCliOptions);
       cmdlineOptions.addPicoCLIOptions(CLI_OPTIONS_PREFIX, l1L2BridgeCliOptions);
       cmdlineOptions.addPicoCLIOptions(CLI_OPTIONS_PREFIX, rpcCliOptions);
       cmdlineOptions.addPicoCLIOptions(CLI_OPTIONS_PREFIX, profitabilityCliOptions);
@@ -81,7 +81,7 @@ public abstract class AbstractLineaSharedOptionsPlugin implements BesuPlugin {
   public void beforeExternalServices() {
     if (!configured) {
       transactionSelectorConfiguration = transactionSelectorCliOptions.toDomainObject();
-      transactionValidatorConfiguration = transactionValidatorCliOptions.toDomainObject();
+      transactionPoolValidatorConfiguration = transactionPoolValidatorCliOptions.toDomainObject();
       l1L2BridgeConfiguration = l1L2BridgeCliOptions.toDomainObject();
       rpcConfiguration = rpcCliOptions.toDomainObject();
       profitabilityConfiguration = profitabilityCliOptions.toDomainObject();
@@ -94,9 +94,9 @@ public abstract class AbstractLineaSharedOptionsPlugin implements BesuPlugin {
         transactionSelectorCliOptions);
 
     log.debug(
-        "Configured plugin {} with transaction validator configuration: {}",
+        "Configured plugin {} with transaction pool validator configuration: {}",
         getName(),
-        transactionValidatorCliOptions);
+        transactionPoolValidatorCliOptions);
 
     log.debug(
         "Configured plugin {} with L1 L2 bridge configuration: {}",

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaTransactionPoolValidatorCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaTransactionPoolValidatorCliOptions.java
@@ -19,7 +19,7 @@ import com.google.common.base.MoreObjects;
 import picocli.CommandLine;
 
 /** The Linea CLI options. */
-public class LineaTransactionValidatorCliOptions {
+public class LineaTransactionPoolValidatorCliOptions {
 
   public static final String DENY_LIST_PATH = "--plugin-linea-deny-list-path";
   public static final String DEFAULT_DENY_LIST_PATH = "lineaDenyList.txt";
@@ -58,15 +58,15 @@ public class LineaTransactionValidatorCliOptions {
               + ")")
   private int maxTxCallDataSize = DEFAULT_MAX_TX_CALLDATA_SIZE;
 
-  private LineaTransactionValidatorCliOptions() {}
+  private LineaTransactionPoolValidatorCliOptions() {}
 
   /**
    * Create Linea cli options.
    *
    * @return the Linea cli options
    */
-  public static LineaTransactionValidatorCliOptions create() {
-    return new LineaTransactionValidatorCliOptions();
+  public static LineaTransactionPoolValidatorCliOptions create() {
+    return new LineaTransactionPoolValidatorCliOptions();
   }
 
   /**
@@ -75,9 +75,9 @@ public class LineaTransactionValidatorCliOptions {
    * @param config the config
    * @return the cli options
    */
-  public static LineaTransactionValidatorCliOptions fromConfig(
-      final LineaTransactionValidatorConfiguration config) {
-    final LineaTransactionValidatorCliOptions options = create();
+  public static LineaTransactionPoolValidatorCliOptions fromConfig(
+      final LineaTransactionPoolValidatorConfiguration config) {
+    final LineaTransactionPoolValidatorCliOptions options = create();
     options.denyListPath = config.denyListPath();
     options.maxTxGasLimit = config.maxTxGasLimit();
     options.maxTxCallDataSize = config.maxTxCalldataSize();
@@ -90,8 +90,8 @@ public class LineaTransactionValidatorCliOptions {
    *
    * @return the Linea factory configuration
    */
-  public LineaTransactionValidatorConfiguration toDomainObject() {
-    return new LineaTransactionValidatorConfiguration(
+  public LineaTransactionPoolValidatorConfiguration toDomainObject() {
+    return new LineaTransactionPoolValidatorConfiguration(
         denyListPath, maxTxGasLimit, maxTxCallDataSize);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/config/LineaTransactionPoolValidatorConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/config/LineaTransactionPoolValidatorConfiguration.java
@@ -25,5 +25,5 @@ import lombok.Builder;
  * @param maxTxCalldataSize the maximum size of calldata allowed for transactions
  */
 @Builder(toBuilder = true)
-public record LineaTransactionValidatorConfiguration(
+public record LineaTransactionPoolValidatorConfiguration(
     String denyListPath, int maxTxGasLimit, int maxTxCalldataSize) {}

--- a/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEndpointServicePlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEndpointServicePlugin.java
@@ -87,6 +87,6 @@ public class LineaEndpointServicePlugin extends AbstractLineaRequiredPlugin {
   public void beforeExternalServices() {
     super.beforeExternalServices();
     lineaEstimateGasMethod.init(
-        rpcConfiguration, transactionValidatorConfiguration, profitabilityConfiguration);
+        rpcConfiguration, transactionPoolValidatorConfiguration, profitabilityConfiguration);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
+++ b/arithmetization/src/main/java/net/consensys/linea/rpc/linea/LineaEstimateGas.java
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.bl.TransactionProfitabilityCalculator;
 import net.consensys.linea.config.LineaProfitabilityConfiguration;
 import net.consensys.linea.config.LineaRpcConfiguration;
-import net.consensys.linea.config.LineaTransactionValidatorConfiguration;
+import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
 import org.apache.tuweni.bytes.Bytes;
 import org.bouncycastle.asn1.sec.SECNamedCurves;
 import org.bouncycastle.asn1.x9.X9ECParameters;
@@ -74,7 +74,7 @@ public class LineaEstimateGas {
   private final TransactionSimulationService transactionSimulationService;
   private final BlockchainService blockchainService;
   private LineaRpcConfiguration rpcConfiguration;
-  private LineaTransactionValidatorConfiguration txValidatorConf;
+  private LineaTransactionPoolValidatorConfiguration txValidatorConf;
   private LineaProfitabilityConfiguration profitabilityConf;
   private TransactionProfitabilityCalculator txProfitabilityCalculator;
 
@@ -89,7 +89,7 @@ public class LineaEstimateGas {
 
   public void init(
       LineaRpcConfiguration rpcConfiguration,
-      final LineaTransactionValidatorConfiguration transactionValidatorConfiguration,
+      final LineaTransactionPoolValidatorConfiguration transactionValidatorConfiguration,
       final LineaProfitabilityConfiguration profitabilityConf) {
     this.rpcConfiguration = rpcConfiguration;
     this.txValidatorConf = transactionValidatorConfiguration;

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorFactory.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorFactory.java
@@ -13,18 +13,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.sequencer.txvalidation;
+package net.consensys.linea.sequencer.txpoolvalidation;
 
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
 
 import net.consensys.linea.config.LineaProfitabilityConfiguration;
-import net.consensys.linea.config.LineaTransactionValidatorConfiguration;
-import net.consensys.linea.sequencer.txvalidation.validators.AllowedAddressValidator;
-import net.consensys.linea.sequencer.txvalidation.validators.CalldataValidator;
-import net.consensys.linea.sequencer.txvalidation.validators.GasLimitValidator;
-import net.consensys.linea.sequencer.txvalidation.validators.ProfitabilityValidator;
+import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
+import net.consensys.linea.sequencer.txpoolvalidation.validators.AllowedAddressValidator;
+import net.consensys.linea.sequencer.txpoolvalidation.validators.CalldataValidator;
+import net.consensys.linea.sequencer.txpoolvalidation.validators.GasLimitValidator;
+import net.consensys.linea.sequencer.txpoolvalidation.validators.ProfitabilityValidator;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
 import org.hyperledger.besu.plugin.services.BlockchainService;
@@ -32,23 +32,23 @@ import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolVal
 import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolValidatorFactory;
 
 /** Represents a factory for creating transaction validators. */
-public class LineaTransactionValidatorFactory implements PluginTransactionPoolValidatorFactory {
+public class LineaTransactionPoolValidatorFactory implements PluginTransactionPoolValidatorFactory {
 
   private final BesuConfiguration besuConfiguration;
   private final BlockchainService blockchainService;
-  private final LineaTransactionValidatorConfiguration txValidatorConf;
+  private final LineaTransactionPoolValidatorConfiguration txPoolValidatorConf;
   private final LineaProfitabilityConfiguration profitabilityConf;
   private final Set<Address> denied;
 
-  public LineaTransactionValidatorFactory(
+  public LineaTransactionPoolValidatorFactory(
       final BesuConfiguration besuConfiguration,
       final BlockchainService blockchainService,
-      final LineaTransactionValidatorConfiguration txValidatorConf,
+      final LineaTransactionPoolValidatorConfiguration txPoolValidatorConf,
       final LineaProfitabilityConfiguration profitabilityConf,
       final Set<Address> denied) {
     this.besuConfiguration = besuConfiguration;
     this.blockchainService = blockchainService;
-    this.txValidatorConf = txValidatorConf;
+    this.txPoolValidatorConf = txPoolValidatorConf;
     this.profitabilityConf = profitabilityConf;
     this.denied = denied;
   }
@@ -58,8 +58,8 @@ public class LineaTransactionValidatorFactory implements PluginTransactionPoolVa
     final var validators =
         new PluginTransactionPoolValidator[] {
           new AllowedAddressValidator(denied),
-          new GasLimitValidator(txValidatorConf),
-          new CalldataValidator(txValidatorConf),
+          new GasLimitValidator(txPoolValidatorConf),
+          new CalldataValidator(txPoolValidatorConf),
           new ProfitabilityValidator(besuConfiguration, blockchainService, profitabilityConf)
         };
 

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorPlugin.java
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.sequencer.txvalidation;
+package net.consensys.linea.sequencer.txpoolvalidation;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -41,11 +41,11 @@ import org.hyperledger.besu.plugin.services.TransactionPoolValidatorService;
  */
 @Slf4j
 @AutoService(BesuPlugin.class)
-public class LineaTransactionValidatorPlugin extends AbstractLineaRequiredPlugin {
+public class LineaTransactionPoolValidatorPlugin extends AbstractLineaRequiredPlugin {
   public static final String NAME = "linea";
   private BesuConfiguration besuConfiguration;
   private BlockchainService blockchainService;
-  private TransactionPoolValidatorService transactionValidatorService;
+  private TransactionPoolValidatorService transactionPoolValidatorService;
 
   @Override
   public Optional<String> getName() {
@@ -70,28 +70,29 @@ public class LineaTransactionValidatorPlugin extends AbstractLineaRequiredPlugin
                     new RuntimeException(
                         "Failed to obtain BlockchainService from the BesuContext."));
 
-    transactionValidatorService =
+    transactionPoolValidatorService =
         context
             .getService(TransactionPoolValidatorService.class)
             .orElseThrow(
                 () ->
                     new RuntimeException(
-                        "Failed to obtain TransactionValidationService from the BesuContext."));
+                        "Failed to obtain TransactionPoolValidationService from the BesuContext."));
   }
 
   @Override
   public void beforeExternalServices() {
     super.beforeExternalServices();
     try (Stream<String> lines =
-        Files.lines(Path.of(new File(transactionValidatorConfiguration.denyListPath()).toURI()))) {
+        Files.lines(
+            Path.of(new File(transactionPoolValidatorConfiguration.denyListPath()).toURI()))) {
       final Set<Address> denied =
           lines.map(l -> Address.fromHexString(l.trim())).collect(Collectors.toUnmodifiableSet());
 
-      transactionValidatorService.registerPluginTransactionValidatorFactory(
-          new LineaTransactionValidatorFactory(
+      transactionPoolValidatorService.registerPluginTransactionValidatorFactory(
+          new LineaTransactionPoolValidatorFactory(
               besuConfiguration,
               blockchainService,
-              transactionValidatorConfiguration,
+              transactionPoolValidatorConfiguration,
               profitabilityConfiguration,
               denied));
 

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/AllowedAddressValidator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/AllowedAddressValidator.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package net.consensys.linea.sequencer.txvalidation.validators;
+package net.consensys.linea.sequencer.txpoolvalidation.validators;
 
 import java.util.Optional;
 import java.util.Set;

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/CalldataValidator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/CalldataValidator.java
@@ -12,28 +12,28 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package net.consensys.linea.sequencer.txvalidation.validators;
+package net.consensys.linea.sequencer.txpoolvalidation.validators;
 
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.consensys.linea.config.LineaTransactionValidatorConfiguration;
+import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
 import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolValidator;
 
 @Slf4j
 @RequiredArgsConstructor
 public class CalldataValidator implements PluginTransactionPoolValidator {
-  final LineaTransactionValidatorConfiguration txValidatorConf;
+  final LineaTransactionPoolValidatorConfiguration txPoolValidatorConf;
 
   @Override
   public Optional<String> validateTransaction(
       final Transaction transaction, final boolean isLocal, final boolean hasPriority) {
-    if (transaction.getPayload().size() > txValidatorConf.maxTxCalldataSize()) {
+    if (transaction.getPayload().size() > txPoolValidatorConf.maxTxCalldataSize()) {
       final String errMsg =
           "Calldata of transaction is greater than the allowed max of "
-              + txValidatorConf.maxTxCalldataSize();
+              + txPoolValidatorConf.maxTxCalldataSize();
       log.debug(errMsg);
       return Optional.of(errMsg);
     }

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidator.java
@@ -12,28 +12,28 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package net.consensys.linea.sequencer.txvalidation.validators;
+package net.consensys.linea.sequencer.txpoolvalidation.validators;
 
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.consensys.linea.config.LineaTransactionValidatorConfiguration;
+import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
 import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolValidator;
 
 @Slf4j
 @RequiredArgsConstructor
 public class GasLimitValidator implements PluginTransactionPoolValidator {
-  final LineaTransactionValidatorConfiguration txValidatorConf;
+  final LineaTransactionPoolValidatorConfiguration txPoolValidatorConf;
 
   @Override
   public Optional<String> validateTransaction(
       final Transaction transaction, final boolean isLocal, final boolean hasPriority) {
-    if (transaction.getGasLimit() > txValidatorConf.maxTxGasLimit()) {
+    if (transaction.getGasLimit() > txPoolValidatorConf.maxTxGasLimit()) {
       final String errMsg =
           "Gas limit of transaction is greater than the allowed max of "
-              + txValidatorConf.maxTxGasLimit();
+              + txPoolValidatorConf.maxTxGasLimit();
       log.debug(errMsg);
       return Optional.of(errMsg);
     }

--- a/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidator.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package net.consensys.linea.sequencer.txvalidation.validators;
+package net.consensys.linea.sequencer.txpoolvalidation.validators;
 
 import java.util.Optional;
 

--- a/arithmetization/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/AllowedAddressValidatorTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/AllowedAddressValidatorTest.java
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.sequencer.txvalidation.validators;
+package net.consensys.linea.sequencer.txpoolvalidation.validators;
 
 import java.util.Optional;
 import java.util.Set;

--- a/arithmetization/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/CalldataValidatorTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/CalldataValidatorTest.java
@@ -13,13 +13,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.sequencer.txvalidation.validators;
+package net.consensys.linea.sequencer.txpoolvalidation.validators;
 
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.consensys.linea.config.LineaTransactionValidatorCliOptions;
+import net.consensys.linea.config.LineaTransactionPoolValidatorCliOptions;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
 import org.junit.jupiter.api.Assertions;
@@ -28,37 +28,37 @@ import org.junit.jupiter.api.Test;
 
 @Slf4j
 @RequiredArgsConstructor
-public class GasLimitValidatorTest {
-  public static final int MAX_TX_GAS_LIMIT = 9_000_000;
-  private GasLimitValidator gasLimitValidator;
+public class CalldataValidatorTest {
+  public static final int MAX_TX_CALLDATA_SIZE = 10_000;
+  private CalldataValidator calldataValidator;
 
   @BeforeEach
   public void initialize() {
-    gasLimitValidator =
-        new GasLimitValidator(
-            LineaTransactionValidatorCliOptions.create().toDomainObject().toBuilder()
-                .maxTxGasLimit(MAX_TX_GAS_LIMIT)
+    calldataValidator =
+        new CalldataValidator(
+            LineaTransactionPoolValidatorCliOptions.create().toDomainObject().toBuilder()
+                .maxTxCalldataSize(MAX_TX_CALLDATA_SIZE)
                 .build());
   }
 
   @Test
-  public void validatedWithValidGasLimit() {
+  public void validatedWithValidCalldata() {
     final org.hyperledger.besu.ethereum.core.Transaction.Builder builder =
         org.hyperledger.besu.ethereum.core.Transaction.builder();
     final org.hyperledger.besu.ethereum.core.Transaction transaction =
-        builder.gasLimit(MAX_TX_GAS_LIMIT).gasPrice(Wei.ZERO).payload(Bytes.EMPTY).build();
+        builder.gasPrice(Wei.ZERO).payload(Bytes.random(MAX_TX_CALLDATA_SIZE)).build();
     Assertions.assertEquals(
-        gasLimitValidator.validateTransaction(transaction, false, false), Optional.empty());
+        calldataValidator.validateTransaction(transaction, false, false), Optional.empty());
   }
 
   @Test
-  public void rejectedWithMaxGasLimitPlusOne() {
+  public void rejectedWithTooBigCalldata() {
     final org.hyperledger.besu.ethereum.core.Transaction.Builder builder =
         org.hyperledger.besu.ethereum.core.Transaction.builder();
     final org.hyperledger.besu.ethereum.core.Transaction transaction =
-        builder.gasLimit(MAX_TX_GAS_LIMIT + 1).gasPrice(Wei.ZERO).payload(Bytes.EMPTY).build();
+        builder.gasPrice(Wei.ZERO).payload(Bytes.random(MAX_TX_CALLDATA_SIZE + 1)).build();
     Assertions.assertEquals(
-        gasLimitValidator.validateTransaction(transaction, false, false).orElseThrow(),
-        "Gas limit of transaction is greater than the allowed max of " + MAX_TX_GAS_LIMIT);
+        calldataValidator.validateTransaction(transaction, false, false).orElseThrow(),
+        "Calldata of transaction is greater than the allowed max of " + MAX_TX_CALLDATA_SIZE);
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidatorTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidatorTest.java
@@ -13,13 +13,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.sequencer.txvalidation.validators;
+package net.consensys.linea.sequencer.txpoolvalidation.validators;
 
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.consensys.linea.config.LineaTransactionValidatorCliOptions;
+import net.consensys.linea.config.LineaTransactionPoolValidatorCliOptions;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
 import org.junit.jupiter.api.Assertions;
@@ -28,37 +28,37 @@ import org.junit.jupiter.api.Test;
 
 @Slf4j
 @RequiredArgsConstructor
-public class CalldataValidatorTest {
-  public static final int MAX_TX_CALLDATA_SIZE = 10_000;
-  private CalldataValidator calldataValidator;
+public class GasLimitValidatorTest {
+  public static final int MAX_TX_GAS_LIMIT = 9_000_000;
+  private GasLimitValidator gasLimitValidator;
 
   @BeforeEach
   public void initialize() {
-    calldataValidator =
-        new CalldataValidator(
-            LineaTransactionValidatorCliOptions.create().toDomainObject().toBuilder()
-                .maxTxCalldataSize(MAX_TX_CALLDATA_SIZE)
+    gasLimitValidator =
+        new GasLimitValidator(
+            LineaTransactionPoolValidatorCliOptions.create().toDomainObject().toBuilder()
+                .maxTxGasLimit(MAX_TX_GAS_LIMIT)
                 .build());
   }
 
   @Test
-  public void validatedWithValidCalldata() {
+  public void validatedWithValidGasLimit() {
     final org.hyperledger.besu.ethereum.core.Transaction.Builder builder =
         org.hyperledger.besu.ethereum.core.Transaction.builder();
     final org.hyperledger.besu.ethereum.core.Transaction transaction =
-        builder.gasPrice(Wei.ZERO).payload(Bytes.random(MAX_TX_CALLDATA_SIZE)).build();
+        builder.gasLimit(MAX_TX_GAS_LIMIT).gasPrice(Wei.ZERO).payload(Bytes.EMPTY).build();
     Assertions.assertEquals(
-        calldataValidator.validateTransaction(transaction, false, false), Optional.empty());
+        gasLimitValidator.validateTransaction(transaction, false, false), Optional.empty());
   }
 
   @Test
-  public void rejectedWithTooBigCalldata() {
+  public void rejectedWithMaxGasLimitPlusOne() {
     final org.hyperledger.besu.ethereum.core.Transaction.Builder builder =
         org.hyperledger.besu.ethereum.core.Transaction.builder();
     final org.hyperledger.besu.ethereum.core.Transaction transaction =
-        builder.gasPrice(Wei.ZERO).payload(Bytes.random(MAX_TX_CALLDATA_SIZE + 1)).build();
+        builder.gasLimit(MAX_TX_GAS_LIMIT + 1).gasPrice(Wei.ZERO).payload(Bytes.EMPTY).build();
     Assertions.assertEquals(
-        calldataValidator.validateTransaction(transaction, false, false).orElseThrow(),
-        "Calldata of transaction is greater than the allowed max of " + MAX_TX_CALLDATA_SIZE);
+        gasLimitValidator.validateTransaction(transaction, false, false).orElseThrow(),
+        "Gas limit of transaction is greater than the allowed max of " + MAX_TX_GAS_LIMIT);
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidatorTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidatorTest.java
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.sequencer.txvalidation.validators;
+package net.consensys.linea.sequencer.txpoolvalidation.validators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
Just renaming `TransactionValidator` to `TransactionPoolValidator` to make it clear that the validation is only applied when a tx is evaluated in the txpool