### PR TITLE
Refactor Exceptions class - reduce number of allocations

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/constants/GlobalConstants.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/constants/GlobalConstants.java
@@ -25,7 +25,8 @@ import java.math.BigInteger;
  */
 public class GlobalConstants {
   public static final int BLOCKHASH_MAX_HISTORY = 0x100;
-  public static final int EIP_3541_MARKER = 0xef;
+  public static final byte EIP_3541_MARKER = (byte) 0xef;
+  public static final int MAX_CODE_SIZE = 24576;
   public static final BigInteger EMPTY_KECCAK_HI =
       new BigInteger("16434357337474432580558001204043214908");
   public static final BigInteger EMPTY_KECCAK_LO =

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -51,6 +51,7 @@ import net.consensys.linea.zktracer.module.hub.fragment.imc.ImcFragment;
 import net.consensys.linea.zktracer.module.hub.fragment.scenario.ScenarioFragment;
 import net.consensys.linea.zktracer.module.hub.precompiles.PrecompileInvocation;
 import net.consensys.linea.zktracer.module.hub.section.*;
+import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.module.hub.signals.PlatformController;
 import net.consensys.linea.zktracer.module.hub.transients.DeploymentInfo;
 import net.consensys.linea.zktracer.module.hub.transients.Transients;
@@ -664,7 +665,7 @@ public class Hub implements Module {
   }
 
   void triggerModules(MessageFrame frame) {
-    if (this.pch.exceptions().none() && this.pch.aborts().none()) {
+    if (Exceptions.none(this.pch.exceptions()) && this.pch.aborts().none()) {
       for (Module precompileLimit : this.precompileLimitModules) {
         precompileLimit.tracePreOpcode(frame);
       }
@@ -732,7 +733,7 @@ public class Hub implements Module {
 
     this.handleStack(frame);
     this.triggerModules(frame);
-    if (this.pch().exceptions().any() || this.currentFrame().opCode() == OpCode.REVERT) {
+    if (Exceptions.any(this.pch().exceptions()) || this.currentFrame().opCode() == OpCode.REVERT) {
       this.callStack.revert(this.state.stamps().hub());
     }
 
@@ -805,7 +806,7 @@ public class Hub implements Module {
       // Trace the exceptions of a transaction that could not even start
       // TODO: integrate with PCH
       // if (this.exceptions == null) {
-      // this.exceptions = Exceptions.fromOutOfGas();
+      // this.exceptions = Exceptions.OUT_OF_GAS;
       // }
       // otherwise 4 account rows (sender, coinbase, sender, recipient) + 1 tx row
       Address toAddress = this.transients.tx().besuTx().getSender();
@@ -912,7 +913,7 @@ public class Hub implements Module {
       if (line.needsResult()) {
         Bytes result = Bytes.EMPTY;
         // Only pop from the stack if no exceptions have been encountered
-        if (this.pch.exceptions().none()) {
+        if (Exceptions.none(this.pch.exceptions())) {
           result = frame.getStackItem(0).copy();
         }
 
@@ -924,7 +925,7 @@ public class Hub implements Module {
       }
     }
 
-    if (this.pch.exceptions().none()) {
+    if (Exceptions.none(this.pch.exceptions())) {
       for (TraceSection.TraceLine line : section.lines()) {
         if (line.specific() instanceof StackFragment stackFragment) {
           stackFragment.feedHashedValue(frame);
@@ -1111,33 +1112,33 @@ public class Hub implements Module {
 
     switch (this.opCodeData().instructionFamily()) {
       case ADD -> {
-        if (this.pch.exceptions().noStackException()) {
+        if (Exceptions.noStackException(this.pch.exceptions())) {
           this.add.tracePostOpcode(frame);
         }
       }
       case MOD -> {
-        if (this.pch.exceptions().noStackException()) {
+        if (Exceptions.noStackException(this.pch.exceptions())) {
           this.mod.tracePostOpcode(frame);
         }
       }
       case MUL -> {
-        if (this.pch.exceptions().noStackException()) {
+        if (Exceptions.noStackException(this.pch.exceptions())) {
           this.mul.tracePostOpcode(frame);
         }
       }
       case EXT -> {
-        if (this.pch.exceptions().noStackException()) {
+        if (Exceptions.noStackException(this.pch.exceptions())) {
           this.ext.tracePostOpcode(frame);
         }
       }
       case WCP -> {
-        if (this.pch.exceptions().noStackException()) {
+        if (Exceptions.noStackException(this.pch.exceptions())) {
           this.wcp.tracePostOpcode(frame);
         }
       }
       case BIN -> {}
       case SHF -> {
-        if (this.pch.exceptions().noStackException()) {
+        if (Exceptions.noStackException(this.pch.exceptions())) {
           this.shf.tracePostOpcode(frame);
         }
       }
@@ -1152,7 +1153,7 @@ public class Hub implements Module {
         }
       }
       case STACK_RAM -> {
-        if (this.pch.exceptions().noStackException()) {
+        if (Exceptions.noStackException(this.pch.exceptions())) {
           this.mxp.tracePostOpcode(frame);
         }
       }
@@ -1243,12 +1244,12 @@ public class Hub implements Module {
           case RETURN -> {
             Bytes returnData = Bytes.EMPTY;
             // Trying to read memory with absurd arguments will throw an exception
-            if (pch.exceptions().none()) {
+            if (Exceptions.none(pch.exceptions())) {
               returnData = this.transients.op().returnData();
             }
             this.currentFrame().returnDataSource(transients.op().returnDataSegment());
             this.currentFrame().returnData(returnData);
-            if (!this.pch.exceptions().any() && !this.currentFrame().underDeployment()) {
+            if (!Exceptions.any(this.pch.exceptions()) && !this.currentFrame().underDeployment()) {
               parentFrame.latestReturnData(returnData);
             } else {
               parentFrame.latestReturnData(Bytes.EMPTY);
@@ -1259,7 +1260,7 @@ public class Hub implements Module {
             final Bytes returnData = this.transients.op().returnData();
             this.currentFrame().returnDataSource(transients.op().returnDataSegment());
             this.currentFrame().returnData(returnData);
-            if (!this.pch.exceptions().any()) {
+            if (!Exceptions.any(this.pch.exceptions())) {
               parentFrame.latestReturnData(returnData);
             } else {
               parentFrame.latestReturnData(Bytes.EMPTY);
@@ -1459,24 +1460,24 @@ public class Hub implements Module {
 
         Optional<Precompile> targetPrecompile = Precompile.maybeOf(calledAddress);
 
-        if (this.pch().exceptions().any()) {
+        if (Exceptions.any(this.pch().exceptions())) {
           //
           // THERE IS AN EXCEPTION
           //
-          if (this.pch().exceptions().staticFault()) {
+          if (Exceptions.staticFault(this.pch().exceptions())) {
             this.addTraceSection(
                 new FailedCallSection(
                     this,
                     ScenarioFragment.forCall(this, hasCode),
                     ImcFragment.forCall(this, myAccount, calledAccount),
                     ContextFragment.readContextData(callStack)));
-          } else if (this.pch().exceptions().outOfMemoryExpansion()) {
+          } else if (Exceptions.outOfMemoryExpansion(this.pch().exceptions())) {
             this.addTraceSection(
                 new FailedCallSection(
                     this,
                     ScenarioFragment.forCall(this, hasCode),
                     ImcFragment.forCall(this, myAccount, calledAccount)));
-          } else if (this.pch().exceptions().outOfGas()) {
+          } else if (Exceptions.outOfGas(this.pch().exceptions())) {
             this.addTraceSection(
                 new FailedCallSection(
                     this,
@@ -1568,7 +1569,7 @@ public class Hub implements Module {
     }
 
     // In all cases, add a context fragment if an exception occurred
-    if (this.pch().exceptions().any()) {
+    if (Exceptions.any(this.pch().exceptions())) {
       this.currentTraceSection()
           .addFragment(
               this, this.currentFrame(), ContextFragment.executionEmptyReturnData(callStack));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/CommonFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/CommonFragment.java
@@ -38,7 +38,7 @@ public final class CommonFragment implements TraceFragment {
   private final TxState txState;
   private final int stamp;
   private final InstructionFamily instructionFamily;
-  private final Exceptions exceptions;
+  private final short exceptions;
   private final int callFrameId;
   @Getter private final int contextNumber;
   @Setter private int newContextNumber;
@@ -63,7 +63,7 @@ public final class CommonFragment implements TraceFragment {
   public static CommonFragment fromHub(
       final Hub hub, final CallFrame frame, boolean tliCounter, int nonStackRowsCounter) {
     long refund = 0;
-    if (hub.pch().exceptions().noStackException()) {
+    if (Exceptions.noStackException(hub.pch().exceptions())) {
       refund = Hub.GAS_PROJECTOR.of(frame.frame(), hub.opCode()).refund();
     }
 
@@ -74,7 +74,7 @@ public final class CommonFragment implements TraceFragment {
         .txState(hub.transients().tx().state())
         .stamp(hub.stamp())
         .instructionFamily(hub.opCodeData().instructionFamily())
-        .exceptions(hub.pch().exceptions().snapshot())
+        .exceptions(hub.pch().exceptions())
         .callFrameId(frame.id())
         .contextNumber(frame.contextNumber())
         .newContextNumber(frame.contextNumber())
@@ -136,8 +136,8 @@ public final class CommonFragment implements TraceFragment {
                         || instructionFamily == InstructionFamily.CREATE
                         || instructionFamily == InstructionFamily.HALT
                         || instructionFamily == InstructionFamily.INVALID)
-                    || exceptions.any()))
-        .exceptionAhoy(exceptions.any())
+                    || Exceptions.any(exceptions)))
+        .exceptionAhoy(Exceptions.any(exceptions))
 
         // Context data
         .contextNumber(Bytes.ofUnsignedInt(contextNumber))

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/StackFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/StackFragment.java
@@ -45,7 +45,7 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 public final class StackFragment implements TraceFragment {
   private final Stack stack;
   @Getter private final List<StackOperation> stackOps;
-  private final Exceptions exceptions;
+  private final short exceptions;
   @Setter private DeploymentExceptions contextExceptions;
   private final long staticGas;
   private EWord hashInfoKeccak = EWord.ZERO;
@@ -57,7 +57,7 @@ public final class StackFragment implements TraceFragment {
       final Hub hub,
       Stack stack,
       List<StackOperation> stackOps,
-      Exceptions exceptions,
+      short exceptions,
       AbortingConditions aborts,
       DeploymentExceptions contextExceptions,
       GasProjection gp,
@@ -69,9 +69,9 @@ public final class StackFragment implements TraceFragment {
     this.opCode = stack.getCurrentOpcodeData().mnemonic();
     this.hashInfoFlag =
         switch (this.opCode) {
-          case SHA3 -> exceptions.none() && gp.messageSize() > 0;
-          case RETURN -> exceptions.none() && gp.messageSize() > 0 && isDeploying;
-          case CREATE2 -> exceptions.none()
+          case SHA3 -> Exceptions.none(exceptions) && gp.messageSize() > 0;
+          case RETURN -> Exceptions.none(exceptions) && gp.messageSize() > 0 && isDeploying;
+          case CREATE2 -> Exceptions.none(exceptions)
               && contextExceptions.none()
               && aborts.none()
               && gp.messageSize() > 0;
@@ -79,7 +79,7 @@ public final class StackFragment implements TraceFragment {
         };
     this.hashInfoSize = this.hashInfoFlag ? gp.messageSize() : 0;
     this.staticGas = gp.staticGas();
-    if (this.opCode == OpCode.RETURN && exceptions.none()) {
+    if (this.opCode == OpCode.RETURN && Exceptions.none(exceptions)) {
       this.hashInfoKeccak =
           EWord.of(org.hyperledger.besu.crypto.Hash.keccak256(hub.transients().op().returnData()));
     }
@@ -89,7 +89,7 @@ public final class StackFragment implements TraceFragment {
       final Hub hub,
       final Stack stack,
       final List<StackOperation> stackOperations,
-      final Exceptions exceptions,
+      final short exceptions,
       final AbortingConditions aborts,
       final GasProjection gp,
       boolean isDeploying) {
@@ -199,15 +199,15 @@ public final class StackFragment implements TraceFragment {
         .pStackDecFlag3(this.stack.getCurrentOpcodeData().stackSettings().flag3())
         .pStackDecFlag4(this.stack.getCurrentOpcodeData().stackSettings().flag4())
         // Exception flag
-        .pStackOpcx(exceptions.invalidOpcode())
-        .pStackSux(exceptions.stackUnderflow())
-        .pStackSox(exceptions.stackOverflow())
-        .pStackOogx(exceptions.outOfGas())
-        .pStackMxpx(exceptions.outOfMemoryExpansion())
-        .pStackRdcx(exceptions.returnDataCopyFault())
-        .pStackJumpx(exceptions.jumpFault())
-        .pStackStaticx(exceptions.staticFault())
-        .pStackSstorex(exceptions.outOfSStore())
+        .pStackOpcx(Exceptions.invalidOpcode(exceptions))
+        .pStackSux(Exceptions.stackUnderflow(exceptions))
+        .pStackSox(Exceptions.stackOverflow(exceptions))
+        .pStackOogx(Exceptions.outOfGas(exceptions))
+        .pStackMxpx(Exceptions.outOfMemoryExpansion(exceptions))
+        .pStackRdcx(Exceptions.returnDataCopyFault(exceptions))
+        .pStackJumpx(Exceptions.jumpFault(exceptions))
+        .pStackStaticx(Exceptions.staticFault(exceptions))
+        .pStackSstorex(Exceptions.outOfSStore(exceptions))
         .pStackIcpx(contextExceptions.invalidCodePrefix())
         .pStackMaxcsx(contextExceptions.codeSizeOverflow())
         // Opcode families

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/ImcFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/ImcFragment.java
@@ -38,6 +38,7 @@ import net.consensys.linea.zktracer.module.hub.fragment.imc.call.oob.opcodes.Dep
 import net.consensys.linea.zktracer.module.hub.fragment.imc.call.oob.opcodes.ExceptionalCall;
 import net.consensys.linea.zktracer.module.hub.fragment.imc.call.oob.opcodes.Jump;
 import net.consensys.linea.zktracer.module.hub.fragment.imc.call.oob.opcodes.SStore;
+import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.opcode.gas.GasConstants;
 import net.consensys.linea.zktracer.types.EWord;
@@ -121,7 +122,7 @@ public class ImcFragment implements TraceFragment {
     if (hub.pch().signals().oob()) {
       switch (hub.opCode()) {
         case CALL, STATICCALL, DELEGATECALL, CALLCODE -> {
-          if (hub.opCode().equals(OpCode.CALL) && hub.pch().exceptions().any()) {
+          if (hub.opCode().equals(OpCode.CALL) && Exceptions.any(hub.pch().exceptions())) {
             r.callOob(new ExceptionalCall(EWord.of(hub.messageFrame().getStackItem(2))));
           } else {
             r.callOob(
@@ -155,7 +156,7 @@ public class ImcFragment implements TraceFragment {
               calledAccount
                   .map(a -> hub.messageFrame().isAddressWarm(a.getAddress()))
                   .orElse(false),
-              hub.pch().exceptions().outOfGas(),
+              Exceptions.outOfGas(hub.pch().exceptions()),
               upfrontCost,
               Math.max(
                   Words.unsignedMin(
@@ -179,7 +180,7 @@ public class ImcFragment implements TraceFragment {
       r.callExp(new ExpCallForExpPricing(EWord.of(hub.messageFrame().getStackItem(1))));
     }
 
-    if (hub.pch().signals().exp() && !hub.pch().exceptions().stackException()) {
+    if (hub.pch().signals().exp() && !Exceptions.stackException(hub.pch().exceptions())) {
       hub.exp().tracePreOpcode(frame);
     }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/call/MxpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/call/MxpCall.java
@@ -18,6 +18,7 @@ package net.consensys.linea.zktracer.module.hub.fragment.imc.call;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.Trace;
 import net.consensys.linea.zktracer.module.hub.fragment.TraceSubFragment;
+import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.types.EWord;
 import org.apache.tuweni.bytes.Bytes;
@@ -46,7 +47,7 @@ public record MxpCall(
     EWord size2 = EWord.ZERO;
 
     return new MxpCall(
-        hub.pch().exceptions().outOfMemoryExpansion(),
+        Exceptions.outOfMemoryExpansion(hub.pch().exceptions()),
         hub.currentFrame().opCodeData().value(),
         opCode == OpCode.RETURN && hub.currentFrame().underDeployment(),
         hub.currentFrame().frame().memoryWordSize(),

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/call/oob/opcodes/DeploymentReturn.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/call/oob/opcodes/DeploymentReturn.java
@@ -18,8 +18,8 @@ package net.consensys.linea.zktracer.module.hub.fragment.imc.call.oob.opcodes;
 import static net.consensys.linea.zktracer.module.constants.GlobalConstants.OOB_INST_DEPLOYMENT;
 import static net.consensys.linea.zktracer.types.Conversions.booleanToBytes;
 
+import net.consensys.linea.zktracer.module.constants.GlobalConstants;
 import net.consensys.linea.zktracer.module.hub.fragment.imc.call.oob.OobCall;
-import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.module.oob.OobDataChannel;
 import net.consensys.linea.zktracer.types.EWord;
 import org.apache.tuweni.bytes.Bytes;
@@ -30,7 +30,7 @@ public record DeploymentReturn(EWord size) implements OobCall {
     return switch (i) {
       case DATA_1 -> size.hi();
       case DATA_2 -> size.lo();
-      case DATA_7 -> booleanToBytes(size.greaterThan(EWord.of(Exceptions.MAX_CODE_SIZE)));
+      case DATA_7 -> booleanToBytes(size.greaterThan(EWord.of(GlobalConstants.MAX_CODE_SIZE)));
       default -> Bytes.EMPTY;
     };
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/scenario/ScenarioFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/scenario/ScenarioFragment.java
@@ -23,6 +23,7 @@ import net.consensys.linea.zktracer.module.hub.Trace;
 import net.consensys.linea.zktracer.module.hub.defer.PostTransactionDefer;
 import net.consensys.linea.zktracer.module.hub.fragment.TraceFragment;
 import net.consensys.linea.zktracer.module.hub.precompiles.PrecompileInvocation;
+import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.types.MemorySpan;
 import net.consensys.linea.zktracer.types.Precompile;
 import org.hyperledger.besu.datatypes.Transaction;
@@ -92,10 +93,10 @@ public class ScenarioFragment implements TraceFragment, PostTransactionDefer {
             targetHasCode,
             hub.currentFrame().id(),
             hub.callStack().futureId(),
-            hub.pch().exceptions().any(),
+            Exceptions.any(hub.pch().exceptions()),
             hub.pch().aborts().any(),
             hub.pch().failures().any(),
-            hub.pch().exceptions().invalidCodePrefix());
+            Exceptions.invalidCodePrefix(hub.pch().exceptions()));
     hub.defers().postTx(r);
     return r;
   }
@@ -107,10 +108,10 @@ public class ScenarioFragment implements TraceFragment, PostTransactionDefer {
         targetHasCode,
         hub.currentFrame().id(),
         hub.callStack().futureId(),
-        hub.pch().exceptions().any(),
+        Exceptions.any(hub.pch().exceptions()),
         hub.pch().aborts().any(),
         hub.pch().failures().any(),
-        hub.pch().exceptions().invalidCodePrefix());
+        Exceptions.invalidCodePrefix(hub.pch().exceptions()));
   }
 
   public static ScenarioFragment forSmartContractCallSection(

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/TraceSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/TraceSection.java
@@ -34,7 +34,7 @@ import net.consensys.linea.zktracer.runtime.callstack.CallFrame;
 import net.consensys.linea.zktracer.runtime.stack.StackLine;
 
 @Accessors(fluent = true)
-/** A TraceSection gather the trace lines linked to a single operation */
+/* A TraceSection gather the trace lines linked to a single operation */
 public abstract class TraceSection {
   @Getter private int stackHeight = 0;
   @Getter private int stackHeightNew = 0;
@@ -251,7 +251,7 @@ public abstract class TraceSection {
                 hub,
                 f.stack().snapshot(),
                 new StackLine().asStackOperations(),
-                hub.pch().exceptions().snapshot(),
+                hub.pch().exceptions(),
                 hub.pch().aborts().snapshot(),
                 Hub.GAS_PROJECTOR.of(f.frame(), f.opCode()),
                 f.underDeployment()));
@@ -263,7 +263,7 @@ public abstract class TraceSection {
                 hub,
                 f.stack().snapshot(),
                 line.asStackOperations(),
-                hub.pch().exceptions().snapshot(),
+                hub.pch().exceptions(),
                 hub.pch().aborts().snapshot(),
                 Hub.GAS_PROJECTOR.of(f.frame(), f.opCode()),
                 f.underDeployment()));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/signals/AbortingConditions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/signals/AbortingConditions.java
@@ -60,7 +60,7 @@ public final class AbortingConditions {
     this.balanceTooLow =
         switch (hub.currentFrame().opCode()) {
           case CALL, CALLCODE -> {
-            if (hub.pch().exceptions().none()) {
+            if (Exceptions.none(hub.pch().exceptions())) {
               final Address myAddress = hub.currentFrame().address();
               final Wei myBalance =
                   hub.messageFrame().getWorldUpdater().get(myAddress).getBalance();
@@ -72,7 +72,7 @@ public final class AbortingConditions {
             }
           }
           case CREATE, CREATE2 -> {
-            if (hub.pch().exceptions().none()) {
+            if (Exceptions.none(hub.pch().exceptions())) {
               final Address myAddress = hub.currentFrame().address();
               final Wei myBalance =
                   hub.messageFrame().getWorldUpdater().get(myAddress).getBalance();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/signals/Exceptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/signals/Exceptions.java
@@ -16,10 +16,8 @@
 package net.consensys.linea.zktracer.module.hub.signals;
 
 import static net.consensys.linea.zktracer.module.constants.GlobalConstants.EIP_3541_MARKER;
+import static net.consensys.linea.zktracer.module.constants.GlobalConstants.MAX_CODE_SIZE;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
@@ -29,169 +27,91 @@ import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.internal.Words;
 
-/** Encode the exceptions that may be triggered byt the execution of an instruction. */
-@Getter
-@RequiredArgsConstructor
-@Accessors(fluent = true)
-public final class Exceptions {
-  public static final int MAX_CODE_SIZE = 24576;
+/** Encode the exceptions that may be triggered by the execution of an instruction. */
+public class Exceptions {
+  private Exceptions() {}
 
-  private final Hub hub;
+  public static final short NONE = 0; // no exceptions occurred
+  private static final short INVALID_OPCODE = 1; // unknown opcode
+  private static final short STACK_UNDERFLOW = 2; // stack underflow
+  private static final short STACK_OVERFLOW = 4; // stack overflow
+  private static final short OUT_OF_MEMORY_EXPANSION = 8; // tried to use memory too far away
+  private static final short OUT_OF_GAS = 16; // not enough gas for instruction
+  private static final short RETURN_DATA_COPY_FAULT = 32; // trying to read past the RETURNDATA end
+  private static final short JUMP_FAULT = 64; // jumping to an invalid destination
+  private static final short STATIC_FAULT =
+      128; // trying to execute non-static instruction in a static context
+  private static final short OUT_OF_SSTORE = 256; // not enough gas to execute an SSTORE
+  private static final short INVALID_CODE_PREFIX = 512;
+  private static final short CODE_SIZE_OVERFLOW = 2048;
 
-  private boolean invalidOpcode;
-  private boolean stackUnderflow;
-  private boolean stackOverflow;
-  private boolean outOfMemoryExpansion;
-  private boolean outOfGas;
-  private boolean returnDataCopyFault;
-  private boolean jumpFault;
-  private boolean staticFault;
-  private boolean outOfSStore;
-  private boolean invalidCodePrefix;
-  private boolean codeSizeOverflow;
-
-  /**
-   * @param invalidOpcode unknown opcode
-   * @param stackUnderflow stack underflow
-   * @param stackOverflow stack overflow
-   * @param outOfMemoryExpansion tried to use memory too far away
-   * @param outOfGas not enough gas for instruction
-   * @param returnDataCopyFault trying to read pas the RETURNDATA end
-   * @param jumpFault jumping to an invalid destination
-   * @param staticFault trying to execute a non-static instruction in a static context
-   * @param outOfSStore not enough gas to execute an SSTORE
-   */
-  public Exceptions(
-      boolean invalidOpcode,
-      boolean stackUnderflow,
-      boolean stackOverflow,
-      boolean outOfMemoryExpansion,
-      boolean outOfGas,
-      boolean returnDataCopyFault,
-      boolean jumpFault,
-      boolean staticFault,
-      boolean outOfSStore,
-      boolean invalidCodePrefix,
-      boolean codeSizeOverflow) {
-    this.hub = null;
-    this.invalidOpcode = invalidOpcode;
-    this.stackUnderflow = stackUnderflow;
-    this.stackOverflow = stackOverflow;
-    this.outOfMemoryExpansion = outOfMemoryExpansion;
-    this.outOfGas = outOfGas;
-    this.returnDataCopyFault = returnDataCopyFault;
-    this.jumpFault = jumpFault;
-    this.staticFault = staticFault;
-    this.outOfSStore = outOfSStore;
-    this.invalidCodePrefix = invalidCodePrefix;
-    this.codeSizeOverflow = codeSizeOverflow;
-  }
-
-  @Override
-  public String toString() {
-    if (this.invalidOpcode) {
-      return "Invalid opcode";
-    }
-    if (this.stackUnderflow) {
-      return "Stack underflow";
-    }
-    if (this.stackOverflow) {
-      return "Stack overflow";
-    }
-    if (this.outOfMemoryExpansion) {
-      return "Out of MXP";
-    }
-    if (this.outOfGas) {
-      return "Out of gas";
-    }
-    if (this.returnDataCopyFault) {
-      return "RDC fault";
-    }
-    if (this.jumpFault) {
-      return "JMP fault";
-    }
-    if (this.staticFault) {
-      return "Static fault";
-    }
-    if (this.outOfSStore) {
-      return "Out of SSTORE";
-    }
-    if (this.invalidCodePrefix) {
-      return "Invalid code prefix";
-    }
-    if (this.codeSizeOverflow) {
-      return "Code size overflow";
-    }
-    return "No exception";
-  }
-
-  public void reset() {
-    this.invalidOpcode = false;
-    this.stackUnderflow = false;
-    this.stackOverflow = false;
-    this.outOfMemoryExpansion = false;
-    this.outOfGas = false;
-    this.returnDataCopyFault = false;
-    this.jumpFault = false;
-    this.staticFault = false;
-    this.outOfSStore = false;
-    this.invalidCodePrefix = false;
-    this.codeSizeOverflow = false;
-  }
-
-  public boolean stackException() {
-    return this.stackUnderflow() || this.stackOverflow();
+  public static boolean stackException(final short bitmask) {
+    return stackOverflow(bitmask) || stackUnderflow(bitmask);
   }
 
   /**
    * @return true if no stack exception has been raised
    */
-  public boolean noStackException() {
-    return !this.stackException();
-  }
-
-  /**
-   * Creates a snapshot (a copy) of the given Exceptions object.
-   *
-   * @return a new Exceptions
-   */
-  public Exceptions snapshot() {
-    return new Exceptions(
-        invalidOpcode,
-        stackUnderflow,
-        stackOverflow,
-        outOfMemoryExpansion,
-        outOfGas,
-        returnDataCopyFault,
-        jumpFault,
-        staticFault,
-        outOfSStore,
-        invalidCodePrefix,
-        codeSizeOverflow);
+  public static boolean noStackException(final short bitmask) {
+    return !stackException(bitmask);
   }
 
   /**
    * @return true if any exception flag has been raised
    */
-  public boolean any() {
-    return this.invalidOpcode
-        || this.stackUnderflow
-        || this.stackOverflow
-        || this.outOfMemoryExpansion
-        || this.outOfGas
-        || this.returnDataCopyFault
-        || this.jumpFault
-        || this.staticFault
-        || this.outOfSStore
-        || this.invalidCodePrefix
-        || this.codeSizeOverflow;
+  public static boolean any(final short bitmask) {
+    return !none(bitmask);
   }
 
   /**
    * @return true if no exception flag has been raised
    */
-  public boolean none() {
-    return !this.any();
+  public static boolean none(final short bitmask) {
+    return bitmask == NONE;
+  }
+
+  public static boolean invalidOpcode(final short bitmask) {
+    return (bitmask & INVALID_OPCODE) != 0;
+  }
+
+  public static boolean stackUnderflow(final short bitmask) {
+    return (bitmask & STACK_UNDERFLOW) != 0;
+  }
+
+  public static boolean stackOverflow(final short bitmask) {
+    return (bitmask & STACK_OVERFLOW) != 0;
+  }
+
+  public static boolean outOfMemoryExpansion(final short bitmask) {
+    return (bitmask & OUT_OF_MEMORY_EXPANSION) != 0;
+  }
+
+  public static boolean outOfGas(final short bitmask) {
+    return (bitmask & OUT_OF_GAS) != 0;
+  }
+
+  public static boolean returnDataCopyFault(final short bitmask) {
+    return (bitmask & RETURN_DATA_COPY_FAULT) != 0;
+  }
+
+  public static boolean jumpFault(final short bitmask) {
+    return (bitmask & JUMP_FAULT) != 0;
+  }
+
+  public static boolean staticFault(final short bitmask) {
+    return (bitmask & STATIC_FAULT) != 0;
+  }
+
+  public static boolean outOfSStore(final short bitmask) {
+    return (bitmask & OUT_OF_SSTORE) != 0;
+  }
+
+  public static boolean invalidCodePrefix(final short bitmask) {
+    return (bitmask & INVALID_CODE_PREFIX) != 0;
+  }
+
+  public static boolean codeSizeOverflow(final short bitmask) {
+    return (bitmask & CODE_SIZE_OVERFLOW) != 0;
   }
 
   private static boolean isInvalidOpcode(final OpCode opCode) {
@@ -274,7 +194,7 @@ public final class Exceptions {
     }
 
     final Bytes deployedCode = frame.getOutputData();
-    return !deployedCode.isEmpty() && (deployedCode.get(0) == (byte) EIP_3541_MARKER);
+    return !deployedCode.isEmpty() && (deployedCode.get(0) == EIP_3541_MARKER);
   }
 
   private static boolean isCodeSizeOverflow(MessageFrame frame) {
@@ -287,48 +207,33 @@ public final class Exceptions {
     return deployedCode.size() > MAX_CODE_SIZE;
   }
 
-  public static Exceptions fromOutOfGas() {
-    return new Exceptions(
-        false, false, false, false, true, false, false, false, false, false, false);
-  }
-
   /**
-   * Compute all the first exception that may have happened in the current frame. Wlthout multiple
+   * Return the first exception that may have happened in the current frame. Although multiple
    * exceptions may be triggered, the one minimizing the quantity of trace lines is generated.
    *
    * @param frame the context from which to compute the putative exceptions
    */
-  public void prepare(final MessageFrame frame, GasProjector gp) {
+  public static short fromFrame(final Hub hub, final MessageFrame frame) {
     OpCode opCode = hub.opCode();
     OpCodeData opCodeData = hub.opCodeData();
 
-    this.reset();
-
-    this.invalidOpcode = isInvalidOpcode(opCode);
-    if (this.invalidOpcode) {
-      return;
+    if (isInvalidOpcode(opCode)) {
+      return INVALID_OPCODE;
+    }
+    if (isStackUnderflow(frame, opCodeData)) {
+      return STACK_UNDERFLOW;
+    }
+    if (isStackOverflow(frame, opCodeData)) {
+      return STACK_OVERFLOW;
+    }
+    if (isStaticFault(frame, opCodeData)) {
+      return STATIC_FAULT;
+    }
+    if (isCodeSizeOverflow(frame)) {
+      return CODE_SIZE_OVERFLOW;
     }
 
-    this.stackUnderflow = isStackUnderflow(frame, opCodeData);
-    if (this.stackUnderflow) {
-      return;
-    }
-
-    this.stackOverflow = isStackOverflow(frame, opCodeData);
-    if (this.stackOverflow) {
-      return;
-    }
-
-    this.staticFault = isStaticFault(frame, opCodeData);
-    if (this.staticFault) {
-      return;
-    }
-
-    this.codeSizeOverflow = isCodeSizeOverflow(frame);
-    if (this.codeSizeOverflow) {
-      return;
-    }
-
+    final GasProjector gp = Hub.GAS_PROJECTOR;
     switch (opCode) {
       case CALLDATACOPY,
           CODECOPY,
@@ -351,63 +256,56 @@ public final class Exceptions {
           MLOAD,
           MSTORE,
           MSTORE8 -> {
-        this.outOfMemoryExpansion = isMemoryExpansionFault(frame, opCode, gp);
-        if (this.outOfMemoryExpansion) {
-          return;
+        if (isMemoryExpansionFault(frame, opCode, gp)) {
+          return OUT_OF_MEMORY_EXPANSION;
         }
-
-        this.outOfGas = isOutOfGas(frame, opCode, gp);
-        if (this.outOfGas) {
-          return;
+        if (isOutOfGas(frame, opCode, gp)) {
+          return OUT_OF_GAS;
         }
       }
+
       case RETURNDATACOPY -> {
-        this.returnDataCopyFault = isReturnDataCopyFault(frame, opCode);
-        if (this.returnDataCopyFault) {
-          return;
+        if (isReturnDataCopyFault(frame, opCode)) {
+          return RETURN_DATA_COPY_FAULT;
         }
-
-        this.outOfMemoryExpansion = isMemoryExpansionFault(frame, opCode, gp);
-        if (this.outOfMemoryExpansion) {
-          return;
+        if (isMemoryExpansionFault(frame, opCode, gp)) {
+          return OUT_OF_MEMORY_EXPANSION;
         }
-
-        this.outOfGas = isOutOfGas(frame, opCode, gp);
-        if (this.outOfGas) {
-          return;
+        if (isOutOfGas(frame, opCode, gp)) {
+          return OUT_OF_GAS;
         }
       }
+
       case STOP -> {}
+
       case JUMP, JUMPI -> {
-        this.outOfGas = isOutOfGas(frame, opCode, gp);
-        if (this.outOfGas) {
-          return;
+        if (isOutOfGas(frame, opCode, gp)) {
+          return OUT_OF_GAS;
         }
-
-        this.jumpFault = isJumpFault(frame, opCode);
-        if (this.jumpFault) {
-          return;
+        if (isJumpFault(frame, opCode)) {
+          return JUMP_FAULT;
         }
       }
+
       case SSTORE -> {
-        this.outOfSStore = isOutOfSStore(frame, opCode);
-        if (this.outOfSStore) {
-          return;
+        if (isOutOfSStore(frame, opCode)) {
+          return OUT_OF_SSTORE;
         }
-
-        this.outOfGas = isOutOfGas(frame, opCode, gp);
-        if (this.outOfGas) {
-          return;
+        if (isOutOfGas(frame, opCode, gp)) {
+          return OUT_OF_GAS;
         }
       }
+
       default -> {
-        this.outOfGas = isOutOfGas(frame, opCode, gp);
-        if (this.outOfGas) {
-          return;
+        if (isOutOfGas(frame, opCode, gp)) {
+          return OUT_OF_GAS;
         }
       }
     }
 
-    this.invalidCodePrefix = isInvalidCodePrefix(frame);
+    if (isInvalidCodePrefix(frame)) {
+      return INVALID_CODE_PREFIX;
+    }
+    return NONE;
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/signals/PlatformController.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/signals/PlatformController.java
@@ -32,7 +32,7 @@ public class PlatformController {
   @Getter private final Signals signals;
 
   /** The exceptions raised during the execution of the current operation */
-  @Getter private final Exceptions exceptions;
+  @Getter private short exceptions;
 
   /** The aborting conditions raised during the execution of the current operation */
   @Getter private final AbortingConditions aborts;
@@ -41,7 +41,7 @@ public class PlatformController {
 
   public PlatformController(final Hub hub) {
     this.hub = hub;
-    this.exceptions = new Exceptions(hub);
+    this.exceptions = Exceptions.NONE;
     this.aborts = new AbortingConditions();
     this.signals = new Signals(this);
     this.failures = new FailureConditions(hub);
@@ -50,7 +50,7 @@ public class PlatformController {
   /** Reset all information */
   public void reset() {
     this.signals.reset();
-    this.exceptions.reset();
+    this.exceptions = Exceptions.NONE;
     this.aborts.reset();
     this.failures.reset();
   }
@@ -64,8 +64,8 @@ public class PlatformController {
   public void setup(MessageFrame frame) {
     this.reset();
 
-    this.exceptions.prepare(frame, Hub.GAS_PROJECTOR);
-    if (this.exceptions.none()) {
+    this.exceptions = Exceptions.fromFrame(hub, frame);
+    if (Exceptions.none(this.exceptions)) {
       this.aborts.prepare(hub);
       if (aborts.none()) {
         this.failures.prepare(frame);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
@@ -26,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 import net.consensys.linea.zktracer.ColumnHeader;
 import net.consensys.linea.zktracer.module.Module;
 import net.consensys.linea.zktracer.module.hub.Hub;
+import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.module.hub.signals.PlatformController;
 import net.consensys.linea.zktracer.module.limits.precompiles.EcRecoverEffectiveCall;
 import net.consensys.linea.zktracer.module.shakiradata.ShakiraData;
@@ -87,7 +88,7 @@ public class Keccak implements Module {
 
     final PlatformController pch = this.hub.pch();
 
-    if (pch.exceptions().none()) {
+    if (Exceptions.none(pch.exceptions())) {
       // Capture calls to SHA3.
       if (opCode == OpCode.SHA3) {
         callShakira(frame, 0, 1, this.sha3Sizes);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/oob/OobOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/oob/OobOperation.java
@@ -58,6 +58,7 @@ import net.consensys.linea.zktracer.ZkTracer;
 import net.consensys.linea.zktracer.container.ModuleOperation;
 import net.consensys.linea.zktracer.module.add.Add;
 import net.consensys.linea.zktracer.module.hub.Hub;
+import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.module.mod.Mod;
 import net.consensys.linea.zktracer.module.oob.parameters.Blake2fCallDataSizeParameters;
 import net.consensys.linea.zktracer.module.oob.parameters.Blake2fParamsParameters;
@@ -209,8 +210,8 @@ public class OobOperation extends ModuleOperation {
         break;
       case CALL, CALLCODE, DELEGATECALL, STATICCALL:
         if (opCode == OpCode.CALL
-            && !hub.pch().exceptions().stackUnderflow()
-            && hub.pch().exceptions().any()) {
+            && !Exceptions.stackUnderflow(hub.pch().exceptions())
+            && Exceptions.any(hub.pch().exceptions())) {
           isXCall = true;
           wghtSum = BigInteger.valueOf(0xCC);
         } else {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobJumpAndJumpiTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobJumpAndJumpiTest.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import net.consensys.linea.zktracer.module.hub.Hub;
+import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.testing.BytecodeCompiler;
 import net.consensys.linea.zktracer.testing.BytecodeRunner;
@@ -68,7 +69,7 @@ public class OobJumpAndJumpiTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().jumpFault());
+    assertFalse(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -96,7 +97,7 @@ public class OobJumpAndJumpiTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().jumpFault());
+    assertFalse(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -123,7 +124,7 @@ public class OobJumpAndJumpiTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().jumpFault());
+    assertTrue(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -150,7 +151,7 @@ public class OobJumpAndJumpiTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().jumpFault());
+    assertTrue(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -196,7 +197,7 @@ public class OobJumpAndJumpiTest {
     bytecodeRunner.run();
 
     Hub hub = bytecodeRunner.getHub();
-    assertFalse(hub.pch().exceptions().jumpFault());
+    assertFalse(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -246,7 +247,7 @@ public class OobJumpAndJumpiTest {
     bytecodeRunner.run();
 
     Hub hub = bytecodeRunner.getHub();
-    assertFalse(hub.pch().exceptions().jumpFault());
+    assertFalse(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -274,7 +275,7 @@ public class OobJumpAndJumpiTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().jumpFault());
+    assertFalse(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -302,7 +303,7 @@ public class OobJumpAndJumpiTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().jumpFault());
+    assertFalse(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -329,7 +330,7 @@ public class OobJumpAndJumpiTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().jumpFault());
+    assertTrue(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -357,7 +358,7 @@ public class OobJumpAndJumpiTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().jumpFault());
+    assertTrue(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -376,7 +377,7 @@ public class OobJumpAndJumpiTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().jumpFault());
+    assertFalse(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -396,7 +397,7 @@ public class OobJumpAndJumpiTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().jumpFault());
+    assertFalse(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -416,7 +417,7 @@ public class OobJumpAndJumpiTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().jumpFault());
+    assertFalse(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -436,7 +437,7 @@ public class OobJumpAndJumpiTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().jumpFault());
+    assertFalse(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -487,7 +488,7 @@ public class OobJumpAndJumpiTest {
     bytecodeRunner.run();
 
     Hub hub = bytecodeRunner.getHub();
-    assertFalse(hub.pch().exceptions().jumpFault());
+    assertFalse(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -542,7 +543,7 @@ public class OobJumpAndJumpiTest {
     bytecodeRunner.run();
 
     Hub hub = bytecodeRunner.getHub();
-    assertFalse(hub.pch().exceptions().jumpFault());
+    assertFalse(Exceptions.jumpFault(hub.pch().exceptions()));
   }
 
   // Support methods

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobRdcTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobRdcTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.math.BigInteger;
 
 import net.consensys.linea.zktracer.module.hub.Hub;
+import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.testing.BytecodeCompiler;
 import net.consensys.linea.zktracer.testing.BytecodeRunner;
@@ -48,7 +49,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().returnDataCopyFault());
+    assertFalse(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Disabled("This test is temporary disabled because of issue with CREATE")
@@ -61,7 +62,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().returnDataCopyFault());
+    assertFalse(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Disabled("This test is temporary disabled because of issue with CREATE")
@@ -74,7 +75,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().returnDataCopyFault());
+    assertFalse(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Disabled("This test is temporary disabled because of issue with CREATE")
@@ -87,7 +88,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().returnDataCopyFault());
+    assertFalse(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Disabled("This test is temporary disabled because of issue with CREATE")
@@ -100,7 +101,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().returnDataCopyFault());
+    assertFalse(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   // Failing cases
@@ -116,7 +117,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -128,7 +129,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -140,7 +141,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   // offset just greater cases
@@ -154,7 +155,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -167,7 +168,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -179,7 +180,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -191,7 +192,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   // offset big left cases
@@ -204,7 +205,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -216,7 +217,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -228,7 +229,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -240,7 +241,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   // offset big right cases
@@ -253,7 +254,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -265,7 +266,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -277,7 +278,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   @Test
@@ -289,7 +290,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
   }
 
   // Same cases but using identity precompile
@@ -303,7 +304,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().returnDataCopyFault());
+    assertFalse(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -325,7 +326,7 @@ public class OobRdcTest {
     Hub hub = bytecodeRunner.getHub();
     System.out.println(bytecodeRunner.getHub().currentFrame().frame().getReturnData());
 
-    assertFalse(hub.pch().exceptions().returnDataCopyFault());
+    assertFalse(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -346,7 +347,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().returnDataCopyFault());
+    assertFalse(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -367,7 +368,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().returnDataCopyFault());
+    assertFalse(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -388,7 +389,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertFalse(hub.pch().exceptions().returnDataCopyFault());
+    assertFalse(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -413,7 +414,7 @@ public class OobRdcTest {
     Hub hub = bytecodeRunner.getHub();
     System.out.println(bytecodeRunner.getHub().currentFrame().frame().getReturnData());
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -434,7 +435,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -455,7 +456,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -478,7 +479,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -500,7 +501,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -521,7 +522,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -542,7 +543,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -563,7 +564,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -583,7 +584,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -604,7 +605,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -625,7 +626,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -646,7 +647,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -667,7 +668,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -688,7 +689,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1
@@ -709,7 +710,7 @@ public class OobRdcTest {
 
     Hub hub = bytecodeRunner.getHub();
 
-    assertTrue(hub.pch().exceptions().returnDataCopyFault());
+    assertTrue(Exceptions.returnDataCopyFault(hub.pch().exceptions()));
 
     // Chunk with index 1 is the one corresponding to IDENTITY precompile
     // precompileCost = (5 + ceil) * 3 where ceil = 1

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/testing/ToyExecutionEnvironment.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/testing/ToyExecutionEnvironment.java
@@ -38,8 +38,8 @@ import net.consensys.linea.blockcapture.snapshots.ConflationSnapshot;
 import net.consensys.linea.blockcapture.snapshots.TransactionSnapshot;
 import net.consensys.linea.corset.CorsetValidator;
 import net.consensys.linea.zktracer.ZkTracer;
+import net.consensys.linea.zktracer.module.constants.GlobalConstants;
 import net.consensys.linea.zktracer.module.hub.Hub;
-import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.*;
 import org.hyperledger.besu.ethereum.core.*;
@@ -238,7 +238,7 @@ public class ToyExecutionEnvironment {
             false,
             Optional.of(this.chainId),
             Set.of(TransactionType.FRONTIER, TransactionType.ACCESS_LIST, TransactionType.EIP1559),
-            Exceptions.MAX_CODE_SIZE),
+            GlobalConstants.MAX_CODE_SIZE),
         contractCreationProcessor,
         messageCallProcessor,
         true,


### PR DESCRIPTION
By looking at the `Exceptions` class I cannot see any change of state that's not through the `prepare` call  which is only called once. This leads me to believe that we don't need to create new `Exceptions` objects every time with `snapshot`.

Also `Exceptions` can only have 1 boolean true at once, by looking at `prepare` so an `Enum` is the most suitable data structure for this case.