### PR TITLE
Feat: Optimise Trace Generation (except hub)

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.add;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -106,11 +105,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc1.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -125,11 +130,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc2.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -144,11 +155,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -163,11 +180,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -182,11 +205,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg2Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg2Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg2Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg2Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -201,11 +230,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -292,11 +327,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("resHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { resHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      resHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -311,11 +352,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("resLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { resLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      resLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -327,12 +374,13 @@ public class Trace {
       filled.set(14);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+    }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));
     stamp.put((byte) b);
-
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.add;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -52,21 +53,21 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("add.ACC_1", 32, length),
-        new ColumnHeader("add.ACC_2", 32, length),
-        new ColumnHeader("add.ARG_1_HI", 32, length),
-        new ColumnHeader("add.ARG_1_LO", 32, length),
-        new ColumnHeader("add.ARG_2_HI", 32, length),
-        new ColumnHeader("add.ARG_2_LO", 32, length),
+        new ColumnHeader("add.ACC_1", 16, length),
+        new ColumnHeader("add.ACC_2", 16, length),
+        new ColumnHeader("add.ARG_1_HI", 16, length),
+        new ColumnHeader("add.ARG_1_LO", 16, length),
+        new ColumnHeader("add.ARG_2_HI", 16, length),
+        new ColumnHeader("add.ARG_2_LO", 16, length),
         new ColumnHeader("add.BYTE_1", 1, length),
         new ColumnHeader("add.BYTE_2", 1, length),
         new ColumnHeader("add.CT", 1, length),
         new ColumnHeader("add.CT_MAX", 1, length),
         new ColumnHeader("add.INST", 1, length),
         new ColumnHeader("add.OVERFLOW", 1, length),
-        new ColumnHeader("add.RES_HI", 32, length),
-        new ColumnHeader("add.RES_LO", 32, length),
-        new ColumnHeader("add.STAMP", 8, length));
+        new ColumnHeader("add.RES_HI", 16, length),
+        new ColumnHeader("add.RES_LO", 16, length),
+        new ColumnHeader("add.STAMP", 4, length));
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -102,11 +103,14 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc1.put((byte) 0);
-    }
-    acc1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
 
     return this;
   }
@@ -118,11 +122,14 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc2.put((byte) 0);
-    }
-    acc2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
 
     return this;
   }
@@ -134,11 +141,14 @@ public class Trace {
       filled.set(2);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg1Hi.put((byte) 0);
-    }
-    arg1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -150,11 +160,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg1Lo.put((byte) 0);
-    }
-    arg1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -166,11 +179,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg2Hi.put((byte) 0);
-    }
-    arg2Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg2Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg2Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -182,11 +198,14 @@ public class Trace {
       filled.set(5);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg2Lo.put((byte) 0);
-    }
-    arg2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -270,11 +289,14 @@ public class Trace {
       filled.set(12);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resHi.put((byte) 0);
-    }
-    resHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { resHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resHi.put(bs.get(j)); }
 
     return this;
   }
@@ -286,11 +308,14 @@ public class Trace {
       filled.set(13);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resLo.put((byte) 0);
-    }
-    resLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { resLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resLo.put(bs.get(j)); }
 
     return this;
   }
@@ -302,7 +327,12 @@ public class Trace {
       filled.set(14);
     }
 
-    stamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    stamp.put((byte) (b >> 24));
+    stamp.put((byte) (b >> 16));
+    stamp.put((byte) (b >> 8));
+    stamp.put((byte) b);
+
 
     return this;
   }
@@ -376,27 +406,27 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      acc1.position(acc1.position() + 32);
+      acc1.position(acc1.position() + 16);
     }
 
     if (!filled.get(1)) {
-      acc2.position(acc2.position() + 32);
+      acc2.position(acc2.position() + 16);
     }
 
     if (!filled.get(2)) {
-      arg1Hi.position(arg1Hi.position() + 32);
+      arg1Hi.position(arg1Hi.position() + 16);
     }
 
     if (!filled.get(3)) {
-      arg1Lo.position(arg1Lo.position() + 32);
+      arg1Lo.position(arg1Lo.position() + 16);
     }
 
     if (!filled.get(4)) {
-      arg2Hi.position(arg2Hi.position() + 32);
+      arg2Hi.position(arg2Hi.position() + 16);
     }
 
     if (!filled.get(5)) {
-      arg2Lo.position(arg2Lo.position() + 32);
+      arg2Lo.position(arg2Lo.position() + 16);
     }
 
     if (!filled.get(6)) {
@@ -424,15 +454,15 @@ public class Trace {
     }
 
     if (!filled.get(12)) {
-      resHi.position(resHi.position() + 32);
+      resHi.position(resHi.position() + 16);
     }
 
     if (!filled.get(13)) {
-      resLo.position(resLo.position() + 32);
+      resLo.position(resLo.position() + 16);
     }
 
     if (!filled.get(14)) {
-      stamp.position(stamp.position() + 8);
+      stamp.position(stamp.position() + 4);
     }
 
     filled.clear();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/bin/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/bin/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.bin;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -172,11 +171,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc1.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -191,11 +196,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc2.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -210,11 +221,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc3.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -229,11 +246,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc4.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -248,11 +271,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc5 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc5 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc5.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc5.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc5.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc5.put(bs.get(j));
+    }
 
     return this;
   }
@@ -267,11 +296,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc6 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc6 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc6.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc6.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc6.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc6.put(bs.get(j));
+    }
 
     return this;
   }
@@ -286,11 +321,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "argument1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { argument1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      argument1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { argument1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      argument1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -305,11 +347,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "argument1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { argument1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      argument1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { argument1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      argument1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -324,11 +373,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument2Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "argument2Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { argument2Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      argument2Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { argument2Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      argument2Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -343,11 +399,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "argument2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { argument2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      argument2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { argument2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      argument2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -614,11 +677,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resultHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("resultHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { resultHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      resultHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resultHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resultHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -633,11 +702,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resultLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("resultLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { resultLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      resultLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resultLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resultLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -661,12 +736,13 @@ public class Trace {
       filled.set(34);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+    }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));
     stamp.put((byte) b);
-
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/bin/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/bin/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.bin;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -74,16 +75,16 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("bin.ACC_1", 32, length),
-        new ColumnHeader("bin.ACC_2", 32, length),
-        new ColumnHeader("bin.ACC_3", 32, length),
-        new ColumnHeader("bin.ACC_4", 32, length),
-        new ColumnHeader("bin.ACC_5", 32, length),
-        new ColumnHeader("bin.ACC_6", 32, length),
-        new ColumnHeader("bin.ARGUMENT_1_HI", 32, length),
-        new ColumnHeader("bin.ARGUMENT_1_LO", 32, length),
-        new ColumnHeader("bin.ARGUMENT_2_HI", 32, length),
-        new ColumnHeader("bin.ARGUMENT_2_LO", 32, length),
+        new ColumnHeader("bin.ACC_1", 16, length),
+        new ColumnHeader("bin.ACC_2", 16, length),
+        new ColumnHeader("bin.ACC_3", 16, length),
+        new ColumnHeader("bin.ACC_4", 16, length),
+        new ColumnHeader("bin.ACC_5", 16, length),
+        new ColumnHeader("bin.ACC_6", 16, length),
+        new ColumnHeader("bin.ARGUMENT_1_HI", 16, length),
+        new ColumnHeader("bin.ARGUMENT_1_LO", 16, length),
+        new ColumnHeader("bin.ARGUMENT_2_HI", 16, length),
+        new ColumnHeader("bin.ARGUMENT_2_LO", 16, length),
         new ColumnHeader("bin.BIT_1", 1, length),
         new ColumnHeader("bin.BIT_B_4", 1, length),
         new ColumnHeader("bin.BITS", 1, length),
@@ -105,10 +106,10 @@ public class Trace {
         new ColumnHeader("bin.LOW_4", 1, length),
         new ColumnHeader("bin.NEG", 1, length),
         new ColumnHeader("bin.PIVOT", 1, length),
-        new ColumnHeader("bin.RESULT_HI", 32, length),
-        new ColumnHeader("bin.RESULT_LO", 32, length),
+        new ColumnHeader("bin.RESULT_HI", 16, length),
+        new ColumnHeader("bin.RESULT_LO", 16, length),
         new ColumnHeader("bin.SMALL", 1, length),
-        new ColumnHeader("bin.STAMP", 8, length),
+        new ColumnHeader("bin.STAMP", 4, length),
         new ColumnHeader("bin.XXX_BYTE_HI", 1, length),
         new ColumnHeader("bin.XXX_BYTE_LO", 1, length));
   }
@@ -168,11 +169,14 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc1.put((byte) 0);
-    }
-    acc1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
 
     return this;
   }
@@ -184,11 +188,14 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc2.put((byte) 0);
-    }
-    acc2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
 
     return this;
   }
@@ -200,11 +207,14 @@ public class Trace {
       filled.set(2);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc3.put((byte) 0);
-    }
-    acc3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc3.put(bs.get(j)); }
 
     return this;
   }
@@ -216,11 +226,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc4.put((byte) 0);
-    }
-    acc4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc4.put(bs.get(j)); }
 
     return this;
   }
@@ -232,11 +245,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc5.put((byte) 0);
-    }
-    acc5.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc5 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc5.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc5.put(bs.get(j)); }
 
     return this;
   }
@@ -248,11 +264,14 @@ public class Trace {
       filled.set(5);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc6.put((byte) 0);
-    }
-    acc6.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc6 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc6.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc6.put(bs.get(j)); }
 
     return this;
   }
@@ -264,11 +283,14 @@ public class Trace {
       filled.set(6);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      argument1Hi.put((byte) 0);
-    }
-    argument1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { argument1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { argument1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -280,11 +302,14 @@ public class Trace {
       filled.set(7);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      argument1Lo.put((byte) 0);
-    }
-    argument1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { argument1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { argument1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -296,11 +321,14 @@ public class Trace {
       filled.set(8);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      argument2Hi.put((byte) 0);
-    }
-    argument2Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument2Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { argument2Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { argument2Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -312,11 +340,14 @@ public class Trace {
       filled.set(9);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      argument2Lo.put((byte) 0);
-    }
-    argument2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { argument2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { argument2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -580,11 +611,14 @@ public class Trace {
       filled.set(31);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resultHi.put((byte) 0);
-    }
-    resultHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resultHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { resultHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resultHi.put(bs.get(j)); }
 
     return this;
   }
@@ -596,11 +630,14 @@ public class Trace {
       filled.set(32);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resultLo.put((byte) 0);
-    }
-    resultLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resultLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { resultLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resultLo.put(bs.get(j)); }
 
     return this;
   }
@@ -624,7 +661,12 @@ public class Trace {
       filled.set(34);
     }
 
-    stamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    stamp.put((byte) (b >> 24));
+    stamp.put((byte) (b >> 16));
+    stamp.put((byte) (b >> 8));
+    stamp.put((byte) b);
+
 
     return this;
   }
@@ -810,43 +852,43 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      acc1.position(acc1.position() + 32);
+      acc1.position(acc1.position() + 16);
     }
 
     if (!filled.get(1)) {
-      acc2.position(acc2.position() + 32);
+      acc2.position(acc2.position() + 16);
     }
 
     if (!filled.get(2)) {
-      acc3.position(acc3.position() + 32);
+      acc3.position(acc3.position() + 16);
     }
 
     if (!filled.get(3)) {
-      acc4.position(acc4.position() + 32);
+      acc4.position(acc4.position() + 16);
     }
 
     if (!filled.get(4)) {
-      acc5.position(acc5.position() + 32);
+      acc5.position(acc5.position() + 16);
     }
 
     if (!filled.get(5)) {
-      acc6.position(acc6.position() + 32);
+      acc6.position(acc6.position() + 16);
     }
 
     if (!filled.get(6)) {
-      argument1Hi.position(argument1Hi.position() + 32);
+      argument1Hi.position(argument1Hi.position() + 16);
     }
 
     if (!filled.get(7)) {
-      argument1Lo.position(argument1Lo.position() + 32);
+      argument1Lo.position(argument1Lo.position() + 16);
     }
 
     if (!filled.get(8)) {
-      argument2Hi.position(argument2Hi.position() + 32);
+      argument2Hi.position(argument2Hi.position() + 16);
     }
 
     if (!filled.get(9)) {
-      argument2Lo.position(argument2Lo.position() + 32);
+      argument2Lo.position(argument2Lo.position() + 16);
     }
 
     if (!filled.get(11)) {
@@ -934,11 +976,11 @@ public class Trace {
     }
 
     if (!filled.get(31)) {
-      resultHi.position(resultHi.position() + 32);
+      resultHi.position(resultHi.position() + 16);
     }
 
     if (!filled.get(32)) {
-      resultLo.position(resultLo.position() + 32);
+      resultLo.position(resultLo.position() + 16);
     }
 
     if (!filled.get(33)) {
@@ -946,7 +988,7 @@ public class Trace {
     }
 
     if (!filled.get(34)) {
-      stamp.position(stamp.position() + 8);
+      stamp.position(stamp.position() + 4);
     }
 
     if (!filled.get(35)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.blake2fmodexpdata;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -58,7 +59,7 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("blake2fmodexpdata.ID", 8, length),
+        new ColumnHeader("blake2fmodexpdata.ID", 6, length),
         new ColumnHeader("blake2fmodexpdata.INDEX", 1, length),
         new ColumnHeader("blake2fmodexpdata.INDEX_MAX", 1, length),
         new ColumnHeader("blake2fmodexpdata.IS_BLAKE_DATA", 1, length),
@@ -68,7 +69,7 @@ public class Trace {
         new ColumnHeader("blake2fmodexpdata.IS_MODEXP_EXPONENT", 1, length),
         new ColumnHeader("blake2fmodexpdata.IS_MODEXP_MODULUS", 1, length),
         new ColumnHeader("blake2fmodexpdata.IS_MODEXP_RESULT", 1, length),
-        new ColumnHeader("blake2fmodexpdata.LIMB", 32, length),
+        new ColumnHeader("blake2fmodexpdata.LIMB", 16, length),
         new ColumnHeader("blake2fmodexpdata.PHASE", 1, length),
         new ColumnHeader("blake2fmodexpdata.STAMP", 1, length));
   }
@@ -104,7 +105,14 @@ public class Trace {
       filled.set(0);
     }
 
-    id.putLong(b);
+    if(b >= 281474976710656L) { throw new IllegalArgumentException("id has invalid value (" + b + ")"); }
+    id.put((byte) (b >> 40));
+    id.put((byte) (b >> 32));
+    id.put((byte) (b >> 24));
+    id.put((byte) (b >> 16));
+    id.put((byte) (b >> 8));
+    id.put((byte) b);
+
 
     return this;
   }
@@ -224,11 +232,14 @@ public class Trace {
       filled.set(10);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      limb.put((byte) 0);
-    }
-    limb.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
 
     return this;
   }
@@ -318,7 +329,7 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      id.position(id.position() + 8);
+      id.position(id.position() + 6);
     }
 
     if (!filled.get(1)) {
@@ -358,7 +369,7 @@ public class Trace {
     }
 
     if (!filled.get(10)) {
-      limb.position(limb.position() + 32);
+      limb.position(limb.position() + 16);
     }
 
     if (!filled.get(11)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.blake2fmodexpdata;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -105,14 +104,15 @@ public class Trace {
       filled.set(0);
     }
 
-    if(b >= 281474976710656L) { throw new IllegalArgumentException("id has invalid value (" + b + ")"); }
+    if (b >= 281474976710656L) {
+      throw new IllegalArgumentException("id has invalid value (" + b + ")");
+    }
     id.put((byte) (b >> 40));
     id.put((byte) (b >> 32));
     id.put((byte) (b >> 24));
     id.put((byte) (b >> 16));
     id.put((byte) (b >> 8));
     id.put((byte) b);
-
 
     return this;
   }
@@ -235,11 +235,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      limb.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      limb.put(bs.get(j));
+    }
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.blockdata;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -89,8 +90,8 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("blockdata.BASEFEE", 8, length),
-        new ColumnHeader("blockdata.BLOCK_GAS_LIMIT", 8, length),
+        new ColumnHeader("blockdata.BASEFEE", 6, length),
+        new ColumnHeader("blockdata.BLOCK_GAS_LIMIT", 6, length),
         new ColumnHeader("blockdata.BYTE_HI_0", 1, length),
         new ColumnHeader("blockdata.BYTE_HI_1", 1, length),
         new ColumnHeader("blockdata.BYTE_HI_10", 1, length),
@@ -123,15 +124,15 @@ public class Trace {
         new ColumnHeader("blockdata.BYTE_LO_7", 1, length),
         new ColumnHeader("blockdata.BYTE_LO_8", 1, length),
         new ColumnHeader("blockdata.BYTE_LO_9", 1, length),
-        new ColumnHeader("blockdata.COINBASE_HI", 8, length),
-        new ColumnHeader("blockdata.COINBASE_LO", 32, length),
-        new ColumnHeader("blockdata.CT", 2, length),
-        new ColumnHeader("blockdata.DATA_HI", 32, length),
-        new ColumnHeader("blockdata.DATA_LO", 32, length),
-        new ColumnHeader("blockdata.FIRST_BLOCK_NUMBER", 8, length),
+        new ColumnHeader("blockdata.COINBASE_HI", 4, length),
+        new ColumnHeader("blockdata.COINBASE_LO", 16, length),
+        new ColumnHeader("blockdata.CT", 1, length),
+        new ColumnHeader("blockdata.DATA_HI", 16, length),
+        new ColumnHeader("blockdata.DATA_LO", 16, length),
+        new ColumnHeader("blockdata.FIRST_BLOCK_NUMBER", 6, length),
         new ColumnHeader("blockdata.INST", 1, length),
-        new ColumnHeader("blockdata.REL_BLOCK", 2, length),
-        new ColumnHeader("blockdata.REL_TX_NUM_MAX", 2, length),
+        new ColumnHeader("blockdata.REL_BLOCK", 1, length),
+        new ColumnHeader("blockdata.REL_TX_NUM_MAX", 1, length),
         new ColumnHeader("blockdata.WCP_FLAG", 1, length));
   }
 
@@ -197,7 +198,14 @@ public class Trace {
       filled.set(0);
     }
 
-    basefee.putLong(b);
+    if(b >= 281474976710656L) { throw new IllegalArgumentException("basefee has invalid value (" + b + ")"); }
+    basefee.put((byte) (b >> 40));
+    basefee.put((byte) (b >> 32));
+    basefee.put((byte) (b >> 24));
+    basefee.put((byte) (b >> 16));
+    basefee.put((byte) (b >> 8));
+    basefee.put((byte) b);
+
 
     return this;
   }
@@ -209,7 +217,14 @@ public class Trace {
       filled.set(1);
     }
 
-    blockGasLimit.putLong(b);
+    if(b >= 281474976710656L) { throw new IllegalArgumentException("blockGasLimit has invalid value (" + b + ")"); }
+    blockGasLimit.put((byte) (b >> 40));
+    blockGasLimit.put((byte) (b >> 32));
+    blockGasLimit.put((byte) (b >> 24));
+    blockGasLimit.put((byte) (b >> 16));
+    blockGasLimit.put((byte) (b >> 8));
+    blockGasLimit.put((byte) b);
+
 
     return this;
   }
@@ -605,7 +620,12 @@ public class Trace {
       filled.set(34);
     }
 
-    coinbaseHi.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("coinbaseHi has invalid value (" + b + ")"); }
+    coinbaseHi.put((byte) (b >> 24));
+    coinbaseHi.put((byte) (b >> 16));
+    coinbaseHi.put((byte) (b >> 8));
+    coinbaseHi.put((byte) b);
+
 
     return this;
   }
@@ -617,23 +637,28 @@ public class Trace {
       filled.set(35);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      coinbaseLo.put((byte) 0);
-    }
-    coinbaseLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("coinbaseLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { coinbaseLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { coinbaseLo.put(bs.get(j)); }
 
     return this;
   }
 
-  public Trace ct(final short b) {
+  public Trace ct(final long b) {
     if (filled.get(36)) {
       throw new IllegalStateException("blockdata.CT already set");
     } else {
       filled.set(36);
     }
 
-    ct.putShort(b);
+    if(b >= 16L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    ct.put((byte) b);
+
 
     return this;
   }
@@ -645,11 +670,14 @@ public class Trace {
       filled.set(37);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      dataHi.put((byte) 0);
-    }
-    dataHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("dataHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { dataHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { dataHi.put(bs.get(j)); }
 
     return this;
   }
@@ -661,11 +689,14 @@ public class Trace {
       filled.set(38);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      dataLo.put((byte) 0);
-    }
-    dataLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("dataLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { dataLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { dataLo.put(bs.get(j)); }
 
     return this;
   }
@@ -677,7 +708,14 @@ public class Trace {
       filled.set(39);
     }
 
-    firstBlockNumber.putLong(b);
+    if(b >= 281474976710656L) { throw new IllegalArgumentException("firstBlockNumber has invalid value (" + b + ")"); }
+    firstBlockNumber.put((byte) (b >> 40));
+    firstBlockNumber.put((byte) (b >> 32));
+    firstBlockNumber.put((byte) (b >> 24));
+    firstBlockNumber.put((byte) (b >> 16));
+    firstBlockNumber.put((byte) (b >> 8));
+    firstBlockNumber.put((byte) b);
+
 
     return this;
   }
@@ -694,26 +732,30 @@ public class Trace {
     return this;
   }
 
-  public Trace relBlock(final short b) {
+  public Trace relBlock(final long b) {
     if (filled.get(41)) {
       throw new IllegalStateException("blockdata.REL_BLOCK already set");
     } else {
       filled.set(41);
     }
 
-    relBlock.putShort(b);
+    if(b >= 256L) { throw new IllegalArgumentException("relBlock has invalid value (" + b + ")"); }
+    relBlock.put((byte) b);
+
 
     return this;
   }
 
-  public Trace relTxNumMax(final short b) {
+  public Trace relTxNumMax(final long b) {
     if (filled.get(42)) {
       throw new IllegalStateException("blockdata.REL_TX_NUM_MAX already set");
     } else {
       filled.set(42);
     }
 
-    relTxNumMax.putShort(b);
+    if(b >= 256L) { throw new IllegalArgumentException("relTxNumMax has invalid value (" + b + ")"); }
+    relTxNumMax.put((byte) b);
+
 
     return this;
   }
@@ -915,11 +957,11 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      basefee.position(basefee.position() + 8);
+      basefee.position(basefee.position() + 6);
     }
 
     if (!filled.get(1)) {
-      blockGasLimit.position(blockGasLimit.position() + 8);
+      blockGasLimit.position(blockGasLimit.position() + 6);
     }
 
     if (!filled.get(2)) {
@@ -1051,27 +1093,27 @@ public class Trace {
     }
 
     if (!filled.get(34)) {
-      coinbaseHi.position(coinbaseHi.position() + 8);
+      coinbaseHi.position(coinbaseHi.position() + 4);
     }
 
     if (!filled.get(35)) {
-      coinbaseLo.position(coinbaseLo.position() + 32);
+      coinbaseLo.position(coinbaseLo.position() + 16);
     }
 
     if (!filled.get(36)) {
-      ct.position(ct.position() + 2);
+      ct.position(ct.position() + 1);
     }
 
     if (!filled.get(37)) {
-      dataHi.position(dataHi.position() + 32);
+      dataHi.position(dataHi.position() + 16);
     }
 
     if (!filled.get(38)) {
-      dataLo.position(dataLo.position() + 32);
+      dataLo.position(dataLo.position() + 16);
     }
 
     if (!filled.get(39)) {
-      firstBlockNumber.position(firstBlockNumber.position() + 8);
+      firstBlockNumber.position(firstBlockNumber.position() + 6);
     }
 
     if (!filled.get(40)) {
@@ -1079,11 +1121,11 @@ public class Trace {
     }
 
     if (!filled.get(41)) {
-      relBlock.position(relBlock.position() + 2);
+      relBlock.position(relBlock.position() + 1);
     }
 
     if (!filled.get(42)) {
-      relTxNumMax.position(relTxNumMax.position() + 2);
+      relTxNumMax.position(relTxNumMax.position() + 1);
     }
 
     if (!filled.get(43)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.blockdata;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -198,14 +197,15 @@ public class Trace {
       filled.set(0);
     }
 
-    if(b >= 281474976710656L) { throw new IllegalArgumentException("basefee has invalid value (" + b + ")"); }
+    if (b >= 281474976710656L) {
+      throw new IllegalArgumentException("basefee has invalid value (" + b + ")");
+    }
     basefee.put((byte) (b >> 40));
     basefee.put((byte) (b >> 32));
     basefee.put((byte) (b >> 24));
     basefee.put((byte) (b >> 16));
     basefee.put((byte) (b >> 8));
     basefee.put((byte) b);
-
 
     return this;
   }
@@ -217,14 +217,15 @@ public class Trace {
       filled.set(1);
     }
 
-    if(b >= 281474976710656L) { throw new IllegalArgumentException("blockGasLimit has invalid value (" + b + ")"); }
+    if (b >= 281474976710656L) {
+      throw new IllegalArgumentException("blockGasLimit has invalid value (" + b + ")");
+    }
     blockGasLimit.put((byte) (b >> 40));
     blockGasLimit.put((byte) (b >> 32));
     blockGasLimit.put((byte) (b >> 24));
     blockGasLimit.put((byte) (b >> 16));
     blockGasLimit.put((byte) (b >> 8));
     blockGasLimit.put((byte) b);
-
 
     return this;
   }
@@ -620,12 +621,13 @@ public class Trace {
       filled.set(34);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("coinbaseHi has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("coinbaseHi has invalid value (" + b + ")");
+    }
     coinbaseHi.put((byte) (b >> 24));
     coinbaseHi.put((byte) (b >> 16));
     coinbaseHi.put((byte) (b >> 8));
     coinbaseHi.put((byte) b);
-
 
     return this;
   }
@@ -640,11 +642,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("coinbaseLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "coinbaseLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { coinbaseLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      coinbaseLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { coinbaseLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      coinbaseLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -656,9 +665,10 @@ public class Trace {
       filled.set(36);
     }
 
-    if(b >= 16L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    if (b >= 16L) {
+      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+    }
     ct.put((byte) b);
-
 
     return this;
   }
@@ -673,11 +683,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("dataHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("dataHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { dataHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      dataHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { dataHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      dataHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -692,11 +708,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("dataLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("dataLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { dataLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      dataLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { dataLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      dataLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -708,14 +730,15 @@ public class Trace {
       filled.set(39);
     }
 
-    if(b >= 281474976710656L) { throw new IllegalArgumentException("firstBlockNumber has invalid value (" + b + ")"); }
+    if (b >= 281474976710656L) {
+      throw new IllegalArgumentException("firstBlockNumber has invalid value (" + b + ")");
+    }
     firstBlockNumber.put((byte) (b >> 40));
     firstBlockNumber.put((byte) (b >> 32));
     firstBlockNumber.put((byte) (b >> 24));
     firstBlockNumber.put((byte) (b >> 16));
     firstBlockNumber.put((byte) (b >> 8));
     firstBlockNumber.put((byte) b);
-
 
     return this;
   }
@@ -739,9 +762,10 @@ public class Trace {
       filled.set(41);
     }
 
-    if(b >= 256L) { throw new IllegalArgumentException("relBlock has invalid value (" + b + ")"); }
+    if (b >= 256L) {
+      throw new IllegalArgumentException("relBlock has invalid value (" + b + ")");
+    }
     relBlock.put((byte) b);
-
 
     return this;
   }
@@ -753,9 +777,10 @@ public class Trace {
       filled.set(42);
     }
 
-    if(b >= 256L) { throw new IllegalArgumentException("relTxNumMax has invalid value (" + b + ")"); }
+    if (b >= 256L) {
+      throw new IllegalArgumentException("relTxNumMax has invalid value (" + b + ")");
+    }
     relTxNumMax.put((byte) b);
-
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.blockhash;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -81,11 +82,11 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("blockhash.ABS_BLOCK", 8, length),
-        new ColumnHeader("blockhash.BLOCK_HASH_HI", 32, length),
-        new ColumnHeader("blockhash.BLOCK_HASH_LO", 32, length),
-        new ColumnHeader("blockhash.BLOCK_NUMBER_HI", 32, length),
-        new ColumnHeader("blockhash.BLOCK_NUMBER_LO", 32, length),
+        new ColumnHeader("blockhash.ABS_BLOCK", 6, length),
+        new ColumnHeader("blockhash.BLOCK_HASH_HI", 16, length),
+        new ColumnHeader("blockhash.BLOCK_HASH_LO", 16, length),
+        new ColumnHeader("blockhash.BLOCK_NUMBER_HI", 16, length),
+        new ColumnHeader("blockhash.BLOCK_NUMBER_LO", 16, length),
         new ColumnHeader("blockhash.BYTE_HI_0", 1, length),
         new ColumnHeader("blockhash.BYTE_HI_1", 1, length),
         new ColumnHeader("blockhash.BYTE_HI_10", 1, length),
@@ -121,9 +122,9 @@ public class Trace {
         new ColumnHeader("blockhash.IN_RANGE", 1, length),
         new ColumnHeader("blockhash.IOMF", 1, length),
         new ColumnHeader("blockhash.LOWER_BOUND_CHECK", 1, length),
-        new ColumnHeader("blockhash.REL_BLOCK", 2, length),
-        new ColumnHeader("blockhash.RES_HI", 32, length),
-        new ColumnHeader("blockhash.RES_LO", 32, length),
+        new ColumnHeader("blockhash.REL_BLOCK", 1, length),
+        new ColumnHeader("blockhash.RES_HI", 16, length),
+        new ColumnHeader("blockhash.RES_LO", 16, length),
         new ColumnHeader("blockhash.UPPER_BOUND_CHECK", 1, length));
   }
 
@@ -189,7 +190,14 @@ public class Trace {
       filled.set(0);
     }
 
-    absBlock.putLong(b);
+    if(b >= 281474976710656L) { throw new IllegalArgumentException("absBlock has invalid value (" + b + ")"); }
+    absBlock.put((byte) (b >> 40));
+    absBlock.put((byte) (b >> 32));
+    absBlock.put((byte) (b >> 24));
+    absBlock.put((byte) (b >> 16));
+    absBlock.put((byte) (b >> 8));
+    absBlock.put((byte) b);
+
 
     return this;
   }
@@ -201,11 +209,14 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      blockHashHi.put((byte) 0);
-    }
-    blockHashHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("blockHashHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { blockHashHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { blockHashHi.put(bs.get(j)); }
 
     return this;
   }
@@ -217,11 +228,14 @@ public class Trace {
       filled.set(2);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      blockHashLo.put((byte) 0);
-    }
-    blockHashLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("blockHashLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { blockHashLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { blockHashLo.put(bs.get(j)); }
 
     return this;
   }
@@ -233,11 +247,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      blockNumberHi.put((byte) 0);
-    }
-    blockNumberHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("blockNumberHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { blockNumberHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { blockNumberHi.put(bs.get(j)); }
 
     return this;
   }
@@ -249,11 +266,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      blockNumberLo.put((byte) 0);
-    }
-    blockNumberLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("blockNumberLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { blockNumberLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { blockNumberLo.put(bs.get(j)); }
 
     return this;
   }
@@ -678,14 +698,16 @@ public class Trace {
     return this;
   }
 
-  public Trace relBlock(final short b) {
+  public Trace relBlock(final long b) {
     if (filled.get(40)) {
       throw new IllegalStateException("blockhash.REL_BLOCK already set");
     } else {
       filled.set(40);
     }
 
-    relBlock.putShort(b);
+    if(b >= 256L) { throw new IllegalArgumentException("relBlock has invalid value (" + b + ")"); }
+    relBlock.put((byte) b);
+
 
     return this;
   }
@@ -697,11 +719,14 @@ public class Trace {
       filled.set(41);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resHi.put((byte) 0);
-    }
-    resHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { resHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resHi.put(bs.get(j)); }
 
     return this;
   }
@@ -713,11 +738,14 @@ public class Trace {
       filled.set(42);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resLo.put((byte) 0);
-    }
-    resLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { resLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resLo.put(bs.get(j)); }
 
     return this;
   }
@@ -919,23 +947,23 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      absBlock.position(absBlock.position() + 8);
+      absBlock.position(absBlock.position() + 6);
     }
 
     if (!filled.get(1)) {
-      blockHashHi.position(blockHashHi.position() + 32);
+      blockHashHi.position(blockHashHi.position() + 16);
     }
 
     if (!filled.get(2)) {
-      blockHashLo.position(blockHashLo.position() + 32);
+      blockHashLo.position(blockHashLo.position() + 16);
     }
 
     if (!filled.get(3)) {
-      blockNumberHi.position(blockNumberHi.position() + 32);
+      blockNumberHi.position(blockNumberHi.position() + 16);
     }
 
     if (!filled.get(4)) {
-      blockNumberLo.position(blockNumberLo.position() + 32);
+      blockNumberLo.position(blockNumberLo.position() + 16);
     }
 
     if (!filled.get(5)) {
@@ -1079,15 +1107,15 @@ public class Trace {
     }
 
     if (!filled.get(40)) {
-      relBlock.position(relBlock.position() + 2);
+      relBlock.position(relBlock.position() + 1);
     }
 
     if (!filled.get(41)) {
-      resHi.position(resHi.position() + 32);
+      resHi.position(resHi.position() + 16);
     }
 
     if (!filled.get(42)) {
-      resLo.position(resLo.position() + 32);
+      resLo.position(resLo.position() + 16);
     }
 
     if (!filled.get(43)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.blockhash;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -190,14 +189,15 @@ public class Trace {
       filled.set(0);
     }
 
-    if(b >= 281474976710656L) { throw new IllegalArgumentException("absBlock has invalid value (" + b + ")"); }
+    if (b >= 281474976710656L) {
+      throw new IllegalArgumentException("absBlock has invalid value (" + b + ")");
+    }
     absBlock.put((byte) (b >> 40));
     absBlock.put((byte) (b >> 32));
     absBlock.put((byte) (b >> 24));
     absBlock.put((byte) (b >> 16));
     absBlock.put((byte) (b >> 8));
     absBlock.put((byte) b);
-
 
     return this;
   }
@@ -212,11 +212,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("blockHashHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "blockHashHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { blockHashHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      blockHashHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { blockHashHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      blockHashHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -231,11 +238,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("blockHashLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "blockHashLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { blockHashLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      blockHashLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { blockHashLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      blockHashLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -250,11 +264,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("blockNumberHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "blockNumberHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { blockNumberHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      blockNumberHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { blockNumberHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      blockNumberHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -269,11 +290,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("blockNumberLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "blockNumberLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { blockNumberLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      blockNumberLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { blockNumberLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      blockNumberLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -705,9 +733,10 @@ public class Trace {
       filled.set(40);
     }
 
-    if(b >= 256L) { throw new IllegalArgumentException("relBlock has invalid value (" + b + ")"); }
+    if (b >= 256L) {
+      throw new IllegalArgumentException("relBlock has invalid value (" + b + ")");
+    }
     relBlock.put((byte) b);
-
 
     return this;
   }
@@ -722,11 +751,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("resHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { resHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      resHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -741,11 +776,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("resLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { resLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      resLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resLo.put(bs.get(j));
+    }
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/Trace.java
@@ -48,9 +48,12 @@ public class Trace {
   public static final int INDEX_MAX_ECRECOVER_RESULT = 0x1;
   public static final int MULMOD = 0x9;
   public static final BigInteger P_BN_HI = new BigInteger("64323764613183177041862057485226039389");
-  public static final BigInteger P_BN_LO = new BigInteger("201385395114098847380338600778089168199");
-  public static final BigInteger SECP256K1N_HI = new BigInteger("340282366920938463463374607431768211455");
-  public static final BigInteger SECP256K1N_LO = new BigInteger("340282366920938463463374607427473243183");
+  public static final BigInteger P_BN_LO =
+      new BigInteger("201385395114098847380338600778089168199");
+  public static final BigInteger SECP256K1N_HI =
+      new BigInteger("340282366920938463463374607431768211455");
+  public static final BigInteger SECP256K1N_LO =
+      new BigInteger("340282366920938463463374607427473243183");
   public static final int TOTAL_SIZE_ECADD_DATA = 0x80;
   public static final int TOTAL_SIZE_ECADD_RESULT = 0x40;
   public static final int TOTAL_SIZE_ECMUL_DATA = 0x60;
@@ -251,18 +254,26 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accPairings has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "accPairings has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accPairings.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accPairings.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accPairings.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accPairings.put(bs.get(j));
+    }
 
     return this;
   }
 
   public Trace acceptablePairOfPointsForPairingCircuit(final Boolean b) {
     if (filled.get(0)) {
-      throw new IllegalStateException("ecdata.ACCEPTABLE_PAIR_OF_POINTS_FOR_PAIRING_CIRCUIT already set");
+      throw new IllegalStateException(
+          "ecdata.ACCEPTABLE_PAIR_OF_POINTS_FOR_PAIRING_CIRCUIT already set");
     } else {
       filled.set(0);
     }
@@ -351,9 +362,10 @@ public class Trace {
       filled.set(8);
     }
 
-    if(b >= 8L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    if (b >= 8L) {
+      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+    }
     ct.put((byte) b);
-
 
     return this;
   }
@@ -365,9 +377,10 @@ public class Trace {
       filled.set(9);
     }
 
-    if(b >= 8L) { throw new IllegalArgumentException("ctMax has invalid value (" + b + ")"); }
+    if (b >= 8L) {
+      throw new IllegalArgumentException("ctMax has invalid value (" + b + ")");
+    }
     ctMax.put((byte) b);
-
 
     return this;
   }
@@ -382,11 +395,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extArg1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "extArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { extArg1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      extArg1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { extArg1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      extArg1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -401,11 +421,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extArg1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "extArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { extArg1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      extArg1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { extArg1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      extArg1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -420,11 +447,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extArg2Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "extArg2Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { extArg2Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      extArg2Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { extArg2Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      extArg2Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -439,11 +473,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extArg2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "extArg2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { extArg2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      extArg2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { extArg2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      extArg2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -458,11 +499,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extArg3Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "extArg3Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { extArg3Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      extArg3Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { extArg3Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      extArg3Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -477,11 +525,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extArg3Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "extArg3Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { extArg3Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      extArg3Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { extArg3Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      extArg3Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -520,11 +575,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extResHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("extResHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { extResHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      extResHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { extResHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      extResHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -539,11 +600,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extResLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("extResLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { extResLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      extResLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { extResLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      extResLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -579,12 +646,13 @@ public class Trace {
       filled.set(22);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("id has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("id has invalid value (" + b + ")");
+    }
     id.put((byte) (b >> 24));
     id.put((byte) (b >> 16));
     id.put((byte) (b >> 8));
     id.put((byte) b);
-
 
     return this;
   }
@@ -611,11 +679,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("indexMax has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("indexMax has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { indexMax.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      indexMax.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { indexMax.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      indexMax.put(bs.get(j));
+    }
 
     return this;
   }
@@ -774,11 +848,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      limb.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      limb.put(bs.get(j));
+    }
 
     return this;
   }
@@ -838,10 +918,11 @@ public class Trace {
       filled.set(42);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("phase has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("phase has invalid value (" + b + ")");
+    }
     phase.put((byte) (b >> 8));
     phase.put((byte) b);
-
 
     return this;
   }
@@ -853,12 +934,13 @@ public class Trace {
       filled.set(43);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+    }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));
     stamp.put((byte) b);
-
 
     return this;
   }
@@ -885,11 +967,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("totalPairings has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "totalPairings has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { totalPairings.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      totalPairings.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { totalPairings.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      totalPairings.put(bs.get(j));
+    }
 
     return this;
   }
@@ -904,11 +993,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("totalSize has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "totalSize has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { totalSize.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      totalSize.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { totalSize.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      totalSize.put(bs.get(j));
+    }
 
     return this;
   }
@@ -923,11 +1019,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("wcpArg1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "wcpArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { wcpArg1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      wcpArg1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { wcpArg1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      wcpArg1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -942,11 +1045,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("wcpArg1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "wcpArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { wcpArg1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      wcpArg1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { wcpArg1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      wcpArg1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -961,11 +1071,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("wcpArg2Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "wcpArg2Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { wcpArg2Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      wcpArg2Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { wcpArg2Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      wcpArg2Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -980,11 +1097,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("wcpArg2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "wcpArg2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { wcpArg2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      wcpArg2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { wcpArg2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      wcpArg2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1031,7 +1155,8 @@ public class Trace {
     }
 
     if (!filled.get(0)) {
-      throw new IllegalStateException("ecdata.ACCEPTABLE_PAIR_OF_POINTS_FOR_PAIRING_CIRCUIT has not been filled");
+      throw new IllegalStateException(
+          "ecdata.ACCEPTABLE_PAIR_OF_POINTS_FOR_PAIRING_CIRCUIT has not been filled");
     }
 
     if (!filled.get(2)) {
@@ -1254,7 +1379,8 @@ public class Trace {
     }
 
     if (!filled.get(0)) {
-      acceptablePairOfPointsForPairingCircuit.position(acceptablePairOfPointsForPairingCircuit.position() + 1);
+      acceptablePairOfPointsForPairingCircuit.position(
+          acceptablePairOfPointsForPairingCircuit.position() + 1);
     }
 
     if (!filled.get(2)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/Trace.java
@@ -48,12 +48,9 @@ public class Trace {
   public static final int INDEX_MAX_ECRECOVER_RESULT = 0x1;
   public static final int MULMOD = 0x9;
   public static final BigInteger P_BN_HI = new BigInteger("64323764613183177041862057485226039389");
-  public static final BigInteger P_BN_LO =
-      new BigInteger("201385395114098847380338600778089168199");
-  public static final BigInteger SECP256K1N_HI =
-      new BigInteger("340282366920938463463374607431768211455");
-  public static final BigInteger SECP256K1N_LO =
-      new BigInteger("340282366920938463463374607427473243183");
+  public static final BigInteger P_BN_LO = new BigInteger("201385395114098847380338600778089168199");
+  public static final BigInteger SECP256K1N_HI = new BigInteger("340282366920938463463374607431768211455");
+  public static final BigInteger SECP256K1N_LO = new BigInteger("340282366920938463463374607427473243183");
   public static final int TOTAL_SIZE_ECADD_DATA = 0x80;
   public static final int TOTAL_SIZE_ECADD_RESULT = 0x40;
   public static final int TOTAL_SIZE_ECMUL_DATA = 0x60;
@@ -131,21 +128,21 @@ public class Trace {
         new ColumnHeader("ecdata.CIRCUIT_SELECTOR_ECPAIRING", 1, length),
         new ColumnHeader("ecdata.CIRCUIT_SELECTOR_ECRECOVER", 1, length),
         new ColumnHeader("ecdata.CIRCUIT_SELECTOR_G2_MEMBERSHIP", 1, length),
-        new ColumnHeader("ecdata.CT", 2, length),
-        new ColumnHeader("ecdata.CT_MAX", 2, length),
-        new ColumnHeader("ecdata.EXT_ARG1_HI", 32, length),
-        new ColumnHeader("ecdata.EXT_ARG1_LO", 32, length),
-        new ColumnHeader("ecdata.EXT_ARG2_HI", 32, length),
-        new ColumnHeader("ecdata.EXT_ARG2_LO", 32, length),
-        new ColumnHeader("ecdata.EXT_ARG3_HI", 32, length),
-        new ColumnHeader("ecdata.EXT_ARG3_LO", 32, length),
+        new ColumnHeader("ecdata.CT", 1, length),
+        new ColumnHeader("ecdata.CT_MAX", 1, length),
+        new ColumnHeader("ecdata.EXT_ARG1_HI", 16, length),
+        new ColumnHeader("ecdata.EXT_ARG1_LO", 16, length),
+        new ColumnHeader("ecdata.EXT_ARG2_HI", 16, length),
+        new ColumnHeader("ecdata.EXT_ARG2_LO", 16, length),
+        new ColumnHeader("ecdata.EXT_ARG3_HI", 16, length),
+        new ColumnHeader("ecdata.EXT_ARG3_LO", 16, length),
         new ColumnHeader("ecdata.EXT_FLAG", 1, length),
         new ColumnHeader("ecdata.EXT_INST", 1, length),
-        new ColumnHeader("ecdata.EXT_RES_HI", 32, length),
-        new ColumnHeader("ecdata.EXT_RES_LO", 32, length),
+        new ColumnHeader("ecdata.EXT_RES_HI", 16, length),
+        new ColumnHeader("ecdata.EXT_RES_LO", 16, length),
         new ColumnHeader("ecdata.G2_MEMBERSHIP_TEST_REQUIRED", 1, length),
         new ColumnHeader("ecdata.HURDLE", 1, length),
-        new ColumnHeader("ecdata.ID", 8, length),
+        new ColumnHeader("ecdata.ID", 4, length),
         new ColumnHeader("ecdata.INDEX", 1, length),
         new ColumnHeader("ecdata.INDEX_MAX", 32, length),
         new ColumnHeader("ecdata.INTERNAL_CHECKS_PASSED", 1, length),
@@ -160,20 +157,20 @@ public class Trace {
         new ColumnHeader("ecdata.IS_INFINITY", 1, length),
         new ColumnHeader("ecdata.IS_LARGE_POINT", 1, length),
         new ColumnHeader("ecdata.IS_SMALL_POINT", 1, length),
-        new ColumnHeader("ecdata.LIMB", 32, length),
+        new ColumnHeader("ecdata.LIMB", 16, length),
         new ColumnHeader("ecdata.NOT_ON_G2", 1, length),
         new ColumnHeader("ecdata.NOT_ON_G2_ACC", 1, length),
         new ColumnHeader("ecdata.NOT_ON_G2_ACC_MAX", 1, length),
         new ColumnHeader("ecdata.OVERALL_TRIVIAL_PAIRING", 1, length),
-        new ColumnHeader("ecdata.PHASE", 4, length),
-        new ColumnHeader("ecdata.STAMP", 8, length),
+        new ColumnHeader("ecdata.PHASE", 2, length),
+        new ColumnHeader("ecdata.STAMP", 4, length),
         new ColumnHeader("ecdata.SUCCESS_BIT", 1, length),
         new ColumnHeader("ecdata.TOTAL_PAIRINGS", 32, length),
         new ColumnHeader("ecdata.TOTAL_SIZE", 32, length),
-        new ColumnHeader("ecdata.WCP_ARG1_HI", 32, length),
-        new ColumnHeader("ecdata.WCP_ARG1_LO", 32, length),
-        new ColumnHeader("ecdata.WCP_ARG2_HI", 32, length),
-        new ColumnHeader("ecdata.WCP_ARG2_LO", 32, length),
+        new ColumnHeader("ecdata.WCP_ARG1_HI", 16, length),
+        new ColumnHeader("ecdata.WCP_ARG1_LO", 16, length),
+        new ColumnHeader("ecdata.WCP_ARG2_HI", 16, length),
+        new ColumnHeader("ecdata.WCP_ARG2_LO", 16, length),
         new ColumnHeader("ecdata.WCP_FLAG", 1, length),
         new ColumnHeader("ecdata.WCP_INST", 1, length),
         new ColumnHeader("ecdata.WCP_RES", 1, length));
@@ -251,19 +248,21 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accPairings.put((byte) 0);
-    }
-    accPairings.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accPairings has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accPairings.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accPairings.put(bs.get(j)); }
 
     return this;
   }
 
   public Trace acceptablePairOfPointsForPairingCircuit(final Boolean b) {
     if (filled.get(0)) {
-      throw new IllegalStateException(
-          "ecdata.ACCEPTABLE_PAIR_OF_POINTS_FOR_PAIRING_CIRCUIT already set");
+      throw new IllegalStateException("ecdata.ACCEPTABLE_PAIR_OF_POINTS_FOR_PAIRING_CIRCUIT already set");
     } else {
       filled.set(0);
     }
@@ -345,26 +344,30 @@ public class Trace {
     return this;
   }
 
-  public Trace ct(final short b) {
+  public Trace ct(final long b) {
     if (filled.get(8)) {
       throw new IllegalStateException("ecdata.CT already set");
     } else {
       filled.set(8);
     }
 
-    ct.putShort(b);
+    if(b >= 8L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    ct.put((byte) b);
+
 
     return this;
   }
 
-  public Trace ctMax(final short b) {
+  public Trace ctMax(final long b) {
     if (filled.get(9)) {
       throw new IllegalStateException("ecdata.CT_MAX already set");
     } else {
       filled.set(9);
     }
 
-    ctMax.putShort(b);
+    if(b >= 8L) { throw new IllegalArgumentException("ctMax has invalid value (" + b + ")"); }
+    ctMax.put((byte) b);
+
 
     return this;
   }
@@ -376,11 +379,14 @@ public class Trace {
       filled.set(10);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      extArg1Hi.put((byte) 0);
-    }
-    extArg1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extArg1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { extArg1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { extArg1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -392,11 +398,14 @@ public class Trace {
       filled.set(11);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      extArg1Lo.put((byte) 0);
-    }
-    extArg1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extArg1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { extArg1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { extArg1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -408,11 +417,14 @@ public class Trace {
       filled.set(12);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      extArg2Hi.put((byte) 0);
-    }
-    extArg2Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extArg2Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { extArg2Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { extArg2Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -424,11 +436,14 @@ public class Trace {
       filled.set(13);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      extArg2Lo.put((byte) 0);
-    }
-    extArg2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extArg2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { extArg2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { extArg2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -440,11 +455,14 @@ public class Trace {
       filled.set(14);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      extArg3Hi.put((byte) 0);
-    }
-    extArg3Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extArg3Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { extArg3Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { extArg3Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -456,11 +474,14 @@ public class Trace {
       filled.set(15);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      extArg3Lo.put((byte) 0);
-    }
-    extArg3Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extArg3Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { extArg3Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { extArg3Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -496,11 +517,14 @@ public class Trace {
       filled.set(18);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      extResHi.put((byte) 0);
-    }
-    extResHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extResHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { extResHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { extResHi.put(bs.get(j)); }
 
     return this;
   }
@@ -512,11 +536,14 @@ public class Trace {
       filled.set(19);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      extResLo.put((byte) 0);
-    }
-    extResLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("extResLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { extResLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { extResLo.put(bs.get(j)); }
 
     return this;
   }
@@ -552,7 +579,12 @@ public class Trace {
       filled.set(22);
     }
 
-    id.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("id has invalid value (" + b + ")"); }
+    id.put((byte) (b >> 24));
+    id.put((byte) (b >> 16));
+    id.put((byte) (b >> 8));
+    id.put((byte) b);
+
 
     return this;
   }
@@ -576,11 +608,14 @@ public class Trace {
       filled.set(24);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      indexMax.put((byte) 0);
-    }
-    indexMax.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("indexMax has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { indexMax.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { indexMax.put(bs.get(j)); }
 
     return this;
   }
@@ -736,11 +771,14 @@ public class Trace {
       filled.set(37);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      limb.put((byte) 0);
-    }
-    limb.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
 
     return this;
   }
@@ -793,14 +831,17 @@ public class Trace {
     return this;
   }
 
-  public Trace phase(final int b) {
+  public Trace phase(final long b) {
     if (filled.get(42)) {
       throw new IllegalStateException("ecdata.PHASE already set");
     } else {
       filled.set(42);
     }
 
-    phase.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("phase has invalid value (" + b + ")"); }
+    phase.put((byte) (b >> 8));
+    phase.put((byte) b);
+
 
     return this;
   }
@@ -812,7 +853,12 @@ public class Trace {
       filled.set(43);
     }
 
-    stamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    stamp.put((byte) (b >> 24));
+    stamp.put((byte) (b >> 16));
+    stamp.put((byte) (b >> 8));
+    stamp.put((byte) b);
+
 
     return this;
   }
@@ -836,11 +882,14 @@ public class Trace {
       filled.set(45);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      totalPairings.put((byte) 0);
-    }
-    totalPairings.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("totalPairings has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { totalPairings.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { totalPairings.put(bs.get(j)); }
 
     return this;
   }
@@ -852,11 +901,14 @@ public class Trace {
       filled.set(46);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      totalSize.put((byte) 0);
-    }
-    totalSize.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("totalSize has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { totalSize.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { totalSize.put(bs.get(j)); }
 
     return this;
   }
@@ -868,11 +920,14 @@ public class Trace {
       filled.set(47);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      wcpArg1Hi.put((byte) 0);
-    }
-    wcpArg1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("wcpArg1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { wcpArg1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { wcpArg1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -884,11 +939,14 @@ public class Trace {
       filled.set(48);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      wcpArg1Lo.put((byte) 0);
-    }
-    wcpArg1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("wcpArg1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { wcpArg1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { wcpArg1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -900,11 +958,14 @@ public class Trace {
       filled.set(49);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      wcpArg2Hi.put((byte) 0);
-    }
-    wcpArg2Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("wcpArg2Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { wcpArg2Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { wcpArg2Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -916,11 +977,14 @@ public class Trace {
       filled.set(50);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      wcpArg2Lo.put((byte) 0);
-    }
-    wcpArg2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("wcpArg2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { wcpArg2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { wcpArg2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -967,8 +1031,7 @@ public class Trace {
     }
 
     if (!filled.get(0)) {
-      throw new IllegalStateException(
-          "ecdata.ACCEPTABLE_PAIR_OF_POINTS_FOR_PAIRING_CIRCUIT has not been filled");
+      throw new IllegalStateException("ecdata.ACCEPTABLE_PAIR_OF_POINTS_FOR_PAIRING_CIRCUIT has not been filled");
     }
 
     if (!filled.get(2)) {
@@ -1191,8 +1254,7 @@ public class Trace {
     }
 
     if (!filled.get(0)) {
-      acceptablePairOfPointsForPairingCircuit.position(
-          acceptablePairOfPointsForPairingCircuit.position() + 1);
+      acceptablePairOfPointsForPairingCircuit.position(acceptablePairOfPointsForPairingCircuit.position() + 1);
     }
 
     if (!filled.get(2)) {
@@ -1220,35 +1282,35 @@ public class Trace {
     }
 
     if (!filled.get(8)) {
-      ct.position(ct.position() + 2);
+      ct.position(ct.position() + 1);
     }
 
     if (!filled.get(9)) {
-      ctMax.position(ctMax.position() + 2);
+      ctMax.position(ctMax.position() + 1);
     }
 
     if (!filled.get(10)) {
-      extArg1Hi.position(extArg1Hi.position() + 32);
+      extArg1Hi.position(extArg1Hi.position() + 16);
     }
 
     if (!filled.get(11)) {
-      extArg1Lo.position(extArg1Lo.position() + 32);
+      extArg1Lo.position(extArg1Lo.position() + 16);
     }
 
     if (!filled.get(12)) {
-      extArg2Hi.position(extArg2Hi.position() + 32);
+      extArg2Hi.position(extArg2Hi.position() + 16);
     }
 
     if (!filled.get(13)) {
-      extArg2Lo.position(extArg2Lo.position() + 32);
+      extArg2Lo.position(extArg2Lo.position() + 16);
     }
 
     if (!filled.get(14)) {
-      extArg3Hi.position(extArg3Hi.position() + 32);
+      extArg3Hi.position(extArg3Hi.position() + 16);
     }
 
     if (!filled.get(15)) {
-      extArg3Lo.position(extArg3Lo.position() + 32);
+      extArg3Lo.position(extArg3Lo.position() + 16);
     }
 
     if (!filled.get(16)) {
@@ -1260,11 +1322,11 @@ public class Trace {
     }
 
     if (!filled.get(18)) {
-      extResHi.position(extResHi.position() + 32);
+      extResHi.position(extResHi.position() + 16);
     }
 
     if (!filled.get(19)) {
-      extResLo.position(extResLo.position() + 32);
+      extResLo.position(extResLo.position() + 16);
     }
 
     if (!filled.get(20)) {
@@ -1276,7 +1338,7 @@ public class Trace {
     }
 
     if (!filled.get(22)) {
-      id.position(id.position() + 8);
+      id.position(id.position() + 4);
     }
 
     if (!filled.get(23)) {
@@ -1336,7 +1398,7 @@ public class Trace {
     }
 
     if (!filled.get(37)) {
-      limb.position(limb.position() + 32);
+      limb.position(limb.position() + 16);
     }
 
     if (!filled.get(38)) {
@@ -1356,11 +1418,11 @@ public class Trace {
     }
 
     if (!filled.get(42)) {
-      phase.position(phase.position() + 4);
+      phase.position(phase.position() + 2);
     }
 
     if (!filled.get(43)) {
-      stamp.position(stamp.position() + 8);
+      stamp.position(stamp.position() + 4);
     }
 
     if (!filled.get(44)) {
@@ -1376,19 +1438,19 @@ public class Trace {
     }
 
     if (!filled.get(47)) {
-      wcpArg1Hi.position(wcpArg1Hi.position() + 32);
+      wcpArg1Hi.position(wcpArg1Hi.position() + 16);
     }
 
     if (!filled.get(48)) {
-      wcpArg1Lo.position(wcpArg1Lo.position() + 32);
+      wcpArg1Lo.position(wcpArg1Lo.position() + 16);
     }
 
     if (!filled.get(49)) {
-      wcpArg2Hi.position(wcpArg2Hi.position() + 32);
+      wcpArg2Hi.position(wcpArg2Hi.position() + 16);
     }
 
     if (!filled.get(50)) {
-      wcpArg2Lo.position(wcpArg2Lo.position() + 32);
+      wcpArg2Lo.position(wcpArg2Lo.position() + 16);
     }
 
     if (!filled.get(51)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.euc;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -97,11 +96,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("ceil has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("ceil has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { ceil.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      ceil.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { ceil.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      ceil.put(bs.get(j));
+    }
 
     return this;
   }
@@ -113,9 +118,10 @@ public class Trace {
       filled.set(1);
     }
 
-    if(b >= 256L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    if (b >= 256L) {
+      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+    }
     ct.put((byte) b);
-
 
     return this;
   }
@@ -127,9 +133,10 @@ public class Trace {
       filled.set(2);
     }
 
-    if(b >= 256L) { throw new IllegalArgumentException("ctMax has invalid value (" + b + ")"); }
+    if (b >= 256L) {
+      throw new IllegalArgumentException("ctMax has invalid value (" + b + ")");
+    }
     ctMax.put((byte) b);
-
 
     return this;
   }
@@ -144,11 +151,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("dividend has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("dividend has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { dividend.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      dividend.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { dividend.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      dividend.put(bs.get(j));
+    }
 
     return this;
   }
@@ -163,11 +176,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("divisor has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("divisor has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { divisor.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      divisor.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { divisor.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      divisor.put(bs.get(j));
+    }
 
     return this;
   }
@@ -218,11 +237,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("quotient has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("quotient has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { quotient.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      quotient.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { quotient.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      quotient.put(bs.get(j));
+    }
 
     return this;
   }
@@ -249,11 +274,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("remainder has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "remainder has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { remainder.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      remainder.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { remainder.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      remainder.put(bs.get(j));
+    }
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.euc;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -49,17 +50,17 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("euc.CEIL", 32, length),
-        new ColumnHeader("euc.CT", 2, length),
-        new ColumnHeader("euc.CT_MAX", 2, length),
-        new ColumnHeader("euc.DIVIDEND", 32, length),
-        new ColumnHeader("euc.DIVISOR", 32, length),
+        new ColumnHeader("euc.CEIL", 8, length),
+        new ColumnHeader("euc.CT", 1, length),
+        new ColumnHeader("euc.CT_MAX", 1, length),
+        new ColumnHeader("euc.DIVIDEND", 8, length),
+        new ColumnHeader("euc.DIVISOR", 8, length),
         new ColumnHeader("euc.DIVISOR_BYTE", 1, length),
         new ColumnHeader("euc.DONE", 1, length),
         new ColumnHeader("euc.IOMF", 1, length),
-        new ColumnHeader("euc.QUOTIENT", 32, length),
+        new ColumnHeader("euc.QUOTIENT", 8, length),
         new ColumnHeader("euc.QUOTIENT_BYTE", 1, length),
-        new ColumnHeader("euc.REMAINDER", 32, length),
+        new ColumnHeader("euc.REMAINDER", 8, length),
         new ColumnHeader("euc.REMAINDER_BYTE", 1, length));
   }
 
@@ -93,35 +94,42 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      ceil.put((byte) 0);
-    }
-    ceil.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("ceil has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { ceil.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { ceil.put(bs.get(j)); }
 
     return this;
   }
 
-  public Trace ct(final short b) {
+  public Trace ct(final long b) {
     if (filled.get(1)) {
       throw new IllegalStateException("euc.CT already set");
     } else {
       filled.set(1);
     }
 
-    ct.putShort(b);
+    if(b >= 256L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    ct.put((byte) b);
+
 
     return this;
   }
 
-  public Trace ctMax(final short b) {
+  public Trace ctMax(final long b) {
     if (filled.get(2)) {
       throw new IllegalStateException("euc.CT_MAX already set");
     } else {
       filled.set(2);
     }
 
-    ctMax.putShort(b);
+    if(b >= 256L) { throw new IllegalArgumentException("ctMax has invalid value (" + b + ")"); }
+    ctMax.put((byte) b);
+
 
     return this;
   }
@@ -133,11 +141,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      dividend.put((byte) 0);
-    }
-    dividend.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("dividend has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { dividend.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { dividend.put(bs.get(j)); }
 
     return this;
   }
@@ -149,11 +160,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      divisor.put((byte) 0);
-    }
-    divisor.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("divisor has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { divisor.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { divisor.put(bs.get(j)); }
 
     return this;
   }
@@ -201,11 +215,14 @@ public class Trace {
       filled.set(8);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      quotient.put((byte) 0);
-    }
-    quotient.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("quotient has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { quotient.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { quotient.put(bs.get(j)); }
 
     return this;
   }
@@ -229,11 +246,14 @@ public class Trace {
       filled.set(10);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      remainder.put((byte) 0);
-    }
-    remainder.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("remainder has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { remainder.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { remainder.put(bs.get(j)); }
 
     return this;
   }
@@ -307,23 +327,23 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      ceil.position(ceil.position() + 32);
+      ceil.position(ceil.position() + 8);
     }
 
     if (!filled.get(1)) {
-      ct.position(ct.position() + 2);
+      ct.position(ct.position() + 1);
     }
 
     if (!filled.get(2)) {
-      ctMax.position(ctMax.position() + 2);
+      ctMax.position(ctMax.position() + 1);
     }
 
     if (!filled.get(3)) {
-      dividend.position(dividend.position() + 32);
+      dividend.position(dividend.position() + 8);
     }
 
     if (!filled.get(4)) {
-      divisor.position(divisor.position() + 32);
+      divisor.position(divisor.position() + 8);
     }
 
     if (!filled.get(5)) {
@@ -339,7 +359,7 @@ public class Trace {
     }
 
     if (!filled.get(8)) {
-      quotient.position(quotient.position() + 32);
+      quotient.position(quotient.position() + 8);
     }
 
     if (!filled.get(9)) {
@@ -347,7 +367,7 @@ public class Trace {
     }
 
     if (!filled.get(10)) {
-      remainder.position(remainder.position() + 32);
+      remainder.position(remainder.position() + 8);
     }
 
     if (!filled.get(11)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpLogOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpLogOperation.java
@@ -17,8 +17,8 @@ package net.consensys.linea.zktracer.module.exp;
 
 import static net.consensys.linea.zktracer.module.constants.GlobalConstants.EXP_INST_EXPLOG;
 import static net.consensys.linea.zktracer.module.constants.GlobalConstants.EVM_INST_ISZERO;
-import static net.consensys.linea.zktracer.module.exp.Trace.MAX_CT_CMPTN_EXP_LOG;
-import static net.consensys.linea.zktracer.module.exp.Trace.MAX_CT_PRPRC_EXP_LOG;
+import static net.consensys.linea.zktracer.module.exp.Trace.CT_MAX_CMPTN_EXP_LOG;
+import static net.consensys.linea.zktracer.module.exp.Trace.CT_MAX_PRPRC_EXP_LOG;
 import static net.consensys.linea.zktracer.opcode.gas.GasConstants.G_EXP_BYTE;
 
 import lombok.EqualsAndHashCode;
@@ -55,7 +55,7 @@ public class ExpLogOperation extends ExpOperation {
     pMacroData1 = this.exponent.hi();
     pMacroData2 = this.exponent.lo();
     pMacroData5 = Bytes.ofUnsignedLong(this.dynCost);
-    initArrays(MAX_CT_PRPRC_EXP_LOG + 1);
+    initArrays(CT_MAX_PRPRC_EXP_LOG + 1);
 
     // Preprocessing
     // First row
@@ -64,7 +64,7 @@ public class ExpLogOperation extends ExpOperation {
     pPreprocessingWcpArg1Lo[0] = this.exponent.hi();
     pPreprocessingWcpArg2Hi[0] = Bytes.EMPTY;
     pPreprocessingWcpArg2Lo[0] = Bytes.EMPTY;
-    pPreprocessingWcpInst[0] = UnsignedByte.of(ISZERO);
+    pPreprocessingWcpInst[0] = UnsignedByte.of(EVM_INST_ISZERO);
     final boolean expnHiIsZero = wcp.callISZERO(this.exponent.hi());
     ;
     pPreprocessingWcpRes[0] = expnHiIsZero;
@@ -77,7 +77,7 @@ public class ExpLogOperation extends ExpOperation {
     }
 
     // Fill trimAcc
-    short maxCt = (short) MAX_CT_CMPTN_EXP_LOG;
+    short maxCt = (short) CT_MAX_CMPTN_EXP_LOG;
     for (short i = 0; i < maxCt + 1; i++) {
       boolean pltBit = i >= pComputationPltJmp;
       byte rawByte = pComputationRawAcc.get(i);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpLogOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpLogOperation.java
@@ -15,8 +15,8 @@
 
 package net.consensys.linea.zktracer.module.exp;
 
-import static net.consensys.linea.zktracer.module.constants.GlobalConstants.EXP_INST_EXPLOG;
 import static net.consensys.linea.zktracer.module.constants.GlobalConstants.EVM_INST_ISZERO;
+import static net.consensys.linea.zktracer.module.constants.GlobalConstants.EXP_INST_EXPLOG;
 import static net.consensys.linea.zktracer.module.exp.Trace.CT_MAX_CMPTN_EXP_LOG;
 import static net.consensys.linea.zktracer.module.exp.Trace.CT_MAX_PRPRC_EXP_LOG;
 import static net.consensys.linea.zktracer.opcode.gas.GasConstants.G_EXP_BYTE;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpLogOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpLogOperation.java
@@ -16,7 +16,7 @@
 package net.consensys.linea.zktracer.module.exp;
 
 import static net.consensys.linea.zktracer.module.constants.GlobalConstants.EXP_INST_EXPLOG;
-import static net.consensys.linea.zktracer.module.exp.Trace.ISZERO;
+import static net.consensys.linea.zktracer.module.constants.GlobalConstants.EVM_INST_ISZERO;
 import static net.consensys.linea.zktracer.module.exp.Trace.MAX_CT_CMPTN_EXP_LOG;
 import static net.consensys.linea.zktracer.module.exp.Trace.MAX_CT_PRPRC_EXP_LOG;
 import static net.consensys.linea.zktracer.opcode.gas.GasConstants.G_EXP_BYTE;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpOperation.java
@@ -15,10 +15,10 @@
 
 package net.consensys.linea.zktracer.module.exp;
 
-import static net.consensys.linea.zktracer.module.exp.Trace.MAX_CT_CMPTN_EXP_LOG;
-import static net.consensys.linea.zktracer.module.exp.Trace.MAX_CT_CMPTN_MODEXP_LOG;
-import static net.consensys.linea.zktracer.module.exp.Trace.MAX_CT_PRPRC_EXP_LOG;
-import static net.consensys.linea.zktracer.module.exp.Trace.MAX_CT_PRPRC_MODEXP_LOG;
+import static net.consensys.linea.zktracer.module.exp.Trace.CT_MAX_CMPTN_EXP_LOG;
+import static net.consensys.linea.zktracer.module.exp.Trace.CT_MAX_CMPTN_MODEXP_LOG;
+import static net.consensys.linea.zktracer.module.exp.Trace.CT_MAX_PRPRC_EXP_LOG;
+import static net.consensys.linea.zktracer.module.exp.Trace.CT_MAX_PRPRC_MODEXP_LOG;
 
 import lombok.Getter;
 import net.consensys.linea.zktracer.container.ModuleOperation;
@@ -64,12 +64,12 @@ public abstract class ExpOperation extends ModuleOperation {
 
   @Override
   protected int computeLineCount() {
-    // We assume MAX_CT_MACRO_EXP_LOG = MAX_CT_MACRO_MODEXP_LOG = 0;
+    // We assume CT_MAX_MACRO_EXP_LOG = CT_MAX_MACRO_MODEXP_LOG = 0;
     if (this.isExpLog()) {
-      return MAX_CT_CMPTN_EXP_LOG + MAX_CT_PRPRC_EXP_LOG + 3;
+      return CT_MAX_CMPTN_EXP_LOG + CT_MAX_PRPRC_EXP_LOG + 3;
     }
 
-    return MAX_CT_CMPTN_MODEXP_LOG + MAX_CT_PRPRC_MODEXP_LOG + 3;
+    return CT_MAX_CMPTN_MODEXP_LOG + CT_MAX_PRPRC_MODEXP_LOG + 3;
   }
 
   public abstract void preCompute();
@@ -79,7 +79,7 @@ public abstract class ExpOperation extends ModuleOperation {
     short pComputationTanzbAcc = 0; // Paired with Tanzb
     boolean manzb;
     short pComputationManzbAcc = 0; // Paired with Manzb
-    short maxCt = (short) (isExpLog() ? MAX_CT_CMPTN_EXP_LOG : MAX_CT_CMPTN_MODEXP_LOG);
+    short maxCt = (short) (isExpLog() ? CT_MAX_CMPTN_EXP_LOG : CT_MAX_CMPTN_MODEXP_LOG);
 
     for (short i = 0; i < maxCt + 1; i++) {
       /*
@@ -122,7 +122,7 @@ public abstract class ExpOperation extends ModuleOperation {
   }
 
   final void traceMacro(int stamp, Trace trace) {
-    // We assume MAX_CT_MACRO_EXP_LOG = MAX_CT_MACRO_MODEXP_LOG = 0;
+    // We assume CT_MAX_MACRO_EXP_LOG = CT_MAX_MACRO_MODEXP_LOG = 0;
     trace
         .macro(true)
         .stamp(stamp)
@@ -140,7 +140,7 @@ public abstract class ExpOperation extends ModuleOperation {
   }
 
   final void tracePreprocessing(int stamp, Trace trace) {
-    short maxCt = (short) (isExpLog() ? MAX_CT_PRPRC_EXP_LOG : MAX_CT_PRPRC_MODEXP_LOG);
+    short maxCt = (short) (isExpLog() ? CT_MAX_PRPRC_EXP_LOG : CT_MAX_PRPRC_MODEXP_LOG);
     for (short i = 0; i < maxCt + 1; i++) {
       trace
           .prprc(true)

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ModexpLogOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ModexpLogOperation.java
@@ -22,8 +22,8 @@ import static net.consensys.linea.zktracer.module.constants.GlobalConstants.EVM_
 import static net.consensys.linea.zktracer.module.constants.GlobalConstants.EXP_INST_MODEXPLOG;
 import static net.consensys.linea.zktracer.module.constants.GlobalConstants.LLARGE;
 import static net.consensys.linea.zktracer.module.constants.GlobalConstants.LLARGEPO;
-import static net.consensys.linea.zktracer.module.exp.Trace.MAX_CT_CMPTN_MODEXP_LOG;
-import static net.consensys.linea.zktracer.module.exp.Trace.MAX_CT_PRPRC_MODEXP_LOG;
+import static net.consensys.linea.zktracer.module.exp.Trace.CT_MAX_CMPTN_MODEXP_LOG;
+import static net.consensys.linea.zktracer.module.exp.Trace.CT_MAX_PRPRC_MODEXP_LOG;
 import static net.consensys.linea.zktracer.types.Conversions.bigIntegerToBytes;
 import static net.consensys.linea.zktracer.types.Utils.leftPadTo;
 
@@ -102,7 +102,7 @@ public class ModexpLogOperation extends ExpOperation {
     pMacroData3 = Bytes.of(this.cdsCutoff);
     pMacroData4 = Bytes.of(this.ebsCutoff);
     pMacroData5 = bigIntegerToBytes(this.leadLog);
-    initArrays(MAX_CT_PRPRC_MODEXP_LOG + 1);
+    initArrays(CT_MAX_PRPRC_MODEXP_LOG + 1);
 
     // Preprocessing
     final BigInteger trimLimb =
@@ -183,7 +183,7 @@ public class ModexpLogOperation extends ExpOperation {
     }
 
     // Fill trimAcc
-    final short maxCt = (short) MAX_CT_CMPTN_MODEXP_LOG;
+    final short maxCt = (short) CT_MAX_CMPTN_MODEXP_LOG;
     for (short i = 0; i < maxCt + 1; i++) {
       final boolean pltBit = i >= pComputationPltJmp;
       final byte rawByte = pComputationRawAcc.get(i);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.exp;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -30,16 +31,12 @@ import org.apache.tuweni.bytes.Bytes;
  * Please DO NOT ATTEMPT TO MODIFY this code directly.
  */
 public class Trace {
-  public static final int EQ = 0x14;
-  public static final int G_EXPBYTES = 0x32;
-  public static final int ISZERO = 0x15;
-  public static final int LT = 0x10;
-  public static final int MAX_CT_CMPTN_EXP_LOG = 0xf;
-  public static final int MAX_CT_CMPTN_MODEXP_LOG = 0xf;
-  public static final int MAX_CT_MACRO_EXP_LOG = 0x0;
-  public static final int MAX_CT_MACRO_MODEXP_LOG = 0x0;
-  public static final int MAX_CT_PRPRC_EXP_LOG = 0x0;
-  public static final int MAX_CT_PRPRC_MODEXP_LOG = 0x4;
+  public static final int CT_MAX_CMPTN_EXP_LOG = 0xf;
+  public static final int CT_MAX_CMPTN_MODEXP_LOG = 0xf;
+  public static final int CT_MAX_MACRO_EXP_LOG = 0x0;
+  public static final int CT_MAX_MACRO_MODEXP_LOG = 0x0;
+  public static final int CT_MAX_PRPRC_EXP_LOG = 0x0;
+  public static final int CT_MAX_PRPRC_MODEXP_LOG = 0x4;
 
   private final BitSet filled = new BitSet();
   private int currentLine = 0;
@@ -73,29 +70,29 @@ public class Trace {
   static List<ColumnHeader> headers(int length) {
     return List.of(
         new ColumnHeader("exp.CMPTN", 1, length),
-        new ColumnHeader("exp.CT", 2, length),
-        new ColumnHeader("exp.CT_MAX", 2, length),
-        new ColumnHeader("exp.DATA_3_xor_WCP_ARG_2_HI", 32, length),
-        new ColumnHeader("exp.DATA_4_xor_WCP_ARG_2_LO", 32, length),
-        new ColumnHeader("exp.DATA_5", 32, length),
-        new ColumnHeader("exp.EXP_INST", 4, length),
+        new ColumnHeader("exp.CT", 1, length),
+        new ColumnHeader("exp.CT_MAX", 1, length),
+        new ColumnHeader("exp.DATA_3_xor_WCP_ARG_2_HI", 16, length),
+        new ColumnHeader("exp.DATA_4_xor_WCP_ARG_2_LO", 16, length),
+        new ColumnHeader("exp.DATA_5", 16, length),
+        new ColumnHeader("exp.EXP_INST", 2, length),
         new ColumnHeader("exp.IS_EXP_LOG", 1, length),
         new ColumnHeader("exp.IS_MODEXP_LOG", 1, length),
         new ColumnHeader("exp.MACRO", 1, length),
-        new ColumnHeader("exp.MANZB_ACC", 2, length),
+        new ColumnHeader("exp.MANZB_ACC", 1, length),
         new ColumnHeader("exp.MANZB_xor_WCP_FLAG", 1, length),
         new ColumnHeader("exp.MSB_ACC", 1, length),
         new ColumnHeader("exp.MSB_BIT_xor_WCP_RES", 1, length),
         new ColumnHeader("exp.MSB_xor_WCP_INST", 1, length),
         new ColumnHeader("exp.PLT_BIT", 1, length),
-        new ColumnHeader("exp.PLT_JMP", 2, length),
+        new ColumnHeader("exp.PLT_JMP", 1, length),
         new ColumnHeader("exp.PRPRC", 1, length),
-        new ColumnHeader("exp.RAW_ACC_xor_DATA_1_xor_WCP_ARG_1_HI", 32, length),
+        new ColumnHeader("exp.RAW_ACC_xor_DATA_1_xor_WCP_ARG_1_HI", 16, length),
         new ColumnHeader("exp.RAW_BYTE", 1, length),
-        new ColumnHeader("exp.STAMP", 8, length),
+        new ColumnHeader("exp.STAMP", 4, length),
         new ColumnHeader("exp.TANZB", 1, length),
-        new ColumnHeader("exp.TANZB_ACC", 2, length),
-        new ColumnHeader("exp.TRIM_ACC_xor_DATA_2_xor_WCP_ARG_1_LO", 32, length),
+        new ColumnHeader("exp.TANZB_ACC", 1, length),
+        new ColumnHeader("exp.TRIM_ACC_xor_DATA_2_xor_WCP_ARG_1_LO", 16, length),
         new ColumnHeader("exp.TRIM_BYTE", 1, length));
   }
 
@@ -147,26 +144,30 @@ public class Trace {
     return this;
   }
 
-  public Trace ct(final short b) {
+  public Trace ct(final long b) {
     if (filled.get(1)) {
       throw new IllegalStateException("exp.CT already set");
     } else {
       filled.set(1);
     }
 
-    ct.putShort(b);
+    if(b >= 16L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    ct.put((byte) b);
+
 
     return this;
   }
 
-  public Trace ctMax(final short b) {
+  public Trace ctMax(final long b) {
     if (filled.get(2)) {
       throw new IllegalStateException("exp.CT_MAX already set");
     } else {
       filled.set(2);
     }
 
-    ctMax.putShort(b);
+    if(b >= 16L) { throw new IllegalArgumentException("ctMax has invalid value (" + b + ")"); }
+    ctMax.put((byte) b);
+
 
     return this;
   }
@@ -219,14 +220,16 @@ public class Trace {
     return this;
   }
 
-  public Trace pComputationManzbAcc(final short b) {
+  public Trace pComputationManzbAcc(final long b) {
     if (filled.get(16)) {
       throw new IllegalStateException("exp.computation/MANZB_ACC already set");
     } else {
       filled.set(16);
     }
 
-    manzbAcc.putShort(b);
+    if(b >= 16L) { throw new IllegalArgumentException("manzbAcc has invalid value (" + b + ")"); }
+    manzbAcc.put((byte) b);
+
 
     return this;
   }
@@ -279,14 +282,16 @@ public class Trace {
     return this;
   }
 
-  public Trace pComputationPltJmp(final short b) {
+  public Trace pComputationPltJmp(final long b) {
     if (filled.get(18)) {
       throw new IllegalStateException("exp.computation/PLT_JMP already set");
     } else {
       filled.set(18);
     }
 
-    pltJmp.putShort(b);
+    if(b >= 64L) { throw new IllegalArgumentException("pltJmp has invalid value (" + b + ")"); }
+    pltJmp.put((byte) b);
+
 
     return this;
   }
@@ -298,11 +303,14 @@ public class Trace {
       filled.set(20);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      rawAccXorData1XorWcpArg1Hi.put((byte) 0);
-    }
-    rawAccXorData1XorWcpArg1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("rawAccXorData1XorWcpArg1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { rawAccXorData1XorWcpArg1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { rawAccXorData1XorWcpArg1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -331,14 +339,16 @@ public class Trace {
     return this;
   }
 
-  public Trace pComputationTanzbAcc(final short b) {
+  public Trace pComputationTanzbAcc(final long b) {
     if (filled.get(17)) {
       throw new IllegalStateException("exp.computation/TANZB_ACC already set");
     } else {
       filled.set(17);
     }
 
-    tanzbAcc.putShort(b);
+    if(b >= 32L) { throw new IllegalArgumentException("tanzbAcc has invalid value (" + b + ")"); }
+    tanzbAcc.put((byte) b);
+
 
     return this;
   }
@@ -350,11 +360,14 @@ public class Trace {
       filled.set(21);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      trimAccXorData2XorWcpArg1Lo.put((byte) 0);
-    }
-    trimAccXorData2XorWcpArg1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("trimAccXorData2XorWcpArg1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { trimAccXorData2XorWcpArg1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { trimAccXorData2XorWcpArg1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -378,11 +391,14 @@ public class Trace {
       filled.set(20);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      rawAccXorData1XorWcpArg1Hi.put((byte) 0);
-    }
-    rawAccXorData1XorWcpArg1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("rawAccXorData1XorWcpArg1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { rawAccXorData1XorWcpArg1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { rawAccXorData1XorWcpArg1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -394,11 +410,14 @@ public class Trace {
       filled.set(21);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      trimAccXorData2XorWcpArg1Lo.put((byte) 0);
-    }
-    trimAccXorData2XorWcpArg1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("trimAccXorData2XorWcpArg1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { trimAccXorData2XorWcpArg1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { trimAccXorData2XorWcpArg1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -410,11 +429,14 @@ public class Trace {
       filled.set(22);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      data3XorWcpArg2Hi.put((byte) 0);
-    }
-    data3XorWcpArg2Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("data3XorWcpArg2Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { data3XorWcpArg2Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { data3XorWcpArg2Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -426,11 +448,14 @@ public class Trace {
       filled.set(23);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      data4XorWcpArg2Lo.put((byte) 0);
-    }
-    data4XorWcpArg2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("data4XorWcpArg2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { data4XorWcpArg2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { data4XorWcpArg2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -442,23 +467,29 @@ public class Trace {
       filled.set(24);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      data5.put((byte) 0);
-    }
-    data5.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("data5 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { data5.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { data5.put(bs.get(j)); }
 
     return this;
   }
 
-  public Trace pMacroExpInst(final int b) {
+  public Trace pMacroExpInst(final long b) {
     if (filled.get(19)) {
       throw new IllegalStateException("exp.macro/EXP_INST already set");
     } else {
       filled.set(19);
     }
 
-    expInst.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("expInst has invalid value (" + b + ")"); }
+    expInst.put((byte) (b >> 8));
+    expInst.put((byte) b);
+
 
     return this;
   }
@@ -470,11 +501,14 @@ public class Trace {
       filled.set(20);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      rawAccXorData1XorWcpArg1Hi.put((byte) 0);
-    }
-    rawAccXorData1XorWcpArg1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("rawAccXorData1XorWcpArg1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { rawAccXorData1XorWcpArg1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { rawAccXorData1XorWcpArg1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -486,11 +520,14 @@ public class Trace {
       filled.set(21);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      trimAccXorData2XorWcpArg1Lo.put((byte) 0);
-    }
-    trimAccXorData2XorWcpArg1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("trimAccXorData2XorWcpArg1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { trimAccXorData2XorWcpArg1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { trimAccXorData2XorWcpArg1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -502,11 +539,14 @@ public class Trace {
       filled.set(22);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      data3XorWcpArg2Hi.put((byte) 0);
-    }
-    data3XorWcpArg2Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("data3XorWcpArg2Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { data3XorWcpArg2Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { data3XorWcpArg2Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -518,11 +558,14 @@ public class Trace {
       filled.set(23);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      data4XorWcpArg2Lo.put((byte) 0);
-    }
-    data4XorWcpArg2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("data4XorWcpArg2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { data4XorWcpArg2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { data4XorWcpArg2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -582,7 +625,12 @@ public class Trace {
       filled.set(7);
     }
 
-    stamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    stamp.put((byte) (b >> 24));
+    stamp.put((byte) (b >> 16));
+    stamp.put((byte) (b >> 8));
+    stamp.put((byte) b);
+
 
     return this;
   }
@@ -661,8 +709,7 @@ public class Trace {
     }
 
     if (!filled.get(20)) {
-      throw new IllegalStateException(
-          "exp.RAW_ACC_xor_DATA_1_xor_WCP_ARG_1_HI has not been filled");
+      throw new IllegalStateException("exp.RAW_ACC_xor_DATA_1_xor_WCP_ARG_1_HI has not been filled");
     }
 
     if (!filled.get(14)) {
@@ -682,8 +729,7 @@ public class Trace {
     }
 
     if (!filled.get(21)) {
-      throw new IllegalStateException(
-          "exp.TRIM_ACC_xor_DATA_2_xor_WCP_ARG_1_LO has not been filled");
+      throw new IllegalStateException("exp.TRIM_ACC_xor_DATA_2_xor_WCP_ARG_1_LO has not been filled");
     }
 
     if (!filled.get(15)) {
@@ -702,27 +748,27 @@ public class Trace {
     }
 
     if (!filled.get(1)) {
-      ct.position(ct.position() + 2);
+      ct.position(ct.position() + 1);
     }
 
     if (!filled.get(2)) {
-      ctMax.position(ctMax.position() + 2);
+      ctMax.position(ctMax.position() + 1);
     }
 
     if (!filled.get(22)) {
-      data3XorWcpArg2Hi.position(data3XorWcpArg2Hi.position() + 32);
+      data3XorWcpArg2Hi.position(data3XorWcpArg2Hi.position() + 16);
     }
 
     if (!filled.get(23)) {
-      data4XorWcpArg2Lo.position(data4XorWcpArg2Lo.position() + 32);
+      data4XorWcpArg2Lo.position(data4XorWcpArg2Lo.position() + 16);
     }
 
     if (!filled.get(24)) {
-      data5.position(data5.position() + 32);
+      data5.position(data5.position() + 16);
     }
 
     if (!filled.get(19)) {
-      expInst.position(expInst.position() + 4);
+      expInst.position(expInst.position() + 2);
     }
 
     if (!filled.get(3)) {
@@ -738,7 +784,7 @@ public class Trace {
     }
 
     if (!filled.get(16)) {
-      manzbAcc.position(manzbAcc.position() + 2);
+      manzbAcc.position(manzbAcc.position() + 1);
     }
 
     if (!filled.get(8)) {
@@ -762,7 +808,7 @@ public class Trace {
     }
 
     if (!filled.get(18)) {
-      pltJmp.position(pltJmp.position() + 2);
+      pltJmp.position(pltJmp.position() + 1);
     }
 
     if (!filled.get(6)) {
@@ -770,7 +816,7 @@ public class Trace {
     }
 
     if (!filled.get(20)) {
-      rawAccXorData1XorWcpArg1Hi.position(rawAccXorData1XorWcpArg1Hi.position() + 32);
+      rawAccXorData1XorWcpArg1Hi.position(rawAccXorData1XorWcpArg1Hi.position() + 16);
     }
 
     if (!filled.get(14)) {
@@ -778,7 +824,7 @@ public class Trace {
     }
 
     if (!filled.get(7)) {
-      stamp.position(stamp.position() + 8);
+      stamp.position(stamp.position() + 4);
     }
 
     if (!filled.get(11)) {
@@ -786,11 +832,11 @@ public class Trace {
     }
 
     if (!filled.get(17)) {
-      tanzbAcc.position(tanzbAcc.position() + 2);
+      tanzbAcc.position(tanzbAcc.position() + 1);
     }
 
     if (!filled.get(21)) {
-      trimAccXorData2XorWcpArg1Lo.position(trimAccXorData2XorWcpArg1Lo.position() + 32);
+      trimAccXorData2XorWcpArg1Lo.position(trimAccXorData2XorWcpArg1Lo.position() + 16);
     }
 
     if (!filled.get(15)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.exp;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -151,9 +150,10 @@ public class Trace {
       filled.set(1);
     }
 
-    if(b >= 16L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    if (b >= 16L) {
+      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+    }
     ct.put((byte) b);
-
 
     return this;
   }
@@ -165,9 +165,10 @@ public class Trace {
       filled.set(2);
     }
 
-    if(b >= 16L) { throw new IllegalArgumentException("ctMax has invalid value (" + b + ")"); }
+    if (b >= 16L) {
+      throw new IllegalArgumentException("ctMax has invalid value (" + b + ")");
+    }
     ctMax.put((byte) b);
-
 
     return this;
   }
@@ -227,9 +228,10 @@ public class Trace {
       filled.set(16);
     }
 
-    if(b >= 16L) { throw new IllegalArgumentException("manzbAcc has invalid value (" + b + ")"); }
+    if (b >= 16L) {
+      throw new IllegalArgumentException("manzbAcc has invalid value (" + b + ")");
+    }
     manzbAcc.put((byte) b);
-
 
     return this;
   }
@@ -289,9 +291,10 @@ public class Trace {
       filled.set(18);
     }
 
-    if(b >= 64L) { throw new IllegalArgumentException("pltJmp has invalid value (" + b + ")"); }
+    if (b >= 64L) {
+      throw new IllegalArgumentException("pltJmp has invalid value (" + b + ")");
+    }
     pltJmp.put((byte) b);
-
 
     return this;
   }
@@ -306,11 +309,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("rawAccXorData1XorWcpArg1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "rawAccXorData1XorWcpArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { rawAccXorData1XorWcpArg1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      rawAccXorData1XorWcpArg1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { rawAccXorData1XorWcpArg1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      rawAccXorData1XorWcpArg1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -346,9 +356,10 @@ public class Trace {
       filled.set(17);
     }
 
-    if(b >= 32L) { throw new IllegalArgumentException("tanzbAcc has invalid value (" + b + ")"); }
+    if (b >= 32L) {
+      throw new IllegalArgumentException("tanzbAcc has invalid value (" + b + ")");
+    }
     tanzbAcc.put((byte) b);
-
 
     return this;
   }
@@ -363,11 +374,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("trimAccXorData2XorWcpArg1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "trimAccXorData2XorWcpArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { trimAccXorData2XorWcpArg1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      trimAccXorData2XorWcpArg1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { trimAccXorData2XorWcpArg1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      trimAccXorData2XorWcpArg1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -394,11 +412,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("rawAccXorData1XorWcpArg1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "rawAccXorData1XorWcpArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { rawAccXorData1XorWcpArg1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      rawAccXorData1XorWcpArg1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { rawAccXorData1XorWcpArg1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      rawAccXorData1XorWcpArg1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -413,11 +438,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("trimAccXorData2XorWcpArg1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "trimAccXorData2XorWcpArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { trimAccXorData2XorWcpArg1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      trimAccXorData2XorWcpArg1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { trimAccXorData2XorWcpArg1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      trimAccXorData2XorWcpArg1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -432,11 +464,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("data3XorWcpArg2Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "data3XorWcpArg2Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { data3XorWcpArg2Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      data3XorWcpArg2Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { data3XorWcpArg2Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      data3XorWcpArg2Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -451,11 +490,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("data4XorWcpArg2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "data4XorWcpArg2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { data4XorWcpArg2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      data4XorWcpArg2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { data4XorWcpArg2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      data4XorWcpArg2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -470,11 +516,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("data5 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("data5 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { data5.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      data5.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { data5.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      data5.put(bs.get(j));
+    }
 
     return this;
   }
@@ -486,10 +538,11 @@ public class Trace {
       filled.set(19);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("expInst has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("expInst has invalid value (" + b + ")");
+    }
     expInst.put((byte) (b >> 8));
     expInst.put((byte) b);
-
 
     return this;
   }
@@ -504,11 +557,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("rawAccXorData1XorWcpArg1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "rawAccXorData1XorWcpArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { rawAccXorData1XorWcpArg1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      rawAccXorData1XorWcpArg1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { rawAccXorData1XorWcpArg1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      rawAccXorData1XorWcpArg1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -523,11 +583,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("trimAccXorData2XorWcpArg1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "trimAccXorData2XorWcpArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { trimAccXorData2XorWcpArg1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      trimAccXorData2XorWcpArg1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { trimAccXorData2XorWcpArg1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      trimAccXorData2XorWcpArg1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -542,11 +609,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("data3XorWcpArg2Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "data3XorWcpArg2Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { data3XorWcpArg2Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      data3XorWcpArg2Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { data3XorWcpArg2Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      data3XorWcpArg2Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -561,11 +635,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("data4XorWcpArg2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "data4XorWcpArg2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { data4XorWcpArg2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      data4XorWcpArg2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { data4XorWcpArg2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      data4XorWcpArg2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -625,12 +706,13 @@ public class Trace {
       filled.set(7);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+    }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));
     stamp.put((byte) b);
-
 
     return this;
   }
@@ -709,7 +791,8 @@ public class Trace {
     }
 
     if (!filled.get(20)) {
-      throw new IllegalStateException("exp.RAW_ACC_xor_DATA_1_xor_WCP_ARG_1_HI has not been filled");
+      throw new IllegalStateException(
+          "exp.RAW_ACC_xor_DATA_1_xor_WCP_ARG_1_HI has not been filled");
     }
 
     if (!filled.get(14)) {
@@ -729,7 +812,8 @@ public class Trace {
     }
 
     if (!filled.get(21)) {
-      throw new IllegalStateException("exp.TRIM_ACC_xor_DATA_2_xor_WCP_ARG_1_LO has not been filled");
+      throw new IllegalStateException(
+          "exp.TRIM_ACC_xor_DATA_2_xor_WCP_ARG_1_LO has not been filled");
     }
 
     if (!filled.get(15)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ext/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ext/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.ext;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -415,11 +414,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accA0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accA0.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accA0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accA0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accA0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -434,11 +439,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accA1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accA1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accA1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accA1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accA1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -453,11 +464,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accA2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accA2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accA2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accA2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accA2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -472,11 +489,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accA3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accA3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accA3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accA3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accA3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -491,11 +514,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accB0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accB0.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accB0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accB0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accB0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -510,11 +539,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accB1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accB1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accB1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accB1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accB1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -529,11 +564,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accB2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accB2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accB2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accB2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accB2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -548,11 +589,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accB3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accB3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accB3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accB3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accB3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -567,11 +614,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accC0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accC0.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accC0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accC0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accC0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -586,11 +639,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accC1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accC1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accC1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accC1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accC1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -605,11 +664,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accC2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accC2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accC2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accC2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accC2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -624,11 +689,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accC3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accC3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accC3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accC3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accC3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -643,11 +714,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accDelta0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "accDelta0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accDelta0.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accDelta0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accDelta0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accDelta0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -662,11 +740,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accDelta1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "accDelta1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accDelta1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accDelta1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accDelta1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accDelta1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -681,11 +766,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accDelta2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "accDelta2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accDelta2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accDelta2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accDelta2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accDelta2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -700,11 +792,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accDelta3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "accDelta3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accDelta3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accDelta3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accDelta3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accDelta3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -719,11 +818,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accH0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accH0.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accH0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accH0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accH0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -738,11 +843,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accH1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accH1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accH1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accH1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accH1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -757,11 +868,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accH2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accH2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accH2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accH2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accH2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -776,11 +893,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accH3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accH3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accH3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accH3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accH3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -795,11 +918,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accH4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accH4.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accH4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accH4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accH4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -814,11 +943,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH5 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accH5 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accH5.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accH5.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accH5.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accH5.put(bs.get(j));
+    }
 
     return this;
   }
@@ -833,11 +968,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accI0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accI0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accI0.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accI0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accI0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accI0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -852,11 +993,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accI1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accI1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accI1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accI1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accI1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accI1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -871,11 +1018,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accI2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accI2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accI2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accI2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accI2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accI2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -890,11 +1043,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accI3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accI3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accI3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accI3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accI3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accI3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -909,11 +1068,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accI4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accI4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accI4.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accI4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accI4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accI4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -928,11 +1093,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accI5 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accI5 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accI5.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accI5.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accI5.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accI5.put(bs.get(j));
+    }
 
     return this;
   }
@@ -947,11 +1118,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accI6 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accI6 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accI6.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accI6.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accI6.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accI6.put(bs.get(j));
+    }
 
     return this;
   }
@@ -966,11 +1143,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accJ0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accJ0.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accJ0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accJ0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accJ0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -985,11 +1168,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accJ1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accJ1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accJ1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accJ1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accJ1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1004,11 +1193,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accJ2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accJ2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accJ2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accJ2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accJ2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1023,11 +1218,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accJ3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accJ3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accJ3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accJ3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accJ3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1042,11 +1243,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accJ4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accJ4.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accJ4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accJ4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accJ4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1061,11 +1268,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ5 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accJ5 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accJ5.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accJ5.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accJ5.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accJ5.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1080,11 +1293,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ6 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accJ6 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accJ6.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accJ6.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accJ6.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accJ6.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1099,11 +1318,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ7 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accJ7 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accJ7.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accJ7.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accJ7.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accJ7.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1118,11 +1343,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accQ0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accQ0.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accQ0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accQ0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accQ0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1137,11 +1368,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accQ1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accQ1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accQ1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accQ1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accQ1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1156,11 +1393,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accQ2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accQ2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accQ2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accQ2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accQ2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1175,11 +1418,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accQ3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accQ3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accQ3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accQ3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accQ3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1194,11 +1443,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accQ4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accQ4.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accQ4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accQ4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accQ4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1213,11 +1468,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ5 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accQ5 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accQ5.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accQ5.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accQ5.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accQ5.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1232,11 +1493,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ6 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accQ6 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accQ6.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accQ6.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accQ6.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accQ6.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1251,11 +1518,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ7 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accQ7 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accQ7.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accQ7.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accQ7.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accQ7.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1270,11 +1543,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accR0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accR0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accR0.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accR0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accR0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accR0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1289,11 +1568,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accR1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accR1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accR1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accR1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accR1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accR1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1308,11 +1593,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accR2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accR2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accR2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accR2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accR2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accR2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1327,11 +1618,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accR3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accR3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accR3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accR3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accR3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accR3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1346,11 +1643,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { arg1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      arg1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1365,11 +1668,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { arg1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      arg1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1384,11 +1693,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { arg2Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      arg2Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg2Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg2Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1403,11 +1718,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { arg2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      arg2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1422,11 +1743,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("arg3Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("arg3Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { arg3Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      arg3Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg3Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg3Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1441,11 +1768,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("arg3Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("arg3Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { arg3Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      arg3Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg3Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg3Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -2096,11 +2429,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("ct has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("ct has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { ct.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      ct.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { ct.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      ct.put(bs.get(j));
+    }
 
     return this;
   }
@@ -2115,11 +2454,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("inst has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("inst has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { inst.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      inst.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { inst.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      inst.put(bs.get(j));
+    }
 
     return this;
   }
@@ -2194,11 +2539,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("resHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("resHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { resHi.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      resHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -2213,11 +2564,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("resLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("resLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { resLo.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      resLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -2232,11 +2589,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("stamp has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("stamp has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { stamp.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      stamp.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { stamp.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      stamp.put(bs.get(j));
+    }
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ext/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ext/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.ext;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -411,11 +412,14 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accA0.put((byte) 0);
-    }
-    accA0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accA0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accA0.put(bs.get(j)); }
 
     return this;
   }
@@ -427,11 +431,14 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accA1.put((byte) 0);
-    }
-    accA1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accA1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accA1.put(bs.get(j)); }
 
     return this;
   }
@@ -443,11 +450,14 @@ public class Trace {
       filled.set(2);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accA2.put((byte) 0);
-    }
-    accA2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accA2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accA2.put(bs.get(j)); }
 
     return this;
   }
@@ -459,11 +469,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accA3.put((byte) 0);
-    }
-    accA3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accA3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accA3.put(bs.get(j)); }
 
     return this;
   }
@@ -475,11 +488,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accB0.put((byte) 0);
-    }
-    accB0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accB0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accB0.put(bs.get(j)); }
 
     return this;
   }
@@ -491,11 +507,14 @@ public class Trace {
       filled.set(5);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accB1.put((byte) 0);
-    }
-    accB1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accB1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accB1.put(bs.get(j)); }
 
     return this;
   }
@@ -507,11 +526,14 @@ public class Trace {
       filled.set(6);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accB2.put((byte) 0);
-    }
-    accB2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accB2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accB2.put(bs.get(j)); }
 
     return this;
   }
@@ -523,11 +545,14 @@ public class Trace {
       filled.set(7);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accB3.put((byte) 0);
-    }
-    accB3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accB3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accB3.put(bs.get(j)); }
 
     return this;
   }
@@ -539,11 +564,14 @@ public class Trace {
       filled.set(8);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accC0.put((byte) 0);
-    }
-    accC0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accC0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accC0.put(bs.get(j)); }
 
     return this;
   }
@@ -555,11 +583,14 @@ public class Trace {
       filled.set(9);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accC1.put((byte) 0);
-    }
-    accC1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accC1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accC1.put(bs.get(j)); }
 
     return this;
   }
@@ -571,11 +602,14 @@ public class Trace {
       filled.set(10);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accC2.put((byte) 0);
-    }
-    accC2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accC2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accC2.put(bs.get(j)); }
 
     return this;
   }
@@ -587,11 +621,14 @@ public class Trace {
       filled.set(11);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accC3.put((byte) 0);
-    }
-    accC3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accC3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accC3.put(bs.get(j)); }
 
     return this;
   }
@@ -603,11 +640,14 @@ public class Trace {
       filled.set(12);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accDelta0.put((byte) 0);
-    }
-    accDelta0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accDelta0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accDelta0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accDelta0.put(bs.get(j)); }
 
     return this;
   }
@@ -619,11 +659,14 @@ public class Trace {
       filled.set(13);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accDelta1.put((byte) 0);
-    }
-    accDelta1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accDelta1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accDelta1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accDelta1.put(bs.get(j)); }
 
     return this;
   }
@@ -635,11 +678,14 @@ public class Trace {
       filled.set(14);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accDelta2.put((byte) 0);
-    }
-    accDelta2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accDelta2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accDelta2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accDelta2.put(bs.get(j)); }
 
     return this;
   }
@@ -651,11 +697,14 @@ public class Trace {
       filled.set(15);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accDelta3.put((byte) 0);
-    }
-    accDelta3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accDelta3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accDelta3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accDelta3.put(bs.get(j)); }
 
     return this;
   }
@@ -667,11 +716,14 @@ public class Trace {
       filled.set(16);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accH0.put((byte) 0);
-    }
-    accH0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accH0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accH0.put(bs.get(j)); }
 
     return this;
   }
@@ -683,11 +735,14 @@ public class Trace {
       filled.set(17);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accH1.put((byte) 0);
-    }
-    accH1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accH1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accH1.put(bs.get(j)); }
 
     return this;
   }
@@ -699,11 +754,14 @@ public class Trace {
       filled.set(18);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accH2.put((byte) 0);
-    }
-    accH2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accH2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accH2.put(bs.get(j)); }
 
     return this;
   }
@@ -715,11 +773,14 @@ public class Trace {
       filled.set(19);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accH3.put((byte) 0);
-    }
-    accH3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accH3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accH3.put(bs.get(j)); }
 
     return this;
   }
@@ -731,11 +792,14 @@ public class Trace {
       filled.set(20);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accH4.put((byte) 0);
-    }
-    accH4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accH4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accH4.put(bs.get(j)); }
 
     return this;
   }
@@ -747,11 +811,14 @@ public class Trace {
       filled.set(21);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accH5.put((byte) 0);
-    }
-    accH5.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH5 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accH5.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accH5.put(bs.get(j)); }
 
     return this;
   }
@@ -763,11 +830,14 @@ public class Trace {
       filled.set(22);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accI0.put((byte) 0);
-    }
-    accI0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accI0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accI0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accI0.put(bs.get(j)); }
 
     return this;
   }
@@ -779,11 +849,14 @@ public class Trace {
       filled.set(23);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accI1.put((byte) 0);
-    }
-    accI1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accI1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accI1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accI1.put(bs.get(j)); }
 
     return this;
   }
@@ -795,11 +868,14 @@ public class Trace {
       filled.set(24);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accI2.put((byte) 0);
-    }
-    accI2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accI2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accI2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accI2.put(bs.get(j)); }
 
     return this;
   }
@@ -811,11 +887,14 @@ public class Trace {
       filled.set(25);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accI3.put((byte) 0);
-    }
-    accI3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accI3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accI3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accI3.put(bs.get(j)); }
 
     return this;
   }
@@ -827,11 +906,14 @@ public class Trace {
       filled.set(26);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accI4.put((byte) 0);
-    }
-    accI4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accI4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accI4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accI4.put(bs.get(j)); }
 
     return this;
   }
@@ -843,11 +925,14 @@ public class Trace {
       filled.set(27);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accI5.put((byte) 0);
-    }
-    accI5.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accI5 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accI5.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accI5.put(bs.get(j)); }
 
     return this;
   }
@@ -859,11 +944,14 @@ public class Trace {
       filled.set(28);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accI6.put((byte) 0);
-    }
-    accI6.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accI6 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accI6.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accI6.put(bs.get(j)); }
 
     return this;
   }
@@ -875,11 +963,14 @@ public class Trace {
       filled.set(29);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accJ0.put((byte) 0);
-    }
-    accJ0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accJ0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accJ0.put(bs.get(j)); }
 
     return this;
   }
@@ -891,11 +982,14 @@ public class Trace {
       filled.set(30);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accJ1.put((byte) 0);
-    }
-    accJ1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accJ1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accJ1.put(bs.get(j)); }
 
     return this;
   }
@@ -907,11 +1001,14 @@ public class Trace {
       filled.set(31);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accJ2.put((byte) 0);
-    }
-    accJ2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accJ2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accJ2.put(bs.get(j)); }
 
     return this;
   }
@@ -923,11 +1020,14 @@ public class Trace {
       filled.set(32);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accJ3.put((byte) 0);
-    }
-    accJ3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accJ3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accJ3.put(bs.get(j)); }
 
     return this;
   }
@@ -939,11 +1039,14 @@ public class Trace {
       filled.set(33);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accJ4.put((byte) 0);
-    }
-    accJ4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accJ4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accJ4.put(bs.get(j)); }
 
     return this;
   }
@@ -955,11 +1058,14 @@ public class Trace {
       filled.set(34);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accJ5.put((byte) 0);
-    }
-    accJ5.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ5 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accJ5.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accJ5.put(bs.get(j)); }
 
     return this;
   }
@@ -971,11 +1077,14 @@ public class Trace {
       filled.set(35);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accJ6.put((byte) 0);
-    }
-    accJ6.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ6 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accJ6.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accJ6.put(bs.get(j)); }
 
     return this;
   }
@@ -987,11 +1096,14 @@ public class Trace {
       filled.set(36);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accJ7.put((byte) 0);
-    }
-    accJ7.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accJ7 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accJ7.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accJ7.put(bs.get(j)); }
 
     return this;
   }
@@ -1003,11 +1115,14 @@ public class Trace {
       filled.set(37);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accQ0.put((byte) 0);
-    }
-    accQ0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accQ0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accQ0.put(bs.get(j)); }
 
     return this;
   }
@@ -1019,11 +1134,14 @@ public class Trace {
       filled.set(38);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accQ1.put((byte) 0);
-    }
-    accQ1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accQ1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accQ1.put(bs.get(j)); }
 
     return this;
   }
@@ -1035,11 +1153,14 @@ public class Trace {
       filled.set(39);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accQ2.put((byte) 0);
-    }
-    accQ2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accQ2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accQ2.put(bs.get(j)); }
 
     return this;
   }
@@ -1051,11 +1172,14 @@ public class Trace {
       filled.set(40);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accQ3.put((byte) 0);
-    }
-    accQ3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accQ3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accQ3.put(bs.get(j)); }
 
     return this;
   }
@@ -1067,11 +1191,14 @@ public class Trace {
       filled.set(41);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accQ4.put((byte) 0);
-    }
-    accQ4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accQ4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accQ4.put(bs.get(j)); }
 
     return this;
   }
@@ -1083,11 +1210,14 @@ public class Trace {
       filled.set(42);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accQ5.put((byte) 0);
-    }
-    accQ5.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ5 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accQ5.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accQ5.put(bs.get(j)); }
 
     return this;
   }
@@ -1099,11 +1229,14 @@ public class Trace {
       filled.set(43);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accQ6.put((byte) 0);
-    }
-    accQ6.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ6 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accQ6.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accQ6.put(bs.get(j)); }
 
     return this;
   }
@@ -1115,11 +1248,14 @@ public class Trace {
       filled.set(44);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accQ7.put((byte) 0);
-    }
-    accQ7.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accQ7 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accQ7.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accQ7.put(bs.get(j)); }
 
     return this;
   }
@@ -1131,11 +1267,14 @@ public class Trace {
       filled.set(45);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accR0.put((byte) 0);
-    }
-    accR0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accR0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accR0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accR0.put(bs.get(j)); }
 
     return this;
   }
@@ -1147,11 +1286,14 @@ public class Trace {
       filled.set(46);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accR1.put((byte) 0);
-    }
-    accR1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accR1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accR1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accR1.put(bs.get(j)); }
 
     return this;
   }
@@ -1163,11 +1305,14 @@ public class Trace {
       filled.set(47);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accR2.put((byte) 0);
-    }
-    accR2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accR2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accR2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accR2.put(bs.get(j)); }
 
     return this;
   }
@@ -1179,11 +1324,14 @@ public class Trace {
       filled.set(48);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accR3.put((byte) 0);
-    }
-    accR3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accR3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accR3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accR3.put(bs.get(j)); }
 
     return this;
   }
@@ -1195,11 +1343,14 @@ public class Trace {
       filled.set(49);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg1Hi.put((byte) 0);
-    }
-    arg1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { arg1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -1211,11 +1362,14 @@ public class Trace {
       filled.set(50);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg1Lo.put((byte) 0);
-    }
-    arg1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { arg1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -1227,11 +1381,14 @@ public class Trace {
       filled.set(51);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg2Hi.put((byte) 0);
-    }
-    arg2Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { arg2Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg2Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -1243,11 +1400,14 @@ public class Trace {
       filled.set(52);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg2Lo.put((byte) 0);
-    }
-    arg2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { arg2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -1259,11 +1419,14 @@ public class Trace {
       filled.set(53);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg3Hi.put((byte) 0);
-    }
-    arg3Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("arg3Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { arg3Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg3Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -1275,11 +1438,14 @@ public class Trace {
       filled.set(54);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg3Lo.put((byte) 0);
-    }
-    arg3Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("arg3Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { arg3Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg3Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -1927,11 +2093,14 @@ public class Trace {
       filled.set(108);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      ct.put((byte) 0);
-    }
-    ct.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("ct has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { ct.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { ct.put(bs.get(j)); }
 
     return this;
   }
@@ -1943,11 +2112,14 @@ public class Trace {
       filled.set(109);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      inst.put((byte) 0);
-    }
-    inst.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("inst has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { inst.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { inst.put(bs.get(j)); }
 
     return this;
   }
@@ -2019,11 +2191,14 @@ public class Trace {
       filled.set(115);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resHi.put((byte) 0);
-    }
-    resHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("resHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { resHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resHi.put(bs.get(j)); }
 
     return this;
   }
@@ -2035,11 +2210,14 @@ public class Trace {
       filled.set(116);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resLo.put((byte) 0);
-    }
-    resLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("resLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { resLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resLo.put(bs.get(j)); }
 
     return this;
   }
@@ -2051,11 +2229,14 @@ public class Trace {
       filled.set(117);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      stamp.put((byte) 0);
-    }
-    stamp.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("stamp has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { stamp.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { stamp.put(bs.get(j)); }
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/gas/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/gas/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.gas;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -47,15 +48,15 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("gas.ACC_1", 32, length),
-        new ColumnHeader("gas.ACC_2", 32, length),
+        new ColumnHeader("gas.ACC_1", 8, length),
+        new ColumnHeader("gas.ACC_2", 8, length),
         new ColumnHeader("gas.BYTE_1", 1, length),
         new ColumnHeader("gas.BYTE_2", 1, length),
-        new ColumnHeader("gas.CT", 2, length),
-        new ColumnHeader("gas.GAS_ACTL", 8, length),
-        new ColumnHeader("gas.GAS_COST", 32, length),
+        new ColumnHeader("gas.CT", 1, length),
+        new ColumnHeader("gas.GAS_ACTL", 4, length),
+        new ColumnHeader("gas.GAS_COST", 8, length),
         new ColumnHeader("gas.OOGX", 1, length),
-        new ColumnHeader("gas.STAMP", 8, length));
+        new ColumnHeader("gas.STAMP", 4, length));
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -85,11 +86,14 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc1.put((byte) 0);
-    }
-    acc1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { acc1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
 
     return this;
   }
@@ -101,11 +105,14 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc2.put((byte) 0);
-    }
-    acc2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { acc2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
 
     return this;
   }
@@ -134,14 +141,16 @@ public class Trace {
     return this;
   }
 
-  public Trace ct(final short b) {
+  public Trace ct(final long b) {
     if (filled.get(4)) {
       throw new IllegalStateException("gas.CT already set");
     } else {
       filled.set(4);
     }
 
-    ct.putShort(b);
+    if(b >= 8L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    ct.put((byte) b);
+
 
     return this;
   }
@@ -153,7 +162,12 @@ public class Trace {
       filled.set(5);
     }
 
-    gasActl.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("gasActl has invalid value (" + b + ")"); }
+    gasActl.put((byte) (b >> 24));
+    gasActl.put((byte) (b >> 16));
+    gasActl.put((byte) (b >> 8));
+    gasActl.put((byte) b);
+
 
     return this;
   }
@@ -165,11 +179,14 @@ public class Trace {
       filled.set(6);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gasCost.put((byte) 0);
-    }
-    gasCost.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("gasCost has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { gasCost.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gasCost.put(bs.get(j)); }
 
     return this;
   }
@@ -193,7 +210,12 @@ public class Trace {
       filled.set(8);
     }
 
-    stamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    stamp.put((byte) (b >> 24));
+    stamp.put((byte) (b >> 16));
+    stamp.put((byte) (b >> 8));
+    stamp.put((byte) b);
+
 
     return this;
   }
@@ -243,11 +265,11 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      acc1.position(acc1.position() + 32);
+      acc1.position(acc1.position() + 8);
     }
 
     if (!filled.get(1)) {
-      acc2.position(acc2.position() + 32);
+      acc2.position(acc2.position() + 8);
     }
 
     if (!filled.get(2)) {
@@ -259,15 +281,15 @@ public class Trace {
     }
 
     if (!filled.get(4)) {
-      ct.position(ct.position() + 2);
+      ct.position(ct.position() + 1);
     }
 
     if (!filled.get(5)) {
-      gasActl.position(gasActl.position() + 8);
+      gasActl.position(gasActl.position() + 4);
     }
 
     if (!filled.get(6)) {
-      gasCost.position(gasCost.position() + 32);
+      gasCost.position(gasCost.position() + 8);
     }
 
     if (!filled.get(7)) {
@@ -275,7 +297,7 @@ public class Trace {
     }
 
     if (!filled.get(8)) {
-      stamp.position(stamp.position() + 8);
+      stamp.position(stamp.position() + 4);
     }
 
     filled.clear();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/gas/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/gas/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.gas;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -89,11 +88,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { acc1.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      acc1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -108,11 +113,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { acc2.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      acc2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -148,9 +159,10 @@ public class Trace {
       filled.set(4);
     }
 
-    if(b >= 8L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    if (b >= 8L) {
+      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+    }
     ct.put((byte) b);
-
 
     return this;
   }
@@ -162,12 +174,13 @@ public class Trace {
       filled.set(5);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("gasActl has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("gasActl has invalid value (" + b + ")");
+    }
     gasActl.put((byte) (b >> 24));
     gasActl.put((byte) (b >> 16));
     gasActl.put((byte) (b >> 8));
     gasActl.put((byte) b);
-
 
     return this;
   }
@@ -182,11 +195,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("gasCost has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("gasCost has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { gasCost.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      gasCost.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gasCost.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gasCost.put(bs.get(j));
+    }
 
     return this;
   }
@@ -210,12 +229,13 @@ public class Trace {
       filled.set(8);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+    }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));
     stamp.put((byte) b);
-
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/logdata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/logdata/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.logdata;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -45,14 +46,14 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("logdata.ABS_LOG_NUM", 4, length),
-        new ColumnHeader("logdata.ABS_LOG_NUM_MAX", 4, length),
-        new ColumnHeader("logdata.INDEX", 4, length),
-        new ColumnHeader("logdata.LIMB", 32, length),
+        new ColumnHeader("logdata.ABS_LOG_NUM", 3, length),
+        new ColumnHeader("logdata.ABS_LOG_NUM_MAX", 3, length),
+        new ColumnHeader("logdata.INDEX", 3, length),
+        new ColumnHeader("logdata.LIMB", 16, length),
         new ColumnHeader("logdata.LOGS_DATA", 1, length),
-        new ColumnHeader("logdata.SIZE_ACC", 8, length),
+        new ColumnHeader("logdata.SIZE_ACC", 4, length),
         new ColumnHeader("logdata.SIZE_LIMB", 1, length),
-        new ColumnHeader("logdata.SIZE_TOTAL", 8, length));
+        new ColumnHeader("logdata.SIZE_TOTAL", 4, length));
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -74,38 +75,50 @@ public class Trace {
     return this.currentLine;
   }
 
-  public Trace absLogNum(final int b) {
+  public Trace absLogNum(final long b) {
     if (filled.get(0)) {
       throw new IllegalStateException("logdata.ABS_LOG_NUM already set");
     } else {
       filled.set(0);
     }
 
-    absLogNum.putInt(b);
+    if(b >= 16777216L) { throw new IllegalArgumentException("absLogNum has invalid value (" + b + ")"); }
+    absLogNum.put((byte) (b >> 16));
+    absLogNum.put((byte) (b >> 8));
+    absLogNum.put((byte) b);
+
 
     return this;
   }
 
-  public Trace absLogNumMax(final int b) {
+  public Trace absLogNumMax(final long b) {
     if (filled.get(1)) {
       throw new IllegalStateException("logdata.ABS_LOG_NUM_MAX already set");
     } else {
       filled.set(1);
     }
 
-    absLogNumMax.putInt(b);
+    if(b >= 16777216L) { throw new IllegalArgumentException("absLogNumMax has invalid value (" + b + ")"); }
+    absLogNumMax.put((byte) (b >> 16));
+    absLogNumMax.put((byte) (b >> 8));
+    absLogNumMax.put((byte) b);
+
 
     return this;
   }
 
-  public Trace index(final int b) {
+  public Trace index(final long b) {
     if (filled.get(2)) {
       throw new IllegalStateException("logdata.INDEX already set");
     } else {
       filled.set(2);
     }
 
-    index.putInt(b);
+    if(b >= 16777216L) { throw new IllegalArgumentException("index has invalid value (" + b + ")"); }
+    index.put((byte) (b >> 16));
+    index.put((byte) (b >> 8));
+    index.put((byte) b);
+
 
     return this;
   }
@@ -117,11 +130,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      limb.put((byte) 0);
-    }
-    limb.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
 
     return this;
   }
@@ -145,7 +161,12 @@ public class Trace {
       filled.set(5);
     }
 
-    sizeAcc.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("sizeAcc has invalid value (" + b + ")"); }
+    sizeAcc.put((byte) (b >> 24));
+    sizeAcc.put((byte) (b >> 16));
+    sizeAcc.put((byte) (b >> 8));
+    sizeAcc.put((byte) b);
+
 
     return this;
   }
@@ -169,7 +190,12 @@ public class Trace {
       filled.set(7);
     }
 
-    sizeTotal.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("sizeTotal has invalid value (" + b + ")"); }
+    sizeTotal.put((byte) (b >> 24));
+    sizeTotal.put((byte) (b >> 16));
+    sizeTotal.put((byte) (b >> 8));
+    sizeTotal.put((byte) b);
+
 
     return this;
   }
@@ -215,19 +241,19 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      absLogNum.position(absLogNum.position() + 4);
+      absLogNum.position(absLogNum.position() + 3);
     }
 
     if (!filled.get(1)) {
-      absLogNumMax.position(absLogNumMax.position() + 4);
+      absLogNumMax.position(absLogNumMax.position() + 3);
     }
 
     if (!filled.get(2)) {
-      index.position(index.position() + 4);
+      index.position(index.position() + 3);
     }
 
     if (!filled.get(3)) {
-      limb.position(limb.position() + 32);
+      limb.position(limb.position() + 16);
     }
 
     if (!filled.get(4)) {
@@ -235,7 +261,7 @@ public class Trace {
     }
 
     if (!filled.get(5)) {
-      sizeAcc.position(sizeAcc.position() + 8);
+      sizeAcc.position(sizeAcc.position() + 4);
     }
 
     if (!filled.get(6)) {
@@ -243,7 +269,7 @@ public class Trace {
     }
 
     if (!filled.get(7)) {
-      sizeTotal.position(sizeTotal.position() + 8);
+      sizeTotal.position(sizeTotal.position() + 4);
     }
 
     filled.clear();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/logdata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/logdata/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.logdata;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -82,11 +81,12 @@ public class Trace {
       filled.set(0);
     }
 
-    if(b >= 16777216L) { throw new IllegalArgumentException("absLogNum has invalid value (" + b + ")"); }
+    if (b >= 16777216L) {
+      throw new IllegalArgumentException("absLogNum has invalid value (" + b + ")");
+    }
     absLogNum.put((byte) (b >> 16));
     absLogNum.put((byte) (b >> 8));
     absLogNum.put((byte) b);
-
 
     return this;
   }
@@ -98,11 +98,12 @@ public class Trace {
       filled.set(1);
     }
 
-    if(b >= 16777216L) { throw new IllegalArgumentException("absLogNumMax has invalid value (" + b + ")"); }
+    if (b >= 16777216L) {
+      throw new IllegalArgumentException("absLogNumMax has invalid value (" + b + ")");
+    }
     absLogNumMax.put((byte) (b >> 16));
     absLogNumMax.put((byte) (b >> 8));
     absLogNumMax.put((byte) b);
-
 
     return this;
   }
@@ -114,11 +115,12 @@ public class Trace {
       filled.set(2);
     }
 
-    if(b >= 16777216L) { throw new IllegalArgumentException("index has invalid value (" + b + ")"); }
+    if (b >= 16777216L) {
+      throw new IllegalArgumentException("index has invalid value (" + b + ")");
+    }
     index.put((byte) (b >> 16));
     index.put((byte) (b >> 8));
     index.put((byte) b);
-
 
     return this;
   }
@@ -133,11 +135,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      limb.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      limb.put(bs.get(j));
+    }
 
     return this;
   }
@@ -161,12 +169,13 @@ public class Trace {
       filled.set(5);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("sizeAcc has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("sizeAcc has invalid value (" + b + ")");
+    }
     sizeAcc.put((byte) (b >> 24));
     sizeAcc.put((byte) (b >> 16));
     sizeAcc.put((byte) (b >> 8));
     sizeAcc.put((byte) b);
-
 
     return this;
   }
@@ -190,12 +199,13 @@ public class Trace {
       filled.set(7);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("sizeTotal has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("sizeTotal has invalid value (" + b + ")");
+    }
     sizeTotal.put((byte) (b >> 24));
     sizeTotal.put((byte) (b >> 16));
     sizeTotal.put((byte) (b >> 8));
     sizeTotal.put((byte) b);
-
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/loginfo/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/loginfo/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.loginfo;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -64,24 +65,24 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("loginfo.ABS_LOG_NUM", 4, length),
-        new ColumnHeader("loginfo.ABS_LOG_NUM_MAX", 4, length),
-        new ColumnHeader("loginfo.ABS_TXN_NUM", 4, length),
-        new ColumnHeader("loginfo.ABS_TXN_NUM_MAX", 4, length),
-        new ColumnHeader("loginfo.ADDR_HI", 8, length),
-        new ColumnHeader("loginfo.ADDR_LO", 32, length),
+        new ColumnHeader("loginfo.ABS_LOG_NUM", 3, length),
+        new ColumnHeader("loginfo.ABS_LOG_NUM_MAX", 3, length),
+        new ColumnHeader("loginfo.ABS_TXN_NUM", 3, length),
+        new ColumnHeader("loginfo.ABS_TXN_NUM_MAX", 3, length),
+        new ColumnHeader("loginfo.ADDR_HI", 4, length),
+        new ColumnHeader("loginfo.ADDR_LO", 16, length),
         new ColumnHeader("loginfo.CT", 1, length),
         new ColumnHeader("loginfo.CT_MAX", 1, length),
-        new ColumnHeader("loginfo.DATA_HI", 32, length),
-        new ColumnHeader("loginfo.DATA_LO", 32, length),
-        new ColumnHeader("loginfo.DATA_SIZE", 8, length),
+        new ColumnHeader("loginfo.DATA_HI", 16, length),
+        new ColumnHeader("loginfo.DATA_LO", 16, length),
+        new ColumnHeader("loginfo.DATA_SIZE", 4, length),
         new ColumnHeader("loginfo.INST", 1, length),
         new ColumnHeader("loginfo.IS_LOG_X_0", 1, length),
         new ColumnHeader("loginfo.IS_LOG_X_1", 1, length),
         new ColumnHeader("loginfo.IS_LOG_X_2", 1, length),
         new ColumnHeader("loginfo.IS_LOG_X_3", 1, length),
         new ColumnHeader("loginfo.IS_LOG_X_4", 1, length),
-        new ColumnHeader("loginfo.PHASE", 4, length),
+        new ColumnHeader("loginfo.PHASE", 2, length),
         new ColumnHeader("loginfo.TOPIC_HI_1", 32, length),
         new ColumnHeader("loginfo.TOPIC_HI_2", 32, length),
         new ColumnHeader("loginfo.TOPIC_HI_3", 32, length),
@@ -131,50 +132,66 @@ public class Trace {
     return this.currentLine;
   }
 
-  public Trace absLogNum(final int b) {
+  public Trace absLogNum(final long b) {
     if (filled.get(0)) {
       throw new IllegalStateException("loginfo.ABS_LOG_NUM already set");
     } else {
       filled.set(0);
     }
 
-    absLogNum.putInt(b);
+    if(b >= 16777216L) { throw new IllegalArgumentException("absLogNum has invalid value (" + b + ")"); }
+    absLogNum.put((byte) (b >> 16));
+    absLogNum.put((byte) (b >> 8));
+    absLogNum.put((byte) b);
+
 
     return this;
   }
 
-  public Trace absLogNumMax(final int b) {
+  public Trace absLogNumMax(final long b) {
     if (filled.get(1)) {
       throw new IllegalStateException("loginfo.ABS_LOG_NUM_MAX already set");
     } else {
       filled.set(1);
     }
 
-    absLogNumMax.putInt(b);
+    if(b >= 16777216L) { throw new IllegalArgumentException("absLogNumMax has invalid value (" + b + ")"); }
+    absLogNumMax.put((byte) (b >> 16));
+    absLogNumMax.put((byte) (b >> 8));
+    absLogNumMax.put((byte) b);
+
 
     return this;
   }
 
-  public Trace absTxnNum(final int b) {
+  public Trace absTxnNum(final long b) {
     if (filled.get(2)) {
       throw new IllegalStateException("loginfo.ABS_TXN_NUM already set");
     } else {
       filled.set(2);
     }
 
-    absTxnNum.putInt(b);
+    if(b >= 16777216L) { throw new IllegalArgumentException("absTxnNum has invalid value (" + b + ")"); }
+    absTxnNum.put((byte) (b >> 16));
+    absTxnNum.put((byte) (b >> 8));
+    absTxnNum.put((byte) b);
+
 
     return this;
   }
 
-  public Trace absTxnNumMax(final int b) {
+  public Trace absTxnNumMax(final long b) {
     if (filled.get(3)) {
       throw new IllegalStateException("loginfo.ABS_TXN_NUM_MAX already set");
     } else {
       filled.set(3);
     }
 
-    absTxnNumMax.putInt(b);
+    if(b >= 16777216L) { throw new IllegalArgumentException("absTxnNumMax has invalid value (" + b + ")"); }
+    absTxnNumMax.put((byte) (b >> 16));
+    absTxnNumMax.put((byte) (b >> 8));
+    absTxnNumMax.put((byte) b);
+
 
     return this;
   }
@@ -186,7 +203,12 @@ public class Trace {
       filled.set(4);
     }
 
-    addrHi.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("addrHi has invalid value (" + b + ")"); }
+    addrHi.put((byte) (b >> 24));
+    addrHi.put((byte) (b >> 16));
+    addrHi.put((byte) (b >> 8));
+    addrHi.put((byte) b);
+
 
     return this;
   }
@@ -198,11 +220,14 @@ public class Trace {
       filled.set(5);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      addrLo.put((byte) 0);
-    }
-    addrLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("addrLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { addrLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { addrLo.put(bs.get(j)); }
 
     return this;
   }
@@ -238,11 +263,14 @@ public class Trace {
       filled.set(8);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      dataHi.put((byte) 0);
-    }
-    dataHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("dataHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { dataHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { dataHi.put(bs.get(j)); }
 
     return this;
   }
@@ -254,11 +282,14 @@ public class Trace {
       filled.set(9);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      dataLo.put((byte) 0);
-    }
-    dataLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("dataLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { dataLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { dataLo.put(bs.get(j)); }
 
     return this;
   }
@@ -270,7 +301,12 @@ public class Trace {
       filled.set(10);
     }
 
-    dataSize.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("dataSize has invalid value (" + b + ")"); }
+    dataSize.put((byte) (b >> 24));
+    dataSize.put((byte) (b >> 16));
+    dataSize.put((byte) (b >> 8));
+    dataSize.put((byte) b);
+
 
     return this;
   }
@@ -347,14 +383,17 @@ public class Trace {
     return this;
   }
 
-  public Trace phase(final int b) {
+  public Trace phase(final long b) {
     if (filled.get(17)) {
       throw new IllegalStateException("loginfo.PHASE already set");
     } else {
       filled.set(17);
     }
 
-    phase.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("phase has invalid value (" + b + ")"); }
+    phase.put((byte) (b >> 8));
+    phase.put((byte) b);
+
 
     return this;
   }
@@ -366,11 +405,14 @@ public class Trace {
       filled.set(18);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      topicHi1.put((byte) 0);
-    }
-    topicHi1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicHi1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { topicHi1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { topicHi1.put(bs.get(j)); }
 
     return this;
   }
@@ -382,11 +424,14 @@ public class Trace {
       filled.set(19);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      topicHi2.put((byte) 0);
-    }
-    topicHi2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicHi2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { topicHi2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { topicHi2.put(bs.get(j)); }
 
     return this;
   }
@@ -398,11 +443,14 @@ public class Trace {
       filled.set(20);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      topicHi3.put((byte) 0);
-    }
-    topicHi3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicHi3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { topicHi3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { topicHi3.put(bs.get(j)); }
 
     return this;
   }
@@ -414,11 +462,14 @@ public class Trace {
       filled.set(21);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      topicHi4.put((byte) 0);
-    }
-    topicHi4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicHi4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { topicHi4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { topicHi4.put(bs.get(j)); }
 
     return this;
   }
@@ -430,11 +481,14 @@ public class Trace {
       filled.set(22);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      topicLo1.put((byte) 0);
-    }
-    topicLo1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicLo1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { topicLo1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { topicLo1.put(bs.get(j)); }
 
     return this;
   }
@@ -446,11 +500,14 @@ public class Trace {
       filled.set(23);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      topicLo2.put((byte) 0);
-    }
-    topicLo2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicLo2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { topicLo2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { topicLo2.put(bs.get(j)); }
 
     return this;
   }
@@ -462,11 +519,14 @@ public class Trace {
       filled.set(24);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      topicLo3.put((byte) 0);
-    }
-    topicLo3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicLo3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { topicLo3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { topicLo3.put(bs.get(j)); }
 
     return this;
   }
@@ -478,11 +538,14 @@ public class Trace {
       filled.set(25);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      topicLo4.put((byte) 0);
-    }
-    topicLo4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicLo4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { topicLo4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { topicLo4.put(bs.get(j)); }
 
     return this;
   }
@@ -616,27 +679,27 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      absLogNum.position(absLogNum.position() + 4);
+      absLogNum.position(absLogNum.position() + 3);
     }
 
     if (!filled.get(1)) {
-      absLogNumMax.position(absLogNumMax.position() + 4);
+      absLogNumMax.position(absLogNumMax.position() + 3);
     }
 
     if (!filled.get(2)) {
-      absTxnNum.position(absTxnNum.position() + 4);
+      absTxnNum.position(absTxnNum.position() + 3);
     }
 
     if (!filled.get(3)) {
-      absTxnNumMax.position(absTxnNumMax.position() + 4);
+      absTxnNumMax.position(absTxnNumMax.position() + 3);
     }
 
     if (!filled.get(4)) {
-      addrHi.position(addrHi.position() + 8);
+      addrHi.position(addrHi.position() + 4);
     }
 
     if (!filled.get(5)) {
-      addrLo.position(addrLo.position() + 32);
+      addrLo.position(addrLo.position() + 16);
     }
 
     if (!filled.get(6)) {
@@ -648,15 +711,15 @@ public class Trace {
     }
 
     if (!filled.get(8)) {
-      dataHi.position(dataHi.position() + 32);
+      dataHi.position(dataHi.position() + 16);
     }
 
     if (!filled.get(9)) {
-      dataLo.position(dataLo.position() + 32);
+      dataLo.position(dataLo.position() + 16);
     }
 
     if (!filled.get(10)) {
-      dataSize.position(dataSize.position() + 8);
+      dataSize.position(dataSize.position() + 4);
     }
 
     if (!filled.get(11)) {
@@ -684,7 +747,7 @@ public class Trace {
     }
 
     if (!filled.get(17)) {
-      phase.position(phase.position() + 4);
+      phase.position(phase.position() + 2);
     }
 
     if (!filled.get(18)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/loginfo/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/loginfo/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.loginfo;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -139,11 +138,12 @@ public class Trace {
       filled.set(0);
     }
 
-    if(b >= 16777216L) { throw new IllegalArgumentException("absLogNum has invalid value (" + b + ")"); }
+    if (b >= 16777216L) {
+      throw new IllegalArgumentException("absLogNum has invalid value (" + b + ")");
+    }
     absLogNum.put((byte) (b >> 16));
     absLogNum.put((byte) (b >> 8));
     absLogNum.put((byte) b);
-
 
     return this;
   }
@@ -155,11 +155,12 @@ public class Trace {
       filled.set(1);
     }
 
-    if(b >= 16777216L) { throw new IllegalArgumentException("absLogNumMax has invalid value (" + b + ")"); }
+    if (b >= 16777216L) {
+      throw new IllegalArgumentException("absLogNumMax has invalid value (" + b + ")");
+    }
     absLogNumMax.put((byte) (b >> 16));
     absLogNumMax.put((byte) (b >> 8));
     absLogNumMax.put((byte) b);
-
 
     return this;
   }
@@ -171,11 +172,12 @@ public class Trace {
       filled.set(2);
     }
 
-    if(b >= 16777216L) { throw new IllegalArgumentException("absTxnNum has invalid value (" + b + ")"); }
+    if (b >= 16777216L) {
+      throw new IllegalArgumentException("absTxnNum has invalid value (" + b + ")");
+    }
     absTxnNum.put((byte) (b >> 16));
     absTxnNum.put((byte) (b >> 8));
     absTxnNum.put((byte) b);
-
 
     return this;
   }
@@ -187,11 +189,12 @@ public class Trace {
       filled.set(3);
     }
 
-    if(b >= 16777216L) { throw new IllegalArgumentException("absTxnNumMax has invalid value (" + b + ")"); }
+    if (b >= 16777216L) {
+      throw new IllegalArgumentException("absTxnNumMax has invalid value (" + b + ")");
+    }
     absTxnNumMax.put((byte) (b >> 16));
     absTxnNumMax.put((byte) (b >> 8));
     absTxnNumMax.put((byte) b);
-
 
     return this;
   }
@@ -203,12 +206,13 @@ public class Trace {
       filled.set(4);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("addrHi has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("addrHi has invalid value (" + b + ")");
+    }
     addrHi.put((byte) (b >> 24));
     addrHi.put((byte) (b >> 16));
     addrHi.put((byte) (b >> 8));
     addrHi.put((byte) b);
-
 
     return this;
   }
@@ -223,11 +227,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("addrLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("addrLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { addrLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      addrLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { addrLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      addrLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -266,11 +276,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("dataHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("dataHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { dataHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      dataHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { dataHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      dataHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -285,11 +301,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("dataLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("dataLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { dataLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      dataLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { dataLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      dataLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -301,12 +323,13 @@ public class Trace {
       filled.set(10);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("dataSize has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("dataSize has invalid value (" + b + ")");
+    }
     dataSize.put((byte) (b >> 24));
     dataSize.put((byte) (b >> 16));
     dataSize.put((byte) (b >> 8));
     dataSize.put((byte) b);
-
 
     return this;
   }
@@ -390,10 +413,11 @@ public class Trace {
       filled.set(17);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("phase has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("phase has invalid value (" + b + ")");
+    }
     phase.put((byte) (b >> 8));
     phase.put((byte) b);
-
 
     return this;
   }
@@ -408,11 +432,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicHi1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("topicHi1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { topicHi1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      topicHi1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { topicHi1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      topicHi1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -427,11 +457,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicHi2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("topicHi2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { topicHi2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      topicHi2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { topicHi2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      topicHi2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -446,11 +482,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicHi3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("topicHi3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { topicHi3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      topicHi3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { topicHi3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      topicHi3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -465,11 +507,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicHi4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("topicHi4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { topicHi4.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      topicHi4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { topicHi4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      topicHi4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -484,11 +532,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicLo1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("topicLo1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { topicLo1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      topicLo1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { topicLo1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      topicLo1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -503,11 +557,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicLo2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("topicLo2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { topicLo2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      topicLo2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { topicLo2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      topicLo2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -522,11 +582,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicLo3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("topicLo3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { topicLo3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      topicLo3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { topicLo3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      topicLo3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -541,11 +607,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("topicLo4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("topicLo4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { topicLo4.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      topicLo4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { topicLo4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      topicLo4.put(bs.get(j));
+    }
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.mmio;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -274,11 +273,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc1.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -293,11 +298,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc2.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -312,11 +323,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc3.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -331,11 +348,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc4.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -350,11 +373,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("accA has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("accA has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { accA.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      accA.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accA.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accA.put(bs.get(j));
+    }
 
     return this;
   }
@@ -369,11 +398,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("accB has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("accB has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { accB.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      accB.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accB.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accB.put(bs.get(j));
+    }
 
     return this;
   }
@@ -388,11 +423,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("accC has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("accC has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { accC.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      accC.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accC.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accC.put(bs.get(j));
+    }
 
     return this;
   }
@@ -407,11 +448,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("accLimb has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("accLimb has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { accLimb.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      accLimb.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accLimb.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accLimb.put(bs.get(j));
+    }
 
     return this;
   }
@@ -534,11 +581,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("cnA has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("cnA has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { cnA.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      cnA.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { cnA.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      cnA.put(bs.get(j));
+    }
 
     return this;
   }
@@ -553,11 +606,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("cnB has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("cnB has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { cnB.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      cnB.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { cnB.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      cnB.put(bs.get(j));
+    }
 
     return this;
   }
@@ -572,11 +631,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("cnC has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("cnC has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { cnC.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      cnC.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { cnC.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      cnC.put(bs.get(j));
+    }
 
     return this;
   }
@@ -591,11 +656,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("contextSource has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "contextSource has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { contextSource.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      contextSource.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { contextSource.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      contextSource.put(bs.get(j));
+    }
 
     return this;
   }
@@ -610,11 +682,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("contextTarget has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "contextTarget has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { contextTarget.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      contextTarget.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { contextTarget.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      contextTarget.put(bs.get(j));
+    }
 
     return this;
   }
@@ -626,9 +705,10 @@ public class Trace {
       filled.set(22);
     }
 
-    if(b >= 256L) { throw new IllegalArgumentException("counter has invalid value (" + b + ")"); }
+    if (b >= 256L) {
+      throw new IllegalArgumentException("counter has invalid value (" + b + ")");
+    }
     counter.put((byte) b);
-
 
     return this;
   }
@@ -640,12 +720,13 @@ public class Trace {
       filled.set(23);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("exoId has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("exoId has invalid value (" + b + ")");
+    }
     exoId.put((byte) (b >> 24));
     exoId.put((byte) (b >> 16));
     exoId.put((byte) (b >> 8));
     exoId.put((byte) b);
-
 
     return this;
   }
@@ -741,12 +822,13 @@ public class Trace {
       filled.set(31);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("exoSum has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("exoSum has invalid value (" + b + ")");
+    }
     exoSum.put((byte) (b >> 24));
     exoSum.put((byte) (b >> 16));
     exoSum.put((byte) (b >> 8));
     exoSum.put((byte) b);
-
 
     return this;
   }
@@ -773,11 +855,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("indexA has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("indexA has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { indexA.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      indexA.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { indexA.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      indexA.put(bs.get(j));
+    }
 
     return this;
   }
@@ -792,11 +880,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("indexB has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("indexB has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { indexB.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      indexB.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { indexB.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      indexB.put(bs.get(j));
+    }
 
     return this;
   }
@@ -811,11 +905,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("indexC has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("indexC has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { indexC.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      indexC.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { indexC.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      indexC.put(bs.get(j));
+    }
 
     return this;
   }
@@ -830,11 +930,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("indexX has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("indexX has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { indexX.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      indexX.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { indexX.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      indexX.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1002,12 +1108,13 @@ public class Trace {
       filled.set(50);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("kecId has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("kecId has invalid value (" + b + ")");
+    }
     kecId.put((byte) (b >> 24));
     kecId.put((byte) (b >> 16));
     kecId.put((byte) (b >> 8));
     kecId.put((byte) b);
-
 
     return this;
   }
@@ -1022,11 +1129,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      limb.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      limb.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1038,10 +1151,11 @@ public class Trace {
       filled.set(52);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("mmioInstruction has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("mmioInstruction has invalid value (" + b + ")");
+    }
     mmioInstruction.put((byte) (b >> 8));
     mmioInstruction.put((byte) b);
-
 
     return this;
   }
@@ -1053,12 +1167,13 @@ public class Trace {
       filled.set(53);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("mmioStamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("mmioStamp has invalid value (" + b + ")");
+    }
     mmioStamp.put((byte) (b >> 24));
     mmioStamp.put((byte) (b >> 16));
     mmioStamp.put((byte) (b >> 8));
     mmioStamp.put((byte) b);
-
 
     return this;
   }
@@ -1070,12 +1185,13 @@ public class Trace {
       filled.set(54);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("phase has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("phase has invalid value (" + b + ")");
+    }
     phase.put((byte) (b >> 24));
     phase.put((byte) (b >> 16));
     phase.put((byte) (b >> 8));
     phase.put((byte) b);
-
 
     return this;
   }
@@ -1090,11 +1206,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("pow2561 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("pow2561 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { pow2561.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      pow2561.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { pow2561.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      pow2561.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1109,11 +1231,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("pow2562 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("pow2562 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { pow2562.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      pow2562.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { pow2562.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      pow2562.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1128,11 +1256,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("size has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("size has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { size.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      size.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { size.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      size.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1156,9 +1290,10 @@ public class Trace {
       filled.set(59);
     }
 
-    if(b >= 256L) { throw new IllegalArgumentException("sourceByteOffset has invalid value (" + b + ")"); }
+    if (b >= 256L) {
+      throw new IllegalArgumentException("sourceByteOffset has invalid value (" + b + ")");
+    }
     sourceByteOffset.put((byte) b);
-
 
     return this;
   }
@@ -1173,11 +1308,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("sourceLimbOffset has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "sourceLimbOffset has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { sourceLimbOffset.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      sourceLimbOffset.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { sourceLimbOffset.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      sourceLimbOffset.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1201,9 +1343,10 @@ public class Trace {
       filled.set(62);
     }
 
-    if(b >= 256L) { throw new IllegalArgumentException("targetByteOffset has invalid value (" + b + ")"); }
+    if (b >= 256L) {
+      throw new IllegalArgumentException("targetByteOffset has invalid value (" + b + ")");
+    }
     targetByteOffset.put((byte) b);
-
 
     return this;
   }
@@ -1218,11 +1361,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("targetLimbOffset has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "targetLimbOffset has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { targetLimbOffset.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      targetLimbOffset.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { targetLimbOffset.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      targetLimbOffset.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1237,11 +1387,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("totalSize has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "totalSize has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { totalSize.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      totalSize.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { totalSize.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      totalSize.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1256,11 +1413,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valA has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("valA has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { valA.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      valA.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { valA.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      valA.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1275,11 +1438,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valANew has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("valANew has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { valANew.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      valANew.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { valANew.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      valANew.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1294,11 +1463,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valB has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("valB has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { valB.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      valB.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { valB.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      valB.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1313,11 +1488,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valBNew has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("valBNew has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { valBNew.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      valBNew.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { valBNew.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      valBNew.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1332,11 +1513,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valC has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("valC has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { valC.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      valC.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { valC.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      valC.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1351,11 +1538,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valCNew has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("valCNew has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { valCNew.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      valCNew.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { valCNew.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      valCNew.put(bs.get(j));
+    }
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.mmio;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -108,14 +109,14 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("mmio.ACC_1", 32, length),
-        new ColumnHeader("mmio.ACC_2", 32, length),
-        new ColumnHeader("mmio.ACC_3", 32, length),
-        new ColumnHeader("mmio.ACC_4", 32, length),
-        new ColumnHeader("mmio.ACC_A", 32, length),
-        new ColumnHeader("mmio.ACC_B", 32, length),
-        new ColumnHeader("mmio.ACC_C", 32, length),
-        new ColumnHeader("mmio.ACC_LIMB", 32, length),
+        new ColumnHeader("mmio.ACC_1", 16, length),
+        new ColumnHeader("mmio.ACC_2", 16, length),
+        new ColumnHeader("mmio.ACC_3", 16, length),
+        new ColumnHeader("mmio.ACC_4", 16, length),
+        new ColumnHeader("mmio.ACC_A", 16, length),
+        new ColumnHeader("mmio.ACC_B", 16, length),
+        new ColumnHeader("mmio.ACC_C", 16, length),
+        new ColumnHeader("mmio.ACC_LIMB", 16, length),
         new ColumnHeader("mmio.BIT_1", 1, length),
         new ColumnHeader("mmio.BIT_2", 1, length),
         new ColumnHeader("mmio.BIT_3", 1, length),
@@ -125,13 +126,13 @@ public class Trace {
         new ColumnHeader("mmio.BYTE_B", 1, length),
         new ColumnHeader("mmio.BYTE_C", 1, length),
         new ColumnHeader("mmio.BYTE_LIMB", 1, length),
-        new ColumnHeader("mmio.CN_A", 32, length),
-        new ColumnHeader("mmio.CN_B", 32, length),
-        new ColumnHeader("mmio.CN_C", 32, length),
-        new ColumnHeader("mmio.CONTEXT_SOURCE", 32, length),
-        new ColumnHeader("mmio.CONTEXT_TARGET", 32, length),
-        new ColumnHeader("mmio.COUNTER", 2, length),
-        new ColumnHeader("mmio.EXO_ID", 8, length),
+        new ColumnHeader("mmio.CN_A", 8, length),
+        new ColumnHeader("mmio.CN_B", 8, length),
+        new ColumnHeader("mmio.CN_C", 8, length),
+        new ColumnHeader("mmio.CONTEXT_SOURCE", 8, length),
+        new ColumnHeader("mmio.CONTEXT_TARGET", 8, length),
+        new ColumnHeader("mmio.COUNTER", 1, length),
+        new ColumnHeader("mmio.EXO_ID", 4, length),
         new ColumnHeader("mmio.EXO_IS_BLAKEMODEXP", 1, length),
         new ColumnHeader("mmio.EXO_IS_ECDATA", 1, length),
         new ColumnHeader("mmio.EXO_IS_KEC", 1, length),
@@ -139,12 +140,12 @@ public class Trace {
         new ColumnHeader("mmio.EXO_IS_RIPSHA", 1, length),
         new ColumnHeader("mmio.EXO_IS_ROM", 1, length),
         new ColumnHeader("mmio.EXO_IS_TXCD", 1, length),
-        new ColumnHeader("mmio.EXO_SUM", 8, length),
+        new ColumnHeader("mmio.EXO_SUM", 4, length),
         new ColumnHeader("mmio.FAST", 1, length),
-        new ColumnHeader("mmio.INDEX_A", 32, length),
-        new ColumnHeader("mmio.INDEX_B", 32, length),
-        new ColumnHeader("mmio.INDEX_C", 32, length),
-        new ColumnHeader("mmio.INDEX_X", 32, length),
+        new ColumnHeader("mmio.INDEX_A", 8, length),
+        new ColumnHeader("mmio.INDEX_B", 8, length),
+        new ColumnHeader("mmio.INDEX_C", 8, length),
+        new ColumnHeader("mmio.INDEX_X", 8, length),
         new ColumnHeader("mmio.IS_LIMB_TO_RAM_ONE_TARGET", 1, length),
         new ColumnHeader("mmio.IS_LIMB_TO_RAM_TRANSPLANT", 1, length),
         new ColumnHeader("mmio.IS_LIMB_TO_RAM_TWO_TARGET", 1, length),
@@ -158,27 +159,27 @@ public class Trace {
         new ColumnHeader("mmio.IS_RAM_TO_RAM_TWO_SOURCE", 1, length),
         new ColumnHeader("mmio.IS_RAM_TO_RAM_TWO_TARGET", 1, length),
         new ColumnHeader("mmio.IS_RAM_VANISHES", 1, length),
-        new ColumnHeader("mmio.KEC_ID", 8, length),
-        new ColumnHeader("mmio.LIMB", 32, length),
-        new ColumnHeader("mmio.MMIO_INSTRUCTION", 4, length),
-        new ColumnHeader("mmio.MMIO_STAMP", 8, length),
-        new ColumnHeader("mmio.PHASE", 8, length),
-        new ColumnHeader("mmio.POW_256_1", 32, length),
-        new ColumnHeader("mmio.POW_256_2", 32, length),
-        new ColumnHeader("mmio.SIZE", 32, length),
+        new ColumnHeader("mmio.KEC_ID", 4, length),
+        new ColumnHeader("mmio.LIMB", 16, length),
+        new ColumnHeader("mmio.MMIO_INSTRUCTION", 2, length),
+        new ColumnHeader("mmio.MMIO_STAMP", 4, length),
+        new ColumnHeader("mmio.PHASE", 4, length),
+        new ColumnHeader("mmio.POW_256_1", 16, length),
+        new ColumnHeader("mmio.POW_256_2", 16, length),
+        new ColumnHeader("mmio.SIZE", 8, length),
         new ColumnHeader("mmio.SLOW", 1, length),
-        new ColumnHeader("mmio.SOURCE_BYTE_OFFSET", 2, length),
-        new ColumnHeader("mmio.SOURCE_LIMB_OFFSET", 32, length),
+        new ColumnHeader("mmio.SOURCE_BYTE_OFFSET", 1, length),
+        new ColumnHeader("mmio.SOURCE_LIMB_OFFSET", 8, length),
         new ColumnHeader("mmio.SUCCESS_BIT", 1, length),
-        new ColumnHeader("mmio.TARGET_BYTE_OFFSET", 2, length),
-        new ColumnHeader("mmio.TARGET_LIMB_OFFSET", 32, length),
-        new ColumnHeader("mmio.TOTAL_SIZE", 32, length),
-        new ColumnHeader("mmio.VAL_A", 32, length),
-        new ColumnHeader("mmio.VAL_A_NEW", 32, length),
-        new ColumnHeader("mmio.VAL_B", 32, length),
-        new ColumnHeader("mmio.VAL_B_NEW", 32, length),
-        new ColumnHeader("mmio.VAL_C", 32, length),
-        new ColumnHeader("mmio.VAL_C_NEW", 32, length));
+        new ColumnHeader("mmio.TARGET_BYTE_OFFSET", 1, length),
+        new ColumnHeader("mmio.TARGET_LIMB_OFFSET", 8, length),
+        new ColumnHeader("mmio.TOTAL_SIZE", 8, length),
+        new ColumnHeader("mmio.VAL_A", 16, length),
+        new ColumnHeader("mmio.VAL_A_NEW", 16, length),
+        new ColumnHeader("mmio.VAL_B", 16, length),
+        new ColumnHeader("mmio.VAL_B_NEW", 16, length),
+        new ColumnHeader("mmio.VAL_C", 16, length),
+        new ColumnHeader("mmio.VAL_C_NEW", 16, length));
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -270,11 +271,14 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc1.put((byte) 0);
-    }
-    acc1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
 
     return this;
   }
@@ -286,11 +290,14 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc2.put((byte) 0);
-    }
-    acc2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
 
     return this;
   }
@@ -302,11 +309,14 @@ public class Trace {
       filled.set(2);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc3.put((byte) 0);
-    }
-    acc3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc3.put(bs.get(j)); }
 
     return this;
   }
@@ -318,11 +328,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc4.put((byte) 0);
-    }
-    acc4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc4.put(bs.get(j)); }
 
     return this;
   }
@@ -334,11 +347,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accA.put((byte) 0);
-    }
-    accA.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("accA has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { accA.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accA.put(bs.get(j)); }
 
     return this;
   }
@@ -350,11 +366,14 @@ public class Trace {
       filled.set(5);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accB.put((byte) 0);
-    }
-    accB.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("accB has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { accB.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accB.put(bs.get(j)); }
 
     return this;
   }
@@ -366,11 +385,14 @@ public class Trace {
       filled.set(6);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accC.put((byte) 0);
-    }
-    accC.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("accC has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { accC.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accC.put(bs.get(j)); }
 
     return this;
   }
@@ -382,11 +404,14 @@ public class Trace {
       filled.set(7);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accLimb.put((byte) 0);
-    }
-    accLimb.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("accLimb has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { accLimb.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accLimb.put(bs.get(j)); }
 
     return this;
   }
@@ -506,11 +531,14 @@ public class Trace {
       filled.set(17);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      cnA.put((byte) 0);
-    }
-    cnA.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("cnA has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { cnA.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { cnA.put(bs.get(j)); }
 
     return this;
   }
@@ -522,11 +550,14 @@ public class Trace {
       filled.set(18);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      cnB.put((byte) 0);
-    }
-    cnB.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("cnB has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { cnB.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { cnB.put(bs.get(j)); }
 
     return this;
   }
@@ -538,11 +569,14 @@ public class Trace {
       filled.set(19);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      cnC.put((byte) 0);
-    }
-    cnC.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("cnC has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { cnC.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { cnC.put(bs.get(j)); }
 
     return this;
   }
@@ -554,11 +588,14 @@ public class Trace {
       filled.set(20);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      contextSource.put((byte) 0);
-    }
-    contextSource.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("contextSource has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { contextSource.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { contextSource.put(bs.get(j)); }
 
     return this;
   }
@@ -570,23 +607,28 @@ public class Trace {
       filled.set(21);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      contextTarget.put((byte) 0);
-    }
-    contextTarget.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("contextTarget has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { contextTarget.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { contextTarget.put(bs.get(j)); }
 
     return this;
   }
 
-  public Trace counter(final short b) {
+  public Trace counter(final long b) {
     if (filled.get(22)) {
       throw new IllegalStateException("mmio.COUNTER already set");
     } else {
       filled.set(22);
     }
 
-    counter.putShort(b);
+    if(b >= 256L) { throw new IllegalArgumentException("counter has invalid value (" + b + ")"); }
+    counter.put((byte) b);
+
 
     return this;
   }
@@ -598,7 +640,12 @@ public class Trace {
       filled.set(23);
     }
 
-    exoId.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("exoId has invalid value (" + b + ")"); }
+    exoId.put((byte) (b >> 24));
+    exoId.put((byte) (b >> 16));
+    exoId.put((byte) (b >> 8));
+    exoId.put((byte) b);
+
 
     return this;
   }
@@ -694,7 +741,12 @@ public class Trace {
       filled.set(31);
     }
 
-    exoSum.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("exoSum has invalid value (" + b + ")"); }
+    exoSum.put((byte) (b >> 24));
+    exoSum.put((byte) (b >> 16));
+    exoSum.put((byte) (b >> 8));
+    exoSum.put((byte) b);
+
 
     return this;
   }
@@ -718,11 +770,14 @@ public class Trace {
       filled.set(33);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      indexA.put((byte) 0);
-    }
-    indexA.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("indexA has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { indexA.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { indexA.put(bs.get(j)); }
 
     return this;
   }
@@ -734,11 +789,14 @@ public class Trace {
       filled.set(34);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      indexB.put((byte) 0);
-    }
-    indexB.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("indexB has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { indexB.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { indexB.put(bs.get(j)); }
 
     return this;
   }
@@ -750,11 +808,14 @@ public class Trace {
       filled.set(35);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      indexC.put((byte) 0);
-    }
-    indexC.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("indexC has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { indexC.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { indexC.put(bs.get(j)); }
 
     return this;
   }
@@ -766,11 +827,14 @@ public class Trace {
       filled.set(36);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      indexX.put((byte) 0);
-    }
-    indexX.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("indexX has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { indexX.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { indexX.put(bs.get(j)); }
 
     return this;
   }
@@ -938,7 +1002,12 @@ public class Trace {
       filled.set(50);
     }
 
-    kecId.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("kecId has invalid value (" + b + ")"); }
+    kecId.put((byte) (b >> 24));
+    kecId.put((byte) (b >> 16));
+    kecId.put((byte) (b >> 8));
+    kecId.put((byte) b);
+
 
     return this;
   }
@@ -950,23 +1019,29 @@ public class Trace {
       filled.set(51);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      limb.put((byte) 0);
-    }
-    limb.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
 
     return this;
   }
 
-  public Trace mmioInstruction(final int b) {
+  public Trace mmioInstruction(final long b) {
     if (filled.get(52)) {
       throw new IllegalStateException("mmio.MMIO_INSTRUCTION already set");
     } else {
       filled.set(52);
     }
 
-    mmioInstruction.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("mmioInstruction has invalid value (" + b + ")"); }
+    mmioInstruction.put((byte) (b >> 8));
+    mmioInstruction.put((byte) b);
+
 
     return this;
   }
@@ -978,7 +1053,12 @@ public class Trace {
       filled.set(53);
     }
 
-    mmioStamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("mmioStamp has invalid value (" + b + ")"); }
+    mmioStamp.put((byte) (b >> 24));
+    mmioStamp.put((byte) (b >> 16));
+    mmioStamp.put((byte) (b >> 8));
+    mmioStamp.put((byte) b);
+
 
     return this;
   }
@@ -990,7 +1070,12 @@ public class Trace {
       filled.set(54);
     }
 
-    phase.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("phase has invalid value (" + b + ")"); }
+    phase.put((byte) (b >> 24));
+    phase.put((byte) (b >> 16));
+    phase.put((byte) (b >> 8));
+    phase.put((byte) b);
+
 
     return this;
   }
@@ -1002,11 +1087,14 @@ public class Trace {
       filled.set(55);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      pow2561.put((byte) 0);
-    }
-    pow2561.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("pow2561 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { pow2561.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { pow2561.put(bs.get(j)); }
 
     return this;
   }
@@ -1018,11 +1106,14 @@ public class Trace {
       filled.set(56);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      pow2562.put((byte) 0);
-    }
-    pow2562.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("pow2562 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { pow2562.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { pow2562.put(bs.get(j)); }
 
     return this;
   }
@@ -1034,11 +1125,14 @@ public class Trace {
       filled.set(57);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      size.put((byte) 0);
-    }
-    size.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("size has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { size.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { size.put(bs.get(j)); }
 
     return this;
   }
@@ -1055,14 +1149,16 @@ public class Trace {
     return this;
   }
 
-  public Trace sourceByteOffset(final short b) {
+  public Trace sourceByteOffset(final long b) {
     if (filled.get(59)) {
       throw new IllegalStateException("mmio.SOURCE_BYTE_OFFSET already set");
     } else {
       filled.set(59);
     }
 
-    sourceByteOffset.putShort(b);
+    if(b >= 256L) { throw new IllegalArgumentException("sourceByteOffset has invalid value (" + b + ")"); }
+    sourceByteOffset.put((byte) b);
+
 
     return this;
   }
@@ -1074,11 +1170,14 @@ public class Trace {
       filled.set(60);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      sourceLimbOffset.put((byte) 0);
-    }
-    sourceLimbOffset.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("sourceLimbOffset has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { sourceLimbOffset.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { sourceLimbOffset.put(bs.get(j)); }
 
     return this;
   }
@@ -1095,14 +1194,16 @@ public class Trace {
     return this;
   }
 
-  public Trace targetByteOffset(final short b) {
+  public Trace targetByteOffset(final long b) {
     if (filled.get(62)) {
       throw new IllegalStateException("mmio.TARGET_BYTE_OFFSET already set");
     } else {
       filled.set(62);
     }
 
-    targetByteOffset.putShort(b);
+    if(b >= 256L) { throw new IllegalArgumentException("targetByteOffset has invalid value (" + b + ")"); }
+    targetByteOffset.put((byte) b);
+
 
     return this;
   }
@@ -1114,11 +1215,14 @@ public class Trace {
       filled.set(63);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      targetLimbOffset.put((byte) 0);
-    }
-    targetLimbOffset.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("targetLimbOffset has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { targetLimbOffset.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { targetLimbOffset.put(bs.get(j)); }
 
     return this;
   }
@@ -1130,11 +1234,14 @@ public class Trace {
       filled.set(64);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      totalSize.put((byte) 0);
-    }
-    totalSize.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("totalSize has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { totalSize.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { totalSize.put(bs.get(j)); }
 
     return this;
   }
@@ -1146,11 +1253,14 @@ public class Trace {
       filled.set(65);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      valA.put((byte) 0);
-    }
-    valA.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valA has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { valA.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { valA.put(bs.get(j)); }
 
     return this;
   }
@@ -1162,11 +1272,14 @@ public class Trace {
       filled.set(66);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      valANew.put((byte) 0);
-    }
-    valANew.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valANew has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { valANew.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { valANew.put(bs.get(j)); }
 
     return this;
   }
@@ -1178,11 +1291,14 @@ public class Trace {
       filled.set(67);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      valB.put((byte) 0);
-    }
-    valB.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valB has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { valB.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { valB.put(bs.get(j)); }
 
     return this;
   }
@@ -1194,11 +1310,14 @@ public class Trace {
       filled.set(68);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      valBNew.put((byte) 0);
-    }
-    valBNew.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valBNew has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { valBNew.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { valBNew.put(bs.get(j)); }
 
     return this;
   }
@@ -1210,11 +1329,14 @@ public class Trace {
       filled.set(69);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      valC.put((byte) 0);
-    }
-    valC.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valC has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { valC.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { valC.put(bs.get(j)); }
 
     return this;
   }
@@ -1226,11 +1348,14 @@ public class Trace {
       filled.set(70);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      valCNew.put((byte) 0);
-    }
-    valCNew.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valCNew has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { valCNew.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { valCNew.put(bs.get(j)); }
 
     return this;
   }
@@ -1528,35 +1653,35 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      acc1.position(acc1.position() + 32);
+      acc1.position(acc1.position() + 16);
     }
 
     if (!filled.get(1)) {
-      acc2.position(acc2.position() + 32);
+      acc2.position(acc2.position() + 16);
     }
 
     if (!filled.get(2)) {
-      acc3.position(acc3.position() + 32);
+      acc3.position(acc3.position() + 16);
     }
 
     if (!filled.get(3)) {
-      acc4.position(acc4.position() + 32);
+      acc4.position(acc4.position() + 16);
     }
 
     if (!filled.get(4)) {
-      accA.position(accA.position() + 32);
+      accA.position(accA.position() + 16);
     }
 
     if (!filled.get(5)) {
-      accB.position(accB.position() + 32);
+      accB.position(accB.position() + 16);
     }
 
     if (!filled.get(6)) {
-      accC.position(accC.position() + 32);
+      accC.position(accC.position() + 16);
     }
 
     if (!filled.get(7)) {
-      accLimb.position(accLimb.position() + 32);
+      accLimb.position(accLimb.position() + 16);
     }
 
     if (!filled.get(8)) {
@@ -1596,31 +1721,31 @@ public class Trace {
     }
 
     if (!filled.get(17)) {
-      cnA.position(cnA.position() + 32);
+      cnA.position(cnA.position() + 8);
     }
 
     if (!filled.get(18)) {
-      cnB.position(cnB.position() + 32);
+      cnB.position(cnB.position() + 8);
     }
 
     if (!filled.get(19)) {
-      cnC.position(cnC.position() + 32);
+      cnC.position(cnC.position() + 8);
     }
 
     if (!filled.get(20)) {
-      contextSource.position(contextSource.position() + 32);
+      contextSource.position(contextSource.position() + 8);
     }
 
     if (!filled.get(21)) {
-      contextTarget.position(contextTarget.position() + 32);
+      contextTarget.position(contextTarget.position() + 8);
     }
 
     if (!filled.get(22)) {
-      counter.position(counter.position() + 2);
+      counter.position(counter.position() + 1);
     }
 
     if (!filled.get(23)) {
-      exoId.position(exoId.position() + 8);
+      exoId.position(exoId.position() + 4);
     }
 
     if (!filled.get(24)) {
@@ -1652,7 +1777,7 @@ public class Trace {
     }
 
     if (!filled.get(31)) {
-      exoSum.position(exoSum.position() + 8);
+      exoSum.position(exoSum.position() + 4);
     }
 
     if (!filled.get(32)) {
@@ -1660,19 +1785,19 @@ public class Trace {
     }
 
     if (!filled.get(33)) {
-      indexA.position(indexA.position() + 32);
+      indexA.position(indexA.position() + 8);
     }
 
     if (!filled.get(34)) {
-      indexB.position(indexB.position() + 32);
+      indexB.position(indexB.position() + 8);
     }
 
     if (!filled.get(35)) {
-      indexC.position(indexC.position() + 32);
+      indexC.position(indexC.position() + 8);
     }
 
     if (!filled.get(36)) {
-      indexX.position(indexX.position() + 32);
+      indexX.position(indexX.position() + 8);
     }
 
     if (!filled.get(37)) {
@@ -1728,35 +1853,35 @@ public class Trace {
     }
 
     if (!filled.get(50)) {
-      kecId.position(kecId.position() + 8);
+      kecId.position(kecId.position() + 4);
     }
 
     if (!filled.get(51)) {
-      limb.position(limb.position() + 32);
+      limb.position(limb.position() + 16);
     }
 
     if (!filled.get(52)) {
-      mmioInstruction.position(mmioInstruction.position() + 4);
+      mmioInstruction.position(mmioInstruction.position() + 2);
     }
 
     if (!filled.get(53)) {
-      mmioStamp.position(mmioStamp.position() + 8);
+      mmioStamp.position(mmioStamp.position() + 4);
     }
 
     if (!filled.get(54)) {
-      phase.position(phase.position() + 8);
+      phase.position(phase.position() + 4);
     }
 
     if (!filled.get(55)) {
-      pow2561.position(pow2561.position() + 32);
+      pow2561.position(pow2561.position() + 16);
     }
 
     if (!filled.get(56)) {
-      pow2562.position(pow2562.position() + 32);
+      pow2562.position(pow2562.position() + 16);
     }
 
     if (!filled.get(57)) {
-      size.position(size.position() + 32);
+      size.position(size.position() + 8);
     }
 
     if (!filled.get(58)) {
@@ -1764,11 +1889,11 @@ public class Trace {
     }
 
     if (!filled.get(59)) {
-      sourceByteOffset.position(sourceByteOffset.position() + 2);
+      sourceByteOffset.position(sourceByteOffset.position() + 1);
     }
 
     if (!filled.get(60)) {
-      sourceLimbOffset.position(sourceLimbOffset.position() + 32);
+      sourceLimbOffset.position(sourceLimbOffset.position() + 8);
     }
 
     if (!filled.get(61)) {
@@ -1776,39 +1901,39 @@ public class Trace {
     }
 
     if (!filled.get(62)) {
-      targetByteOffset.position(targetByteOffset.position() + 2);
+      targetByteOffset.position(targetByteOffset.position() + 1);
     }
 
     if (!filled.get(63)) {
-      targetLimbOffset.position(targetLimbOffset.position() + 32);
+      targetLimbOffset.position(targetLimbOffset.position() + 8);
     }
 
     if (!filled.get(64)) {
-      totalSize.position(totalSize.position() + 32);
+      totalSize.position(totalSize.position() + 8);
     }
 
     if (!filled.get(65)) {
-      valA.position(valA.position() + 32);
+      valA.position(valA.position() + 16);
     }
 
     if (!filled.get(66)) {
-      valANew.position(valANew.position() + 32);
+      valANew.position(valANew.position() + 16);
     }
 
     if (!filled.get(67)) {
-      valB.position(valB.position() + 32);
+      valB.position(valB.position() + 16);
     }
 
     if (!filled.get(68)) {
-      valBNew.position(valBNew.position() + 32);
+      valBNew.position(valBNew.position() + 16);
     }
 
     if (!filled.get(69)) {
-      valC.position(valC.position() + 32);
+      valC.position(valC.position() + 16);
     }
 
     if (!filled.get(70)) {
-      valCNew.position(valCNew.position() + 32);
+      valCNew.position(valCNew.position() + 16);
     }
 
     filled.clear();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.mmu;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -138,14 +139,14 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("mmu.AUX_ID_xor_CN_S_xor_EUC_A", 32, length),
+        new ColumnHeader("mmu.AUX_ID_xor_CN_S_xor_EUC_A", 8, length),
         new ColumnHeader("mmu.BIN_1", 1, length),
         new ColumnHeader("mmu.BIN_2", 1, length),
         new ColumnHeader("mmu.BIN_3", 1, length),
         new ColumnHeader("mmu.BIN_4", 1, length),
         new ColumnHeader("mmu.BIN_5", 1, length),
-        new ColumnHeader("mmu.EXO_SUM_xor_EXO_ID", 8, length),
-        new ColumnHeader("mmu.INST_xor_INST_xor_CT", 4, length),
+        new ColumnHeader("mmu.EXO_SUM_xor_EXO_ID", 4, length),
+        new ColumnHeader("mmu.INST_xor_INST_xor_CT", 2, length),
         new ColumnHeader("mmu.IS_ANY_TO_RAM_WITH_PADDING_PURE_PADDING", 1, length),
         new ColumnHeader("mmu.IS_ANY_TO_RAM_WITH_PADDING_SOME_DATA", 1, length),
         new ColumnHeader("mmu.IS_BLAKE", 1, length),
@@ -159,46 +160,46 @@ public class Trace {
         new ColumnHeader("mmu.IS_RAM_TO_EXO_WITH_PADDING", 1, length),
         new ColumnHeader("mmu.IS_RAM_TO_RAM_SANS_PADDING", 1, length),
         new ColumnHeader("mmu.IS_RIGHT_PADDED_WORD_EXTRACTION", 1, length),
-        new ColumnHeader("mmu.KEC_ID", 8, length),
-        new ColumnHeader("mmu.LIMB_1_xor_LIMB_xor_WCP_ARG_1_HI", 32, length),
-        new ColumnHeader("mmu.LIMB_2_xor_WCP_ARG_1_LO", 32, length),
+        new ColumnHeader("mmu.KEC_ID", 4, length),
+        new ColumnHeader("mmu.LIMB_1_xor_LIMB_xor_WCP_ARG_1_HI", 16, length),
+        new ColumnHeader("mmu.LIMB_2_xor_WCP_ARG_1_LO", 16, length),
         new ColumnHeader("mmu.LZRO", 1, length),
         new ColumnHeader("mmu.MACRO", 1, length),
         new ColumnHeader("mmu.MICRO", 1, length),
-        new ColumnHeader("mmu.MMIO_STAMP", 8, length),
+        new ColumnHeader("mmu.MMIO_STAMP", 4, length),
         new ColumnHeader("mmu.NT_FIRST", 1, length),
         new ColumnHeader("mmu.NT_LAST", 1, length),
         new ColumnHeader("mmu.NT_MDDL", 1, length),
         new ColumnHeader("mmu.NT_ONLY", 1, length),
-        new ColumnHeader("mmu.OUT_1", 32, length),
-        new ColumnHeader("mmu.OUT_2", 32, length),
-        new ColumnHeader("mmu.OUT_3", 32, length),
-        new ColumnHeader("mmu.OUT_4", 32, length),
-        new ColumnHeader("mmu.OUT_5", 32, length),
-        new ColumnHeader("mmu.PHASE", 8, length),
-        new ColumnHeader("mmu.PHASE_xor_EXO_SUM", 8, length),
+        new ColumnHeader("mmu.OUT_1", 8, length),
+        new ColumnHeader("mmu.OUT_2", 8, length),
+        new ColumnHeader("mmu.OUT_3", 8, length),
+        new ColumnHeader("mmu.OUT_4", 8, length),
+        new ColumnHeader("mmu.OUT_5", 8, length),
+        new ColumnHeader("mmu.PHASE", 4, length),
+        new ColumnHeader("mmu.PHASE_xor_EXO_SUM", 4, length),
         new ColumnHeader("mmu.PRPRC", 1, length),
-        new ColumnHeader("mmu.REF_OFFSET_xor_CN_T_xor_EUC_B", 32, length),
-        new ColumnHeader("mmu.REF_SIZE_xor_SLO_xor_EUC_CEIL", 32, length),
+        new ColumnHeader("mmu.REF_OFFSET_xor_CN_T_xor_EUC_B", 8, length),
+        new ColumnHeader("mmu.REF_SIZE_xor_SLO_xor_EUC_CEIL", 8, length),
         new ColumnHeader("mmu.RZ_FIRST", 1, length),
         new ColumnHeader("mmu.RZ_LAST", 1, length),
         new ColumnHeader("mmu.RZ_MDDL", 1, length),
         new ColumnHeader("mmu.RZ_ONLY", 1, length),
         new ColumnHeader("mmu.SBO_xor_WCP_INST", 1, length),
         new ColumnHeader("mmu.SIZE", 1, length),
-        new ColumnHeader("mmu.SIZE_xor_TLO_xor_EUC_QUOT", 32, length),
-        new ColumnHeader("mmu.SRC_ID_xor_TOTAL_SIZE_xor_EUC_REM", 32, length),
-        new ColumnHeader("mmu.SRC_OFFSET_HI_xor_WCP_ARG_2_LO", 32, length),
-        new ColumnHeader("mmu.SRC_OFFSET_LO", 32, length),
-        new ColumnHeader("mmu.STAMP", 8, length),
+        new ColumnHeader("mmu.SIZE_xor_TLO_xor_EUC_QUOT", 8, length),
+        new ColumnHeader("mmu.SRC_ID_xor_TOTAL_SIZE_xor_EUC_REM", 8, length),
+        new ColumnHeader("mmu.SRC_OFFSET_HI_xor_WCP_ARG_2_LO", 16, length),
+        new ColumnHeader("mmu.SRC_OFFSET_LO", 16, length),
+        new ColumnHeader("mmu.STAMP", 4, length),
         new ColumnHeader("mmu.SUCCESS_BIT_xor_SUCCESS_BIT_xor_EUC_FLAG", 1, length),
         new ColumnHeader("mmu.TBO", 1, length),
-        new ColumnHeader("mmu.TGT_ID", 32, length),
-        new ColumnHeader("mmu.TGT_OFFSET_LO", 32, length),
-        new ColumnHeader("mmu.TOT", 8, length),
-        new ColumnHeader("mmu.TOTLZ", 8, length),
-        new ColumnHeader("mmu.TOTNT", 8, length),
-        new ColumnHeader("mmu.TOTRZ", 8, length),
+        new ColumnHeader("mmu.TGT_ID", 8, length),
+        new ColumnHeader("mmu.TGT_OFFSET_LO", 8, length),
+        new ColumnHeader("mmu.TOT", 4, length),
+        new ColumnHeader("mmu.TOTLZ", 4, length),
+        new ColumnHeader("mmu.TOTNT", 4, length),
+        new ColumnHeader("mmu.TOTRZ", 4, length),
         new ColumnHeader("mmu.WCP_FLAG", 1, length),
         new ColumnHeader("mmu.WCP_RES", 1, length));
   }
@@ -536,7 +537,12 @@ public class Trace {
       filled.set(21);
     }
 
-    mmioStamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("mmioStamp has invalid value (" + b + ")"); }
+    mmioStamp.put((byte) (b >> 24));
+    mmioStamp.put((byte) (b >> 16));
+    mmioStamp.put((byte) (b >> 8));
+    mmioStamp.put((byte) b);
+
 
     return this;
   }
@@ -596,11 +602,14 @@ public class Trace {
       filled.set(26);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      out1.put((byte) 0);
-    }
-    out1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("out1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { out1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { out1.put(bs.get(j)); }
 
     return this;
   }
@@ -612,11 +621,14 @@ public class Trace {
       filled.set(27);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      out2.put((byte) 0);
-    }
-    out2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("out2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { out2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { out2.put(bs.get(j)); }
 
     return this;
   }
@@ -628,11 +640,14 @@ public class Trace {
       filled.set(28);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      out3.put((byte) 0);
-    }
-    out3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("out3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { out3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { out3.put(bs.get(j)); }
 
     return this;
   }
@@ -644,11 +659,14 @@ public class Trace {
       filled.set(29);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      out4.put((byte) 0);
-    }
-    out4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("out4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { out4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { out4.put(bs.get(j)); }
 
     return this;
   }
@@ -660,11 +678,14 @@ public class Trace {
       filled.set(30);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      out5.put((byte) 0);
-    }
-    out5.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("out5 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { out5.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { out5.put(bs.get(j)); }
 
     return this;
   }
@@ -676,11 +697,14 @@ public class Trace {
       filled.set(52);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      auxIdXorCnSXorEucA.put((byte) 0);
-    }
-    auxIdXorCnSXorEucA.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("auxIdXorCnSXorEucA has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { auxIdXorCnSXorEucA.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { auxIdXorCnSXorEucA.put(bs.get(j)); }
 
     return this;
   }
@@ -692,19 +716,27 @@ public class Trace {
       filled.set(48);
     }
 
-    exoSumXorExoId.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("exoSumXorExoId has invalid value (" + b + ")"); }
+    exoSumXorExoId.put((byte) (b >> 24));
+    exoSumXorExoId.put((byte) (b >> 16));
+    exoSumXorExoId.put((byte) (b >> 8));
+    exoSumXorExoId.put((byte) b);
+
 
     return this;
   }
 
-  public Trace pMacroInst(final int b) {
+  public Trace pMacroInst(final long b) {
     if (filled.get(47)) {
       throw new IllegalStateException("mmu.macro/INST already set");
     } else {
       filled.set(47);
     }
 
-    instXorInstXorCt.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("instXorInstXorCt has invalid value (" + b + ")"); }
+    instXorInstXorCt.put((byte) (b >> 8));
+    instXorInstXorCt.put((byte) b);
+
 
     return this;
   }
@@ -716,11 +748,14 @@ public class Trace {
       filled.set(59);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      limb1XorLimbXorWcpArg1Hi.put((byte) 0);
-    }
-    limb1XorLimbXorWcpArg1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb1XorLimbXorWcpArg1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { limb1XorLimbXorWcpArg1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { limb1XorLimbXorWcpArg1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -732,11 +767,14 @@ public class Trace {
       filled.set(60);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      limb2XorWcpArg1Lo.put((byte) 0);
-    }
-    limb2XorWcpArg1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb2XorWcpArg1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { limb2XorWcpArg1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { limb2XorWcpArg1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -748,7 +786,12 @@ public class Trace {
       filled.set(49);
     }
 
-    phaseXorExoSum.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("phaseXorExoSum has invalid value (" + b + ")"); }
+    phaseXorExoSum.put((byte) (b >> 24));
+    phaseXorExoSum.put((byte) (b >> 16));
+    phaseXorExoSum.put((byte) (b >> 8));
+    phaseXorExoSum.put((byte) b);
+
 
     return this;
   }
@@ -760,11 +803,14 @@ public class Trace {
       filled.set(53);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      refOffsetXorCnTXorEucB.put((byte) 0);
-    }
-    refOffsetXorCnTXorEucB.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("refOffsetXorCnTXorEucB has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { refOffsetXorCnTXorEucB.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { refOffsetXorCnTXorEucB.put(bs.get(j)); }
 
     return this;
   }
@@ -776,11 +822,14 @@ public class Trace {
       filled.set(54);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      refSizeXorSloXorEucCeil.put((byte) 0);
-    }
-    refSizeXorSloXorEucCeil.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("refSizeXorSloXorEucCeil has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { refSizeXorSloXorEucCeil.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { refSizeXorSloXorEucCeil.put(bs.get(j)); }
 
     return this;
   }
@@ -792,11 +841,14 @@ public class Trace {
       filled.set(55);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      sizeXorTloXorEucQuot.put((byte) 0);
-    }
-    sizeXorTloXorEucQuot.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("sizeXorTloXorEucQuot has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { sizeXorTloXorEucQuot.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { sizeXorTloXorEucQuot.put(bs.get(j)); }
 
     return this;
   }
@@ -808,11 +860,14 @@ public class Trace {
       filled.set(56);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      srcIdXorTotalSizeXorEucRem.put((byte) 0);
-    }
-    srcIdXorTotalSizeXorEucRem.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("srcIdXorTotalSizeXorEucRem has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { srcIdXorTotalSizeXorEucRem.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { srcIdXorTotalSizeXorEucRem.put(bs.get(j)); }
 
     return this;
   }
@@ -824,11 +879,14 @@ public class Trace {
       filled.set(61);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      srcOffsetHiXorWcpArg2Lo.put((byte) 0);
-    }
-    srcOffsetHiXorWcpArg2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("srcOffsetHiXorWcpArg2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { srcOffsetHiXorWcpArg2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { srcOffsetHiXorWcpArg2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -840,11 +898,14 @@ public class Trace {
       filled.set(62);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      srcOffsetLo.put((byte) 0);
-    }
-    srcOffsetLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("srcOffsetLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { srcOffsetLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { srcOffsetLo.put(bs.get(j)); }
 
     return this;
   }
@@ -868,11 +929,14 @@ public class Trace {
       filled.set(57);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      tgtId.put((byte) 0);
-    }
-    tgtId.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("tgtId has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { tgtId.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { tgtId.put(bs.get(j)); }
 
     return this;
   }
@@ -884,11 +948,14 @@ public class Trace {
       filled.set(58);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      tgtOffsetLo.put((byte) 0);
-    }
-    tgtOffsetLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("tgtOffsetLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { tgtOffsetLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { tgtOffsetLo.put(bs.get(j)); }
 
     return this;
   }
@@ -900,11 +967,14 @@ public class Trace {
       filled.set(52);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      auxIdXorCnSXorEucA.put((byte) 0);
-    }
-    auxIdXorCnSXorEucA.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("auxIdXorCnSXorEucA has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { auxIdXorCnSXorEucA.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { auxIdXorCnSXorEucA.put(bs.get(j)); }
 
     return this;
   }
@@ -916,11 +986,14 @@ public class Trace {
       filled.set(53);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      refOffsetXorCnTXorEucB.put((byte) 0);
-    }
-    refOffsetXorCnTXorEucB.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("refOffsetXorCnTXorEucB has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { refOffsetXorCnTXorEucB.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { refOffsetXorCnTXorEucB.put(bs.get(j)); }
 
     return this;
   }
@@ -932,7 +1005,12 @@ public class Trace {
       filled.set(48);
     }
 
-    exoSumXorExoId.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("exoSumXorExoId has invalid value (" + b + ")"); }
+    exoSumXorExoId.put((byte) (b >> 24));
+    exoSumXorExoId.put((byte) (b >> 16));
+    exoSumXorExoId.put((byte) (b >> 8));
+    exoSumXorExoId.put((byte) b);
+
 
     return this;
   }
@@ -944,19 +1022,27 @@ public class Trace {
       filled.set(49);
     }
 
-    phaseXorExoSum.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("phaseXorExoSum has invalid value (" + b + ")"); }
+    phaseXorExoSum.put((byte) (b >> 24));
+    phaseXorExoSum.put((byte) (b >> 16));
+    phaseXorExoSum.put((byte) (b >> 8));
+    phaseXorExoSum.put((byte) b);
+
 
     return this;
   }
 
-  public Trace pMicroInst(final int b) {
+  public Trace pMicroInst(final long b) {
     if (filled.get(47)) {
       throw new IllegalStateException("mmu.micro/INST already set");
     } else {
       filled.set(47);
     }
 
-    instXorInstXorCt.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("instXorInstXorCt has invalid value (" + b + ")"); }
+    instXorInstXorCt.put((byte) (b >> 8));
+    instXorInstXorCt.put((byte) b);
+
 
     return this;
   }
@@ -968,7 +1054,12 @@ public class Trace {
       filled.set(50);
     }
 
-    kecId.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("kecId has invalid value (" + b + ")"); }
+    kecId.put((byte) (b >> 24));
+    kecId.put((byte) (b >> 16));
+    kecId.put((byte) (b >> 8));
+    kecId.put((byte) b);
+
 
     return this;
   }
@@ -980,11 +1071,14 @@ public class Trace {
       filled.set(59);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      limb1XorLimbXorWcpArg1Hi.put((byte) 0);
-    }
-    limb1XorLimbXorWcpArg1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb1XorLimbXorWcpArg1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { limb1XorLimbXorWcpArg1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { limb1XorLimbXorWcpArg1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -996,7 +1090,12 @@ public class Trace {
       filled.set(51);
     }
 
-    phase.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("phase has invalid value (" + b + ")"); }
+    phase.put((byte) (b >> 24));
+    phase.put((byte) (b >> 16));
+    phase.put((byte) (b >> 8));
+    phase.put((byte) b);
+
 
     return this;
   }
@@ -1032,11 +1131,14 @@ public class Trace {
       filled.set(54);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      refSizeXorSloXorEucCeil.put((byte) 0);
-    }
-    refSizeXorSloXorEucCeil.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("refSizeXorSloXorEucCeil has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { refSizeXorSloXorEucCeil.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { refSizeXorSloXorEucCeil.put(bs.get(j)); }
 
     return this;
   }
@@ -1072,11 +1174,14 @@ public class Trace {
       filled.set(55);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      sizeXorTloXorEucQuot.put((byte) 0);
-    }
-    sizeXorTloXorEucQuot.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("sizeXorTloXorEucQuot has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { sizeXorTloXorEucQuot.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { sizeXorTloXorEucQuot.put(bs.get(j)); }
 
     return this;
   }
@@ -1088,23 +1193,29 @@ public class Trace {
       filled.set(56);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      srcIdXorTotalSizeXorEucRem.put((byte) 0);
-    }
-    srcIdXorTotalSizeXorEucRem.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("srcIdXorTotalSizeXorEucRem has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { srcIdXorTotalSizeXorEucRem.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { srcIdXorTotalSizeXorEucRem.put(bs.get(j)); }
 
     return this;
   }
 
-  public Trace pPrprcCt(final int b) {
+  public Trace pPrprcCt(final long b) {
     if (filled.get(47)) {
       throw new IllegalStateException("mmu.prprc/CT already set");
     } else {
       filled.set(47);
     }
 
-    instXorInstXorCt.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("instXorInstXorCt has invalid value (" + b + ")"); }
+    instXorInstXorCt.put((byte) (b >> 8));
+    instXorInstXorCt.put((byte) b);
+
 
     return this;
   }
@@ -1116,11 +1227,14 @@ public class Trace {
       filled.set(52);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      auxIdXorCnSXorEucA.put((byte) 0);
-    }
-    auxIdXorCnSXorEucA.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("auxIdXorCnSXorEucA has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { auxIdXorCnSXorEucA.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { auxIdXorCnSXorEucA.put(bs.get(j)); }
 
     return this;
   }
@@ -1132,11 +1246,14 @@ public class Trace {
       filled.set(53);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      refOffsetXorCnTXorEucB.put((byte) 0);
-    }
-    refOffsetXorCnTXorEucB.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("refOffsetXorCnTXorEucB has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { refOffsetXorCnTXorEucB.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { refOffsetXorCnTXorEucB.put(bs.get(j)); }
 
     return this;
   }
@@ -1148,11 +1265,14 @@ public class Trace {
       filled.set(54);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      refSizeXorSloXorEucCeil.put((byte) 0);
-    }
-    refSizeXorSloXorEucCeil.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("refSizeXorSloXorEucCeil has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { refSizeXorSloXorEucCeil.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { refSizeXorSloXorEucCeil.put(bs.get(j)); }
 
     return this;
   }
@@ -1176,11 +1296,14 @@ public class Trace {
       filled.set(55);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      sizeXorTloXorEucQuot.put((byte) 0);
-    }
-    sizeXorTloXorEucQuot.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("sizeXorTloXorEucQuot has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { sizeXorTloXorEucQuot.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { sizeXorTloXorEucQuot.put(bs.get(j)); }
 
     return this;
   }
@@ -1192,11 +1315,14 @@ public class Trace {
       filled.set(56);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      srcIdXorTotalSizeXorEucRem.put((byte) 0);
-    }
-    srcIdXorTotalSizeXorEucRem.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("srcIdXorTotalSizeXorEucRem has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { srcIdXorTotalSizeXorEucRem.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { srcIdXorTotalSizeXorEucRem.put(bs.get(j)); }
 
     return this;
   }
@@ -1208,11 +1334,14 @@ public class Trace {
       filled.set(59);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      limb1XorLimbXorWcpArg1Hi.put((byte) 0);
-    }
-    limb1XorLimbXorWcpArg1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb1XorLimbXorWcpArg1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { limb1XorLimbXorWcpArg1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { limb1XorLimbXorWcpArg1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -1224,11 +1353,14 @@ public class Trace {
       filled.set(60);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      limb2XorWcpArg1Lo.put((byte) 0);
-    }
-    limb2XorWcpArg1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb2XorWcpArg1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { limb2XorWcpArg1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { limb2XorWcpArg1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -1240,11 +1372,14 @@ public class Trace {
       filled.set(61);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      srcOffsetHiXorWcpArg2Lo.put((byte) 0);
-    }
-    srcOffsetHiXorWcpArg2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("srcOffsetHiXorWcpArg2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { srcOffsetHiXorWcpArg2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { srcOffsetHiXorWcpArg2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -1352,7 +1487,12 @@ public class Trace {
       filled.set(36);
     }
 
-    stamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    stamp.put((byte) (b >> 24));
+    stamp.put((byte) (b >> 16));
+    stamp.put((byte) (b >> 8));
+    stamp.put((byte) b);
+
 
     return this;
   }
@@ -1364,7 +1504,12 @@ public class Trace {
       filled.set(37);
     }
 
-    tot.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("tot has invalid value (" + b + ")"); }
+    tot.put((byte) (b >> 24));
+    tot.put((byte) (b >> 16));
+    tot.put((byte) (b >> 8));
+    tot.put((byte) b);
+
 
     return this;
   }
@@ -1376,7 +1521,12 @@ public class Trace {
       filled.set(38);
     }
 
-    totlz.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("totlz has invalid value (" + b + ")"); }
+    totlz.put((byte) (b >> 24));
+    totlz.put((byte) (b >> 16));
+    totlz.put((byte) (b >> 8));
+    totlz.put((byte) b);
+
 
     return this;
   }
@@ -1388,7 +1538,12 @@ public class Trace {
       filled.set(39);
     }
 
-    totnt.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("totnt has invalid value (" + b + ")"); }
+    totnt.put((byte) (b >> 24));
+    totnt.put((byte) (b >> 16));
+    totnt.put((byte) (b >> 8));
+    totnt.put((byte) b);
+
 
     return this;
   }
@@ -1400,7 +1555,12 @@ public class Trace {
       filled.set(40);
     }
 
-    totrz.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("totrz has invalid value (" + b + ")"); }
+    totrz.put((byte) (b >> 24));
+    totrz.put((byte) (b >> 16));
+    totrz.put((byte) (b >> 8));
+    totrz.put((byte) b);
+
 
     return this;
   }
@@ -1439,13 +1599,11 @@ public class Trace {
     }
 
     if (!filled.get(5)) {
-      throw new IllegalStateException(
-          "mmu.IS_ANY_TO_RAM_WITH_PADDING_PURE_PADDING has not been filled");
+      throw new IllegalStateException("mmu.IS_ANY_TO_RAM_WITH_PADDING_PURE_PADDING has not been filled");
     }
 
     if (!filled.get(6)) {
-      throw new IllegalStateException(
-          "mmu.IS_ANY_TO_RAM_WITH_PADDING_SOME_DATA has not been filled");
+      throw new IllegalStateException("mmu.IS_ANY_TO_RAM_WITH_PADDING_SOME_DATA has not been filled");
     }
 
     if (!filled.get(7)) {
@@ -1621,8 +1779,7 @@ public class Trace {
     }
 
     if (!filled.get(41)) {
-      throw new IllegalStateException(
-          "mmu.SUCCESS_BIT_xor_SUCCESS_BIT_xor_EUC_FLAG has not been filled");
+      throw new IllegalStateException("mmu.SUCCESS_BIT_xor_SUCCESS_BIT_xor_EUC_FLAG has not been filled");
     }
 
     if (!filled.get(46)) {
@@ -1669,7 +1826,7 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(52)) {
-      auxIdXorCnSXorEucA.position(auxIdXorCnSXorEucA.position() + 32);
+      auxIdXorCnSXorEucA.position(auxIdXorCnSXorEucA.position() + 8);
     }
 
     if (!filled.get(0)) {
@@ -1693,11 +1850,11 @@ public class Trace {
     }
 
     if (!filled.get(48)) {
-      exoSumXorExoId.position(exoSumXorExoId.position() + 8);
+      exoSumXorExoId.position(exoSumXorExoId.position() + 4);
     }
 
     if (!filled.get(47)) {
-      instXorInstXorCt.position(instXorInstXorCt.position() + 4);
+      instXorInstXorCt.position(instXorInstXorCt.position() + 2);
     }
 
     if (!filled.get(5)) {
@@ -1753,15 +1910,15 @@ public class Trace {
     }
 
     if (!filled.get(50)) {
-      kecId.position(kecId.position() + 8);
+      kecId.position(kecId.position() + 4);
     }
 
     if (!filled.get(59)) {
-      limb1XorLimbXorWcpArg1Hi.position(limb1XorLimbXorWcpArg1Hi.position() + 32);
+      limb1XorLimbXorWcpArg1Hi.position(limb1XorLimbXorWcpArg1Hi.position() + 16);
     }
 
     if (!filled.get(60)) {
-      limb2XorWcpArg1Lo.position(limb2XorWcpArg1Lo.position() + 32);
+      limb2XorWcpArg1Lo.position(limb2XorWcpArg1Lo.position() + 16);
     }
 
     if (!filled.get(18)) {
@@ -1777,7 +1934,7 @@ public class Trace {
     }
 
     if (!filled.get(21)) {
-      mmioStamp.position(mmioStamp.position() + 8);
+      mmioStamp.position(mmioStamp.position() + 4);
     }
 
     if (!filled.get(22)) {
@@ -1797,31 +1954,31 @@ public class Trace {
     }
 
     if (!filled.get(26)) {
-      out1.position(out1.position() + 32);
+      out1.position(out1.position() + 8);
     }
 
     if (!filled.get(27)) {
-      out2.position(out2.position() + 32);
+      out2.position(out2.position() + 8);
     }
 
     if (!filled.get(28)) {
-      out3.position(out3.position() + 32);
+      out3.position(out3.position() + 8);
     }
 
     if (!filled.get(29)) {
-      out4.position(out4.position() + 32);
+      out4.position(out4.position() + 8);
     }
 
     if (!filled.get(30)) {
-      out5.position(out5.position() + 32);
+      out5.position(out5.position() + 8);
     }
 
     if (!filled.get(51)) {
-      phase.position(phase.position() + 8);
+      phase.position(phase.position() + 4);
     }
 
     if (!filled.get(49)) {
-      phaseXorExoSum.position(phaseXorExoSum.position() + 8);
+      phaseXorExoSum.position(phaseXorExoSum.position() + 4);
     }
 
     if (!filled.get(31)) {
@@ -1829,11 +1986,11 @@ public class Trace {
     }
 
     if (!filled.get(53)) {
-      refOffsetXorCnTXorEucB.position(refOffsetXorCnTXorEucB.position() + 32);
+      refOffsetXorCnTXorEucB.position(refOffsetXorCnTXorEucB.position() + 8);
     }
 
     if (!filled.get(54)) {
-      refSizeXorSloXorEucCeil.position(refSizeXorSloXorEucCeil.position() + 32);
+      refSizeXorSloXorEucCeil.position(refSizeXorSloXorEucCeil.position() + 8);
     }
 
     if (!filled.get(32)) {
@@ -1861,23 +2018,23 @@ public class Trace {
     }
 
     if (!filled.get(55)) {
-      sizeXorTloXorEucQuot.position(sizeXorTloXorEucQuot.position() + 32);
+      sizeXorTloXorEucQuot.position(sizeXorTloXorEucQuot.position() + 8);
     }
 
     if (!filled.get(56)) {
-      srcIdXorTotalSizeXorEucRem.position(srcIdXorTotalSizeXorEucRem.position() + 32);
+      srcIdXorTotalSizeXorEucRem.position(srcIdXorTotalSizeXorEucRem.position() + 8);
     }
 
     if (!filled.get(61)) {
-      srcOffsetHiXorWcpArg2Lo.position(srcOffsetHiXorWcpArg2Lo.position() + 32);
+      srcOffsetHiXorWcpArg2Lo.position(srcOffsetHiXorWcpArg2Lo.position() + 16);
     }
 
     if (!filled.get(62)) {
-      srcOffsetLo.position(srcOffsetLo.position() + 32);
+      srcOffsetLo.position(srcOffsetLo.position() + 16);
     }
 
     if (!filled.get(36)) {
-      stamp.position(stamp.position() + 8);
+      stamp.position(stamp.position() + 4);
     }
 
     if (!filled.get(41)) {
@@ -1889,27 +2046,27 @@ public class Trace {
     }
 
     if (!filled.get(57)) {
-      tgtId.position(tgtId.position() + 32);
+      tgtId.position(tgtId.position() + 8);
     }
 
     if (!filled.get(58)) {
-      tgtOffsetLo.position(tgtOffsetLo.position() + 32);
+      tgtOffsetLo.position(tgtOffsetLo.position() + 8);
     }
 
     if (!filled.get(37)) {
-      tot.position(tot.position() + 8);
+      tot.position(tot.position() + 4);
     }
 
     if (!filled.get(38)) {
-      totlz.position(totlz.position() + 8);
+      totlz.position(totlz.position() + 4);
     }
 
     if (!filled.get(39)) {
-      totnt.position(totnt.position() + 8);
+      totnt.position(totnt.position() + 4);
     }
 
     if (!filled.get(40)) {
-      totrz.position(totrz.position() + 8);
+      totrz.position(totrz.position() + 4);
     }
 
     if (!filled.get(42)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.mmu;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -537,12 +536,13 @@ public class Trace {
       filled.set(21);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("mmioStamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("mmioStamp has invalid value (" + b + ")");
+    }
     mmioStamp.put((byte) (b >> 24));
     mmioStamp.put((byte) (b >> 16));
     mmioStamp.put((byte) (b >> 8));
     mmioStamp.put((byte) b);
-
 
     return this;
   }
@@ -605,11 +605,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("out1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("out1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { out1.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      out1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { out1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      out1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -624,11 +630,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("out2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("out2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { out2.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      out2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { out2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      out2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -643,11 +655,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("out3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("out3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { out3.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      out3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { out3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      out3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -662,11 +680,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("out4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("out4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { out4.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      out4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { out4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      out4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -681,11 +705,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("out5 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("out5 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { out5.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      out5.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { out5.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      out5.put(bs.get(j));
+    }
 
     return this;
   }
@@ -700,11 +730,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("auxIdXorCnSXorEucA has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "auxIdXorCnSXorEucA has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { auxIdXorCnSXorEucA.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      auxIdXorCnSXorEucA.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { auxIdXorCnSXorEucA.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      auxIdXorCnSXorEucA.put(bs.get(j));
+    }
 
     return this;
   }
@@ -716,12 +753,13 @@ public class Trace {
       filled.set(48);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("exoSumXorExoId has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("exoSumXorExoId has invalid value (" + b + ")");
+    }
     exoSumXorExoId.put((byte) (b >> 24));
     exoSumXorExoId.put((byte) (b >> 16));
     exoSumXorExoId.put((byte) (b >> 8));
     exoSumXorExoId.put((byte) b);
-
 
     return this;
   }
@@ -733,10 +771,11 @@ public class Trace {
       filled.set(47);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("instXorInstXorCt has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("instXorInstXorCt has invalid value (" + b + ")");
+    }
     instXorInstXorCt.put((byte) (b >> 8));
     instXorInstXorCt.put((byte) b);
-
 
     return this;
   }
@@ -751,11 +790,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb1XorLimbXorWcpArg1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "limb1XorLimbXorWcpArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { limb1XorLimbXorWcpArg1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      limb1XorLimbXorWcpArg1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { limb1XorLimbXorWcpArg1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      limb1XorLimbXorWcpArg1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -770,11 +816,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb2XorWcpArg1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "limb2XorWcpArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { limb2XorWcpArg1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      limb2XorWcpArg1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { limb2XorWcpArg1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      limb2XorWcpArg1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -786,12 +839,13 @@ public class Trace {
       filled.set(49);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("phaseXorExoSum has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("phaseXorExoSum has invalid value (" + b + ")");
+    }
     phaseXorExoSum.put((byte) (b >> 24));
     phaseXorExoSum.put((byte) (b >> 16));
     phaseXorExoSum.put((byte) (b >> 8));
     phaseXorExoSum.put((byte) b);
-
 
     return this;
   }
@@ -806,11 +860,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("refOffsetXorCnTXorEucB has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "refOffsetXorCnTXorEucB has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { refOffsetXorCnTXorEucB.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      refOffsetXorCnTXorEucB.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { refOffsetXorCnTXorEucB.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      refOffsetXorCnTXorEucB.put(bs.get(j));
+    }
 
     return this;
   }
@@ -825,11 +886,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("refSizeXorSloXorEucCeil has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "refSizeXorSloXorEucCeil has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { refSizeXorSloXorEucCeil.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      refSizeXorSloXorEucCeil.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { refSizeXorSloXorEucCeil.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      refSizeXorSloXorEucCeil.put(bs.get(j));
+    }
 
     return this;
   }
@@ -844,11 +912,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("sizeXorTloXorEucQuot has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "sizeXorTloXorEucQuot has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { sizeXorTloXorEucQuot.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      sizeXorTloXorEucQuot.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { sizeXorTloXorEucQuot.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      sizeXorTloXorEucQuot.put(bs.get(j));
+    }
 
     return this;
   }
@@ -863,11 +938,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("srcIdXorTotalSizeXorEucRem has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "srcIdXorTotalSizeXorEucRem has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { srcIdXorTotalSizeXorEucRem.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      srcIdXorTotalSizeXorEucRem.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { srcIdXorTotalSizeXorEucRem.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      srcIdXorTotalSizeXorEucRem.put(bs.get(j));
+    }
 
     return this;
   }
@@ -882,11 +964,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("srcOffsetHiXorWcpArg2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "srcOffsetHiXorWcpArg2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { srcOffsetHiXorWcpArg2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      srcOffsetHiXorWcpArg2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { srcOffsetHiXorWcpArg2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      srcOffsetHiXorWcpArg2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -901,11 +990,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("srcOffsetLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "srcOffsetLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { srcOffsetLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      srcOffsetLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { srcOffsetLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      srcOffsetLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -932,11 +1028,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("tgtId has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("tgtId has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { tgtId.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      tgtId.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { tgtId.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      tgtId.put(bs.get(j));
+    }
 
     return this;
   }
@@ -951,11 +1053,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("tgtOffsetLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "tgtOffsetLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { tgtOffsetLo.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      tgtOffsetLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { tgtOffsetLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      tgtOffsetLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -970,11 +1079,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("auxIdXorCnSXorEucA has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "auxIdXorCnSXorEucA has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { auxIdXorCnSXorEucA.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      auxIdXorCnSXorEucA.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { auxIdXorCnSXorEucA.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      auxIdXorCnSXorEucA.put(bs.get(j));
+    }
 
     return this;
   }
@@ -989,11 +1105,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("refOffsetXorCnTXorEucB has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "refOffsetXorCnTXorEucB has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { refOffsetXorCnTXorEucB.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      refOffsetXorCnTXorEucB.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { refOffsetXorCnTXorEucB.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      refOffsetXorCnTXorEucB.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1005,12 +1128,13 @@ public class Trace {
       filled.set(48);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("exoSumXorExoId has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("exoSumXorExoId has invalid value (" + b + ")");
+    }
     exoSumXorExoId.put((byte) (b >> 24));
     exoSumXorExoId.put((byte) (b >> 16));
     exoSumXorExoId.put((byte) (b >> 8));
     exoSumXorExoId.put((byte) b);
-
 
     return this;
   }
@@ -1022,12 +1146,13 @@ public class Trace {
       filled.set(49);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("phaseXorExoSum has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("phaseXorExoSum has invalid value (" + b + ")");
+    }
     phaseXorExoSum.put((byte) (b >> 24));
     phaseXorExoSum.put((byte) (b >> 16));
     phaseXorExoSum.put((byte) (b >> 8));
     phaseXorExoSum.put((byte) b);
-
 
     return this;
   }
@@ -1039,10 +1164,11 @@ public class Trace {
       filled.set(47);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("instXorInstXorCt has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("instXorInstXorCt has invalid value (" + b + ")");
+    }
     instXorInstXorCt.put((byte) (b >> 8));
     instXorInstXorCt.put((byte) b);
-
 
     return this;
   }
@@ -1054,12 +1180,13 @@ public class Trace {
       filled.set(50);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("kecId has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("kecId has invalid value (" + b + ")");
+    }
     kecId.put((byte) (b >> 24));
     kecId.put((byte) (b >> 16));
     kecId.put((byte) (b >> 8));
     kecId.put((byte) b);
-
 
     return this;
   }
@@ -1074,11 +1201,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb1XorLimbXorWcpArg1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "limb1XorLimbXorWcpArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { limb1XorLimbXorWcpArg1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      limb1XorLimbXorWcpArg1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { limb1XorLimbXorWcpArg1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      limb1XorLimbXorWcpArg1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1090,12 +1224,13 @@ public class Trace {
       filled.set(51);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("phase has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("phase has invalid value (" + b + ")");
+    }
     phase.put((byte) (b >> 24));
     phase.put((byte) (b >> 16));
     phase.put((byte) (b >> 8));
     phase.put((byte) b);
-
 
     return this;
   }
@@ -1134,11 +1269,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("refSizeXorSloXorEucCeil has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "refSizeXorSloXorEucCeil has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { refSizeXorSloXorEucCeil.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      refSizeXorSloXorEucCeil.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { refSizeXorSloXorEucCeil.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      refSizeXorSloXorEucCeil.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1177,11 +1319,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("sizeXorTloXorEucQuot has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "sizeXorTloXorEucQuot has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { sizeXorTloXorEucQuot.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      sizeXorTloXorEucQuot.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { sizeXorTloXorEucQuot.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      sizeXorTloXorEucQuot.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1196,11 +1345,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("srcIdXorTotalSizeXorEucRem has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "srcIdXorTotalSizeXorEucRem has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { srcIdXorTotalSizeXorEucRem.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      srcIdXorTotalSizeXorEucRem.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { srcIdXorTotalSizeXorEucRem.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      srcIdXorTotalSizeXorEucRem.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1212,10 +1368,11 @@ public class Trace {
       filled.set(47);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("instXorInstXorCt has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("instXorInstXorCt has invalid value (" + b + ")");
+    }
     instXorInstXorCt.put((byte) (b >> 8));
     instXorInstXorCt.put((byte) b);
-
 
     return this;
   }
@@ -1230,11 +1387,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("auxIdXorCnSXorEucA has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "auxIdXorCnSXorEucA has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { auxIdXorCnSXorEucA.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      auxIdXorCnSXorEucA.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { auxIdXorCnSXorEucA.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      auxIdXorCnSXorEucA.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1249,11 +1413,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("refOffsetXorCnTXorEucB has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "refOffsetXorCnTXorEucB has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { refOffsetXorCnTXorEucB.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      refOffsetXorCnTXorEucB.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { refOffsetXorCnTXorEucB.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      refOffsetXorCnTXorEucB.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1268,11 +1439,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("refSizeXorSloXorEucCeil has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "refSizeXorSloXorEucCeil has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { refSizeXorSloXorEucCeil.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      refSizeXorSloXorEucCeil.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { refSizeXorSloXorEucCeil.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      refSizeXorSloXorEucCeil.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1299,11 +1477,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("sizeXorTloXorEucQuot has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "sizeXorTloXorEucQuot has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { sizeXorTloXorEucQuot.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      sizeXorTloXorEucQuot.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { sizeXorTloXorEucQuot.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      sizeXorTloXorEucQuot.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1318,11 +1503,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("srcIdXorTotalSizeXorEucRem has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "srcIdXorTotalSizeXorEucRem has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { srcIdXorTotalSizeXorEucRem.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      srcIdXorTotalSizeXorEucRem.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { srcIdXorTotalSizeXorEucRem.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      srcIdXorTotalSizeXorEucRem.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1337,11 +1529,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb1XorLimbXorWcpArg1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "limb1XorLimbXorWcpArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { limb1XorLimbXorWcpArg1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      limb1XorLimbXorWcpArg1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { limb1XorLimbXorWcpArg1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      limb1XorLimbXorWcpArg1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1356,11 +1555,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb2XorWcpArg1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "limb2XorWcpArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { limb2XorWcpArg1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      limb2XorWcpArg1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { limb2XorWcpArg1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      limb2XorWcpArg1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1375,11 +1581,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("srcOffsetHiXorWcpArg2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "srcOffsetHiXorWcpArg2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { srcOffsetHiXorWcpArg2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      srcOffsetHiXorWcpArg2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { srcOffsetHiXorWcpArg2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      srcOffsetHiXorWcpArg2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1487,12 +1700,13 @@ public class Trace {
       filled.set(36);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+    }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));
     stamp.put((byte) b);
-
 
     return this;
   }
@@ -1504,12 +1718,13 @@ public class Trace {
       filled.set(37);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("tot has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("tot has invalid value (" + b + ")");
+    }
     tot.put((byte) (b >> 24));
     tot.put((byte) (b >> 16));
     tot.put((byte) (b >> 8));
     tot.put((byte) b);
-
 
     return this;
   }
@@ -1521,12 +1736,13 @@ public class Trace {
       filled.set(38);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("totlz has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("totlz has invalid value (" + b + ")");
+    }
     totlz.put((byte) (b >> 24));
     totlz.put((byte) (b >> 16));
     totlz.put((byte) (b >> 8));
     totlz.put((byte) b);
-
 
     return this;
   }
@@ -1538,12 +1754,13 @@ public class Trace {
       filled.set(39);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("totnt has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("totnt has invalid value (" + b + ")");
+    }
     totnt.put((byte) (b >> 24));
     totnt.put((byte) (b >> 16));
     totnt.put((byte) (b >> 8));
     totnt.put((byte) b);
-
 
     return this;
   }
@@ -1555,12 +1772,13 @@ public class Trace {
       filled.set(40);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("totrz has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("totrz has invalid value (" + b + ")");
+    }
     totrz.put((byte) (b >> 24));
     totrz.put((byte) (b >> 16));
     totrz.put((byte) (b >> 8));
     totrz.put((byte) b);
-
 
     return this;
   }
@@ -1599,11 +1817,13 @@ public class Trace {
     }
 
     if (!filled.get(5)) {
-      throw new IllegalStateException("mmu.IS_ANY_TO_RAM_WITH_PADDING_PURE_PADDING has not been filled");
+      throw new IllegalStateException(
+          "mmu.IS_ANY_TO_RAM_WITH_PADDING_PURE_PADDING has not been filled");
     }
 
     if (!filled.get(6)) {
-      throw new IllegalStateException("mmu.IS_ANY_TO_RAM_WITH_PADDING_SOME_DATA has not been filled");
+      throw new IllegalStateException(
+          "mmu.IS_ANY_TO_RAM_WITH_PADDING_SOME_DATA has not been filled");
     }
 
     if (!filled.get(7)) {
@@ -1779,7 +1999,8 @@ public class Trace {
     }
 
     if (!filled.get(41)) {
-      throw new IllegalStateException("mmu.SUCCESS_BIT_xor_SUCCESS_BIT_xor_EUC_FLAG has not been filled");
+      throw new IllegalStateException(
+          "mmu.SUCCESS_BIT_xor_SUCCESS_BIT_xor_EUC_FLAG has not been filled");
     }
 
     if (!filled.get(46)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mod/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mod/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.mod;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -103,33 +104,33 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("mod.ACC_1_2", 32, length),
-        new ColumnHeader("mod.ACC_1_3", 32, length),
-        new ColumnHeader("mod.ACC_2_2", 32, length),
-        new ColumnHeader("mod.ACC_2_3", 32, length),
-        new ColumnHeader("mod.ACC_B_0", 32, length),
-        new ColumnHeader("mod.ACC_B_1", 32, length),
-        new ColumnHeader("mod.ACC_B_2", 32, length),
-        new ColumnHeader("mod.ACC_B_3", 32, length),
-        new ColumnHeader("mod.ACC_DELTA_0", 32, length),
-        new ColumnHeader("mod.ACC_DELTA_1", 32, length),
-        new ColumnHeader("mod.ACC_DELTA_2", 32, length),
-        new ColumnHeader("mod.ACC_DELTA_3", 32, length),
-        new ColumnHeader("mod.ACC_H_0", 32, length),
-        new ColumnHeader("mod.ACC_H_1", 32, length),
-        new ColumnHeader("mod.ACC_H_2", 32, length),
-        new ColumnHeader("mod.ACC_Q_0", 32, length),
-        new ColumnHeader("mod.ACC_Q_1", 32, length),
-        new ColumnHeader("mod.ACC_Q_2", 32, length),
-        new ColumnHeader("mod.ACC_Q_3", 32, length),
-        new ColumnHeader("mod.ACC_R_0", 32, length),
-        new ColumnHeader("mod.ACC_R_1", 32, length),
-        new ColumnHeader("mod.ACC_R_2", 32, length),
-        new ColumnHeader("mod.ACC_R_3", 32, length),
-        new ColumnHeader("mod.ARG_1_HI", 32, length),
-        new ColumnHeader("mod.ARG_1_LO", 32, length),
-        new ColumnHeader("mod.ARG_2_HI", 32, length),
-        new ColumnHeader("mod.ARG_2_LO", 32, length),
+        new ColumnHeader("mod.ACC_1_2", 8, length),
+        new ColumnHeader("mod.ACC_1_3", 8, length),
+        new ColumnHeader("mod.ACC_2_2", 8, length),
+        new ColumnHeader("mod.ACC_2_3", 8, length),
+        new ColumnHeader("mod.ACC_B_0", 8, length),
+        new ColumnHeader("mod.ACC_B_1", 8, length),
+        new ColumnHeader("mod.ACC_B_2", 8, length),
+        new ColumnHeader("mod.ACC_B_3", 8, length),
+        new ColumnHeader("mod.ACC_DELTA_0", 8, length),
+        new ColumnHeader("mod.ACC_DELTA_1", 8, length),
+        new ColumnHeader("mod.ACC_DELTA_2", 8, length),
+        new ColumnHeader("mod.ACC_DELTA_3", 8, length),
+        new ColumnHeader("mod.ACC_H_0", 8, length),
+        new ColumnHeader("mod.ACC_H_1", 8, length),
+        new ColumnHeader("mod.ACC_H_2", 8, length),
+        new ColumnHeader("mod.ACC_Q_0", 8, length),
+        new ColumnHeader("mod.ACC_Q_1", 8, length),
+        new ColumnHeader("mod.ACC_Q_2", 8, length),
+        new ColumnHeader("mod.ACC_Q_3", 8, length),
+        new ColumnHeader("mod.ACC_R_0", 8, length),
+        new ColumnHeader("mod.ACC_R_1", 8, length),
+        new ColumnHeader("mod.ACC_R_2", 8, length),
+        new ColumnHeader("mod.ACC_R_3", 8, length),
+        new ColumnHeader("mod.ARG_1_HI", 16, length),
+        new ColumnHeader("mod.ARG_1_LO", 16, length),
+        new ColumnHeader("mod.ARG_2_HI", 16, length),
+        new ColumnHeader("mod.ARG_2_LO", 16, length),
         new ColumnHeader("mod.BYTE_1_2", 1, length),
         new ColumnHeader("mod.BYTE_1_3", 1, length),
         new ColumnHeader("mod.BYTE_2_2", 1, length),
@@ -155,7 +156,7 @@ public class Trace {
         new ColumnHeader("mod.BYTE_R_3", 1, length),
         new ColumnHeader("mod.CMP_1", 1, length),
         new ColumnHeader("mod.CMP_2", 1, length),
-        new ColumnHeader("mod.CT", 2, length),
+        new ColumnHeader("mod.CT", 1, length),
         new ColumnHeader("mod.INST", 1, length),
         new ColumnHeader("mod.IS_DIV", 1, length),
         new ColumnHeader("mod.IS_MOD", 1, length),
@@ -165,10 +166,10 @@ public class Trace {
         new ColumnHeader("mod.MSB_1", 1, length),
         new ColumnHeader("mod.MSB_2", 1, length),
         new ColumnHeader("mod.OLI", 1, length),
-        new ColumnHeader("mod.RES_HI", 32, length),
-        new ColumnHeader("mod.RES_LO", 32, length),
+        new ColumnHeader("mod.RES_HI", 16, length),
+        new ColumnHeader("mod.RES_LO", 16, length),
         new ColumnHeader("mod.SIGNED", 1, length),
-        new ColumnHeader("mod.STAMP", 8, length));
+        new ColumnHeader("mod.STAMP", 4, length));
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -255,11 +256,14 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc12.put((byte) 0);
-    }
-    acc12.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("acc12 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { acc12.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc12.put(bs.get(j)); }
 
     return this;
   }
@@ -271,11 +275,14 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc13.put((byte) 0);
-    }
-    acc13.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("acc13 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { acc13.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc13.put(bs.get(j)); }
 
     return this;
   }
@@ -287,11 +294,14 @@ public class Trace {
       filled.set(2);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc22.put((byte) 0);
-    }
-    acc22.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("acc22 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { acc22.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc22.put(bs.get(j)); }
 
     return this;
   }
@@ -303,11 +313,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc23.put((byte) 0);
-    }
-    acc23.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("acc23 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { acc23.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc23.put(bs.get(j)); }
 
     return this;
   }
@@ -319,11 +332,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accB0.put((byte) 0);
-    }
-    accB0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accB0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accB0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accB0.put(bs.get(j)); }
 
     return this;
   }
@@ -335,11 +351,14 @@ public class Trace {
       filled.set(5);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accB1.put((byte) 0);
-    }
-    accB1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accB1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accB1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accB1.put(bs.get(j)); }
 
     return this;
   }
@@ -351,11 +370,14 @@ public class Trace {
       filled.set(6);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accB2.put((byte) 0);
-    }
-    accB2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accB2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accB2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accB2.put(bs.get(j)); }
 
     return this;
   }
@@ -367,11 +389,14 @@ public class Trace {
       filled.set(7);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accB3.put((byte) 0);
-    }
-    accB3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accB3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accB3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accB3.put(bs.get(j)); }
 
     return this;
   }
@@ -383,11 +408,14 @@ public class Trace {
       filled.set(8);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accDelta0.put((byte) 0);
-    }
-    accDelta0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accDelta0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accDelta0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accDelta0.put(bs.get(j)); }
 
     return this;
   }
@@ -399,11 +427,14 @@ public class Trace {
       filled.set(9);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accDelta1.put((byte) 0);
-    }
-    accDelta1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accDelta1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accDelta1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accDelta1.put(bs.get(j)); }
 
     return this;
   }
@@ -415,11 +446,14 @@ public class Trace {
       filled.set(10);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accDelta2.put((byte) 0);
-    }
-    accDelta2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accDelta2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accDelta2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accDelta2.put(bs.get(j)); }
 
     return this;
   }
@@ -431,11 +465,14 @@ public class Trace {
       filled.set(11);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accDelta3.put((byte) 0);
-    }
-    accDelta3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accDelta3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accDelta3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accDelta3.put(bs.get(j)); }
 
     return this;
   }
@@ -447,11 +484,14 @@ public class Trace {
       filled.set(12);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accH0.put((byte) 0);
-    }
-    accH0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accH0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accH0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accH0.put(bs.get(j)); }
 
     return this;
   }
@@ -463,11 +503,14 @@ public class Trace {
       filled.set(13);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accH1.put((byte) 0);
-    }
-    accH1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accH1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accH1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accH1.put(bs.get(j)); }
 
     return this;
   }
@@ -479,11 +522,14 @@ public class Trace {
       filled.set(14);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accH2.put((byte) 0);
-    }
-    accH2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accH2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accH2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accH2.put(bs.get(j)); }
 
     return this;
   }
@@ -495,11 +541,14 @@ public class Trace {
       filled.set(15);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accQ0.put((byte) 0);
-    }
-    accQ0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accQ0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accQ0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accQ0.put(bs.get(j)); }
 
     return this;
   }
@@ -511,11 +560,14 @@ public class Trace {
       filled.set(16);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accQ1.put((byte) 0);
-    }
-    accQ1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accQ1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accQ1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accQ1.put(bs.get(j)); }
 
     return this;
   }
@@ -527,11 +579,14 @@ public class Trace {
       filled.set(17);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accQ2.put((byte) 0);
-    }
-    accQ2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accQ2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accQ2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accQ2.put(bs.get(j)); }
 
     return this;
   }
@@ -543,11 +598,14 @@ public class Trace {
       filled.set(18);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accQ3.put((byte) 0);
-    }
-    accQ3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accQ3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accQ3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accQ3.put(bs.get(j)); }
 
     return this;
   }
@@ -559,11 +617,14 @@ public class Trace {
       filled.set(19);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accR0.put((byte) 0);
-    }
-    accR0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accR0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accR0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accR0.put(bs.get(j)); }
 
     return this;
   }
@@ -575,11 +636,14 @@ public class Trace {
       filled.set(20);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accR1.put((byte) 0);
-    }
-    accR1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accR1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accR1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accR1.put(bs.get(j)); }
 
     return this;
   }
@@ -591,11 +655,14 @@ public class Trace {
       filled.set(21);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accR2.put((byte) 0);
-    }
-    accR2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accR2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accR2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accR2.put(bs.get(j)); }
 
     return this;
   }
@@ -607,11 +674,14 @@ public class Trace {
       filled.set(22);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accR3.put((byte) 0);
-    }
-    accR3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accR3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { accR3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accR3.put(bs.get(j)); }
 
     return this;
   }
@@ -623,11 +693,14 @@ public class Trace {
       filled.set(23);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg1Hi.put((byte) 0);
-    }
-    arg1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -639,11 +712,14 @@ public class Trace {
       filled.set(24);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg1Lo.put((byte) 0);
-    }
-    arg1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -655,11 +731,14 @@ public class Trace {
       filled.set(25);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg2Hi.put((byte) 0);
-    }
-    arg2Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg2Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg2Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -671,11 +750,14 @@ public class Trace {
       filled.set(26);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg2Lo.put((byte) 0);
-    }
-    arg2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -980,14 +1062,16 @@ public class Trace {
     return this;
   }
 
-  public Trace ct(final short b) {
+  public Trace ct(final long b) {
     if (filled.get(52)) {
       throw new IllegalStateException("mod.CT already set");
     } else {
       filled.set(52);
     }
 
-    ct.putShort(b);
+    if(b >= 16L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    ct.put((byte) b);
+
 
     return this;
   }
@@ -1107,11 +1191,14 @@ public class Trace {
       filled.set(62);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resHi.put((byte) 0);
-    }
-    resHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { resHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resHi.put(bs.get(j)); }
 
     return this;
   }
@@ -1123,11 +1210,14 @@ public class Trace {
       filled.set(63);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resLo.put((byte) 0);
-    }
-    resLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { resLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resLo.put(bs.get(j)); }
 
     return this;
   }
@@ -1151,7 +1241,12 @@ public class Trace {
       filled.set(65);
     }
 
-    stamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    stamp.put((byte) (b >> 24));
+    stamp.put((byte) (b >> 16));
+    stamp.put((byte) (b >> 8));
+    stamp.put((byte) b);
+
 
     return this;
   }
@@ -1429,111 +1524,111 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      acc12.position(acc12.position() + 32);
+      acc12.position(acc12.position() + 8);
     }
 
     if (!filled.get(1)) {
-      acc13.position(acc13.position() + 32);
+      acc13.position(acc13.position() + 8);
     }
 
     if (!filled.get(2)) {
-      acc22.position(acc22.position() + 32);
+      acc22.position(acc22.position() + 8);
     }
 
     if (!filled.get(3)) {
-      acc23.position(acc23.position() + 32);
+      acc23.position(acc23.position() + 8);
     }
 
     if (!filled.get(4)) {
-      accB0.position(accB0.position() + 32);
+      accB0.position(accB0.position() + 8);
     }
 
     if (!filled.get(5)) {
-      accB1.position(accB1.position() + 32);
+      accB1.position(accB1.position() + 8);
     }
 
     if (!filled.get(6)) {
-      accB2.position(accB2.position() + 32);
+      accB2.position(accB2.position() + 8);
     }
 
     if (!filled.get(7)) {
-      accB3.position(accB3.position() + 32);
+      accB3.position(accB3.position() + 8);
     }
 
     if (!filled.get(8)) {
-      accDelta0.position(accDelta0.position() + 32);
+      accDelta0.position(accDelta0.position() + 8);
     }
 
     if (!filled.get(9)) {
-      accDelta1.position(accDelta1.position() + 32);
+      accDelta1.position(accDelta1.position() + 8);
     }
 
     if (!filled.get(10)) {
-      accDelta2.position(accDelta2.position() + 32);
+      accDelta2.position(accDelta2.position() + 8);
     }
 
     if (!filled.get(11)) {
-      accDelta3.position(accDelta3.position() + 32);
+      accDelta3.position(accDelta3.position() + 8);
     }
 
     if (!filled.get(12)) {
-      accH0.position(accH0.position() + 32);
+      accH0.position(accH0.position() + 8);
     }
 
     if (!filled.get(13)) {
-      accH1.position(accH1.position() + 32);
+      accH1.position(accH1.position() + 8);
     }
 
     if (!filled.get(14)) {
-      accH2.position(accH2.position() + 32);
+      accH2.position(accH2.position() + 8);
     }
 
     if (!filled.get(15)) {
-      accQ0.position(accQ0.position() + 32);
+      accQ0.position(accQ0.position() + 8);
     }
 
     if (!filled.get(16)) {
-      accQ1.position(accQ1.position() + 32);
+      accQ1.position(accQ1.position() + 8);
     }
 
     if (!filled.get(17)) {
-      accQ2.position(accQ2.position() + 32);
+      accQ2.position(accQ2.position() + 8);
     }
 
     if (!filled.get(18)) {
-      accQ3.position(accQ3.position() + 32);
+      accQ3.position(accQ3.position() + 8);
     }
 
     if (!filled.get(19)) {
-      accR0.position(accR0.position() + 32);
+      accR0.position(accR0.position() + 8);
     }
 
     if (!filled.get(20)) {
-      accR1.position(accR1.position() + 32);
+      accR1.position(accR1.position() + 8);
     }
 
     if (!filled.get(21)) {
-      accR2.position(accR2.position() + 32);
+      accR2.position(accR2.position() + 8);
     }
 
     if (!filled.get(22)) {
-      accR3.position(accR3.position() + 32);
+      accR3.position(accR3.position() + 8);
     }
 
     if (!filled.get(23)) {
-      arg1Hi.position(arg1Hi.position() + 32);
+      arg1Hi.position(arg1Hi.position() + 16);
     }
 
     if (!filled.get(24)) {
-      arg1Lo.position(arg1Lo.position() + 32);
+      arg1Lo.position(arg1Lo.position() + 16);
     }
 
     if (!filled.get(25)) {
-      arg2Hi.position(arg2Hi.position() + 32);
+      arg2Hi.position(arg2Hi.position() + 16);
     }
 
     if (!filled.get(26)) {
-      arg2Lo.position(arg2Lo.position() + 32);
+      arg2Lo.position(arg2Lo.position() + 16);
     }
 
     if (!filled.get(27)) {
@@ -1637,7 +1732,7 @@ public class Trace {
     }
 
     if (!filled.get(52)) {
-      ct.position(ct.position() + 2);
+      ct.position(ct.position() + 1);
     }
 
     if (!filled.get(53)) {
@@ -1677,11 +1772,11 @@ public class Trace {
     }
 
     if (!filled.get(62)) {
-      resHi.position(resHi.position() + 32);
+      resHi.position(resHi.position() + 16);
     }
 
     if (!filled.get(63)) {
-      resLo.position(resLo.position() + 32);
+      resLo.position(resLo.position() + 16);
     }
 
     if (!filled.get(64)) {
@@ -1689,7 +1784,7 @@ public class Trace {
     }
 
     if (!filled.get(65)) {
-      stamp.position(stamp.position() + 8);
+      stamp.position(stamp.position() + 4);
     }
 
     filled.clear();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mod/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mod/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.mod;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -259,11 +258,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("acc12 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("acc12 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { acc12.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      acc12.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc12.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc12.put(bs.get(j));
+    }
 
     return this;
   }
@@ -278,11 +283,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("acc13 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("acc13 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { acc13.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      acc13.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc13.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc13.put(bs.get(j));
+    }
 
     return this;
   }
@@ -297,11 +308,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("acc22 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("acc22 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { acc22.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      acc22.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc22.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc22.put(bs.get(j));
+    }
 
     return this;
   }
@@ -316,11 +333,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("acc23 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("acc23 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { acc23.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      acc23.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc23.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc23.put(bs.get(j));
+    }
 
     return this;
   }
@@ -335,11 +358,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accB0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accB0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accB0.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accB0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accB0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accB0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -354,11 +383,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accB1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accB1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accB1.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accB1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accB1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accB1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -373,11 +408,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accB2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accB2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accB2.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accB2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accB2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accB2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -392,11 +433,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accB3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accB3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accB3.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accB3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accB3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accB3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -411,11 +458,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accDelta0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "accDelta0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accDelta0.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accDelta0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accDelta0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accDelta0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -430,11 +484,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accDelta1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "accDelta1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accDelta1.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accDelta1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accDelta1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accDelta1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -449,11 +510,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accDelta2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "accDelta2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accDelta2.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accDelta2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accDelta2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accDelta2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -468,11 +536,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accDelta3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "accDelta3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accDelta3.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accDelta3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accDelta3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accDelta3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -487,11 +562,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accH0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accH0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accH0.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accH0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accH0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accH0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -506,11 +587,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accH1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accH1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accH1.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accH1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accH1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accH1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -525,11 +612,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accH2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accH2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accH2.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accH2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accH2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accH2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -544,11 +637,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accQ0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accQ0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accQ0.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accQ0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accQ0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accQ0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -563,11 +662,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accQ1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accQ1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accQ1.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accQ1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accQ1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accQ1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -582,11 +687,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accQ2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accQ2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accQ2.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accQ2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accQ2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accQ2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -601,11 +712,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accQ3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accQ3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accQ3.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accQ3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accQ3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accQ3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -620,11 +737,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accR0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accR0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accR0.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accR0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accR0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accR0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -639,11 +762,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accR1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accR1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accR1.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accR1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accR1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accR1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -658,11 +787,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accR2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accR2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accR2.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accR2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accR2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accR2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -677,11 +812,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("accR3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("accR3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { accR3.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      accR3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accR3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accR3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -696,11 +837,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -715,11 +862,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -734,11 +887,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg2Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg2Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg2Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg2Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -753,11 +912,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1069,9 +1234,10 @@ public class Trace {
       filled.set(52);
     }
 
-    if(b >= 16L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    if (b >= 16L) {
+      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+    }
     ct.put((byte) b);
-
 
     return this;
   }
@@ -1194,11 +1360,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("resHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { resHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      resHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1213,11 +1385,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("resLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { resLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      resLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1241,12 +1419,13 @@ public class Trace {
       filled.set(65);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+    }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));
     stamp.put((byte) b);
-
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mul/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mul/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.mul;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -104,10 +105,10 @@ public class Trace {
         new ColumnHeader("mul.ACC_H_1", 32, length),
         new ColumnHeader("mul.ACC_H_2", 32, length),
         new ColumnHeader("mul.ACC_H_3", 32, length),
-        new ColumnHeader("mul.ARG_1_HI", 32, length),
-        new ColumnHeader("mul.ARG_1_LO", 32, length),
-        new ColumnHeader("mul.ARG_2_HI", 32, length),
-        new ColumnHeader("mul.ARG_2_LO", 32, length),
+        new ColumnHeader("mul.ARG_1_HI", 16, length),
+        new ColumnHeader("mul.ARG_1_LO", 16, length),
+        new ColumnHeader("mul.ARG_2_HI", 16, length),
+        new ColumnHeader("mul.ARG_2_LO", 16, length),
         new ColumnHeader("mul.BIT_NUM", 1, length),
         new ColumnHeader("mul.BITS", 1, length),
         new ColumnHeader("mul.BYTE_A_0", 1, length),
@@ -131,10 +132,10 @@ public class Trace {
         new ColumnHeader("mul.EXPONENT_BIT_ACCUMULATOR", 32, length),
         new ColumnHeader("mul.EXPONENT_BIT_SOURCE", 1, length),
         new ColumnHeader("mul.INSTRUCTION", 1, length),
-        new ColumnHeader("mul.MUL_STAMP", 8, length),
+        new ColumnHeader("mul.MUL_STAMP", 4, length),
         new ColumnHeader("mul.OLI", 1, length),
-        new ColumnHeader("mul.RES_HI", 32, length),
-        new ColumnHeader("mul.RES_LO", 32, length),
+        new ColumnHeader("mul.RES_HI", 16, length),
+        new ColumnHeader("mul.RES_LO", 16, length),
         new ColumnHeader("mul.RESULT_VANISHES", 1, length),
         new ColumnHeader("mul.SQUARE_AND_MULTIPLY", 1, length),
         new ColumnHeader("mul.TINY_BASE", 1, length),
@@ -210,11 +211,14 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accA0.put((byte) 0);
-    }
-    accA0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accA0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accA0.put(bs.get(j)); }
 
     return this;
   }
@@ -226,11 +230,14 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accA1.put((byte) 0);
-    }
-    accA1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accA1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accA1.put(bs.get(j)); }
 
     return this;
   }
@@ -242,11 +249,14 @@ public class Trace {
       filled.set(2);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accA2.put((byte) 0);
-    }
-    accA2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accA2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accA2.put(bs.get(j)); }
 
     return this;
   }
@@ -258,11 +268,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accA3.put((byte) 0);
-    }
-    accA3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accA3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accA3.put(bs.get(j)); }
 
     return this;
   }
@@ -274,11 +287,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accB0.put((byte) 0);
-    }
-    accB0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accB0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accB0.put(bs.get(j)); }
 
     return this;
   }
@@ -290,11 +306,14 @@ public class Trace {
       filled.set(5);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accB1.put((byte) 0);
-    }
-    accB1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accB1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accB1.put(bs.get(j)); }
 
     return this;
   }
@@ -306,11 +325,14 @@ public class Trace {
       filled.set(6);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accB2.put((byte) 0);
-    }
-    accB2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accB2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accB2.put(bs.get(j)); }
 
     return this;
   }
@@ -322,11 +344,14 @@ public class Trace {
       filled.set(7);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accB3.put((byte) 0);
-    }
-    accB3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accB3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accB3.put(bs.get(j)); }
 
     return this;
   }
@@ -338,11 +363,14 @@ public class Trace {
       filled.set(8);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accC0.put((byte) 0);
-    }
-    accC0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accC0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accC0.put(bs.get(j)); }
 
     return this;
   }
@@ -354,11 +382,14 @@ public class Trace {
       filled.set(9);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accC1.put((byte) 0);
-    }
-    accC1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accC1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accC1.put(bs.get(j)); }
 
     return this;
   }
@@ -370,11 +401,14 @@ public class Trace {
       filled.set(10);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accC2.put((byte) 0);
-    }
-    accC2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accC2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accC2.put(bs.get(j)); }
 
     return this;
   }
@@ -386,11 +420,14 @@ public class Trace {
       filled.set(11);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accC3.put((byte) 0);
-    }
-    accC3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accC3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accC3.put(bs.get(j)); }
 
     return this;
   }
@@ -402,11 +439,14 @@ public class Trace {
       filled.set(12);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accH0.put((byte) 0);
-    }
-    accH0.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH0 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accH0.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accH0.put(bs.get(j)); }
 
     return this;
   }
@@ -418,11 +458,14 @@ public class Trace {
       filled.set(13);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accH1.put((byte) 0);
-    }
-    accH1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accH1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accH1.put(bs.get(j)); }
 
     return this;
   }
@@ -434,11 +477,14 @@ public class Trace {
       filled.set(14);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accH2.put((byte) 0);
-    }
-    accH2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accH2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accH2.put(bs.get(j)); }
 
     return this;
   }
@@ -450,11 +496,14 @@ public class Trace {
       filled.set(15);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accH3.put((byte) 0);
-    }
-    accH3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { accH3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accH3.put(bs.get(j)); }
 
     return this;
   }
@@ -466,11 +515,14 @@ public class Trace {
       filled.set(16);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg1Hi.put((byte) 0);
-    }
-    arg1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -482,11 +534,14 @@ public class Trace {
       filled.set(17);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg1Lo.put((byte) 0);
-    }
-    arg1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -498,11 +553,14 @@ public class Trace {
       filled.set(18);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg2Hi.put((byte) 0);
-    }
-    arg2Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg2Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg2Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -514,11 +572,14 @@ public class Trace {
       filled.set(19);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg2Lo.put((byte) 0);
-    }
-    arg2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -770,11 +831,14 @@ public class Trace {
       filled.set(40);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      exponentBitAccumulator.put((byte) 0);
-    }
-    exponentBitAccumulator.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("exponentBitAccumulator has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { exponentBitAccumulator.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { exponentBitAccumulator.put(bs.get(j)); }
 
     return this;
   }
@@ -810,7 +874,12 @@ public class Trace {
       filled.set(43);
     }
 
-    mulStamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("mulStamp has invalid value (" + b + ")"); }
+    mulStamp.put((byte) (b >> 24));
+    mulStamp.put((byte) (b >> 16));
+    mulStamp.put((byte) (b >> 8));
+    mulStamp.put((byte) b);
+
 
     return this;
   }
@@ -834,11 +903,14 @@ public class Trace {
       filled.set(46);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resHi.put((byte) 0);
-    }
-    resHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { resHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resHi.put(bs.get(j)); }
 
     return this;
   }
@@ -850,11 +922,14 @@ public class Trace {
       filled.set(47);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resLo.put((byte) 0);
-    }
-    resLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { resLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resLo.put(bs.get(j)); }
 
     return this;
   }
@@ -1184,19 +1259,19 @@ public class Trace {
     }
 
     if (!filled.get(16)) {
-      arg1Hi.position(arg1Hi.position() + 32);
+      arg1Hi.position(arg1Hi.position() + 16);
     }
 
     if (!filled.get(17)) {
-      arg1Lo.position(arg1Lo.position() + 32);
+      arg1Lo.position(arg1Lo.position() + 16);
     }
 
     if (!filled.get(18)) {
-      arg2Hi.position(arg2Hi.position() + 32);
+      arg2Hi.position(arg2Hi.position() + 16);
     }
 
     if (!filled.get(19)) {
-      arg2Lo.position(arg2Lo.position() + 32);
+      arg2Lo.position(arg2Lo.position() + 16);
     }
 
     if (!filled.get(21)) {
@@ -1292,7 +1367,7 @@ public class Trace {
     }
 
     if (!filled.get(43)) {
-      mulStamp.position(mulStamp.position() + 8);
+      mulStamp.position(mulStamp.position() + 4);
     }
 
     if (!filled.get(44)) {
@@ -1300,11 +1375,11 @@ public class Trace {
     }
 
     if (!filled.get(46)) {
-      resHi.position(resHi.position() + 32);
+      resHi.position(resHi.position() + 16);
     }
 
     if (!filled.get(47)) {
-      resLo.position(resLo.position() + 32);
+      resLo.position(resLo.position() + 16);
     }
 
     if (!filled.get(45)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mul/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mul/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.mul;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -214,11 +213,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accA0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accA0.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accA0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accA0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accA0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -233,11 +238,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accA1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accA1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accA1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accA1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accA1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -252,11 +263,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accA2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accA2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accA2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accA2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accA2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -271,11 +288,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accA3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accA3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accA3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accA3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accA3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accA3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -290,11 +313,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accB0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accB0.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accB0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accB0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accB0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -309,11 +338,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accB1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accB1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accB1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accB1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accB1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -328,11 +363,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accB2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accB2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accB2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accB2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accB2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -347,11 +388,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accB3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accB3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accB3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accB3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accB3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accB3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -366,11 +413,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accC0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accC0.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accC0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accC0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accC0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -385,11 +438,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accC1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accC1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accC1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accC1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accC1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -404,11 +463,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accC2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accC2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accC2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accC2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accC2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -423,11 +488,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accC3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accC3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accC3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accC3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accC3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accC3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -442,11 +513,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH0 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accH0 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accH0.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accH0.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accH0.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accH0.put(bs.get(j));
+    }
 
     return this;
   }
@@ -461,11 +538,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accH1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accH1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accH1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accH1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accH1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -480,11 +563,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accH2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accH2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accH2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accH2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accH2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -499,11 +588,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("accH3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("accH3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { accH3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      accH3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accH3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accH3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -518,11 +613,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -537,11 +638,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -556,11 +663,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg2Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg2Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg2Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg2Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -575,11 +688,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -834,11 +953,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("exponentBitAccumulator has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "exponentBitAccumulator has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { exponentBitAccumulator.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      exponentBitAccumulator.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { exponentBitAccumulator.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      exponentBitAccumulator.put(bs.get(j));
+    }
 
     return this;
   }
@@ -874,12 +1000,13 @@ public class Trace {
       filled.set(43);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("mulStamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("mulStamp has invalid value (" + b + ")");
+    }
     mulStamp.put((byte) (b >> 24));
     mulStamp.put((byte) (b >> 16));
     mulStamp.put((byte) (b >> 8));
     mulStamp.put((byte) b);
-
 
     return this;
   }
@@ -906,11 +1033,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("resHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { resHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      resHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -925,11 +1058,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("resLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { resLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      resLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resLo.put(bs.get(j));
+    }
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.mxp;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -93,13 +94,13 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("mxp.ACC_1", 32, length),
-        new ColumnHeader("mxp.ACC_2", 32, length),
-        new ColumnHeader("mxp.ACC_3", 32, length),
-        new ColumnHeader("mxp.ACC_4", 32, length),
-        new ColumnHeader("mxp.ACC_A", 32, length),
-        new ColumnHeader("mxp.ACC_Q", 32, length),
-        new ColumnHeader("mxp.ACC_W", 32, length),
+        new ColumnHeader("mxp.ACC_1", 17, length),
+        new ColumnHeader("mxp.ACC_2", 17, length),
+        new ColumnHeader("mxp.ACC_3", 17, length),
+        new ColumnHeader("mxp.ACC_4", 17, length),
+        new ColumnHeader("mxp.ACC_A", 17, length),
+        new ColumnHeader("mxp.ACC_Q", 17, length),
+        new ColumnHeader("mxp.ACC_W", 17, length),
         new ColumnHeader("mxp.BYTE_1", 1, length),
         new ColumnHeader("mxp.BYTE_2", 1, length),
         new ColumnHeader("mxp.BYTE_3", 1, length),
@@ -109,18 +110,18 @@ public class Trace {
         new ColumnHeader("mxp.BYTE_QQ", 1, length),
         new ColumnHeader("mxp.BYTE_R", 1, length),
         new ColumnHeader("mxp.BYTE_W", 1, length),
-        new ColumnHeader("mxp.C_MEM", 32, length),
-        new ColumnHeader("mxp.C_MEM_NEW", 32, length),
-        new ColumnHeader("mxp.CN", 32, length),
+        new ColumnHeader("mxp.C_MEM", 8, length),
+        new ColumnHeader("mxp.C_MEM_NEW", 8, length),
+        new ColumnHeader("mxp.CN", 8, length),
         new ColumnHeader("mxp.COMP", 1, length),
-        new ColumnHeader("mxp.CT", 2, length),
+        new ColumnHeader("mxp.CT", 1, length),
         new ColumnHeader("mxp.DEPLOYS", 1, length),
         new ColumnHeader("mxp.EXPANDS", 1, length),
-        new ColumnHeader("mxp.GAS_MXP", 32, length),
-        new ColumnHeader("mxp.GBYTE", 32, length),
-        new ColumnHeader("mxp.GWORD", 32, length),
+        new ColumnHeader("mxp.GAS_MXP", 8, length),
+        new ColumnHeader("mxp.GBYTE", 8, length),
+        new ColumnHeader("mxp.GWORD", 8, length),
         new ColumnHeader("mxp.INST", 1, length),
-        new ColumnHeader("mxp.LIN_COST", 32, length),
+        new ColumnHeader("mxp.LIN_COST", 8, length),
         new ColumnHeader("mxp.MAX_OFFSET", 32, length),
         new ColumnHeader("mxp.MAX_OFFSET_1", 32, length),
         new ColumnHeader("mxp.MAX_OFFSET_2", 32, length),
@@ -132,19 +133,19 @@ public class Trace {
         new ColumnHeader("mxp.MXP_TYPE_5", 1, length),
         new ColumnHeader("mxp.MXPX", 1, length),
         new ColumnHeader("mxp.NOOP", 1, length),
-        new ColumnHeader("mxp.OFFSET_1_HI", 32, length),
-        new ColumnHeader("mxp.OFFSET_1_LO", 32, length),
-        new ColumnHeader("mxp.OFFSET_2_HI", 32, length),
-        new ColumnHeader("mxp.OFFSET_2_LO", 32, length),
-        new ColumnHeader("mxp.QUAD_COST", 32, length),
+        new ColumnHeader("mxp.OFFSET_1_HI", 16, length),
+        new ColumnHeader("mxp.OFFSET_1_LO", 16, length),
+        new ColumnHeader("mxp.OFFSET_2_HI", 16, length),
+        new ColumnHeader("mxp.OFFSET_2_LO", 16, length),
+        new ColumnHeader("mxp.QUAD_COST", 8, length),
         new ColumnHeader("mxp.ROOB", 1, length),
-        new ColumnHeader("mxp.SIZE_1_HI", 32, length),
-        new ColumnHeader("mxp.SIZE_1_LO", 32, length),
-        new ColumnHeader("mxp.SIZE_2_HI", 32, length),
-        new ColumnHeader("mxp.SIZE_2_LO", 32, length),
-        new ColumnHeader("mxp.STAMP", 8, length),
-        new ColumnHeader("mxp.WORDS", 32, length),
-        new ColumnHeader("mxp.WORDS_NEW", 32, length));
+        new ColumnHeader("mxp.SIZE_1_HI", 16, length),
+        new ColumnHeader("mxp.SIZE_1_LO", 16, length),
+        new ColumnHeader("mxp.SIZE_2_HI", 16, length),
+        new ColumnHeader("mxp.SIZE_2_LO", 16, length),
+        new ColumnHeader("mxp.STAMP", 4, length),
+        new ColumnHeader("mxp.WORDS", 8, length),
+        new ColumnHeader("mxp.WORDS_NEW", 8, length));
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -217,11 +218,14 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc1.put((byte) 0);
-    }
-    acc1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 136) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<17; i++) { acc1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
 
     return this;
   }
@@ -233,11 +237,14 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc2.put((byte) 0);
-    }
-    acc2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 136) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<17; i++) { acc2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
 
     return this;
   }
@@ -249,11 +256,14 @@ public class Trace {
       filled.set(2);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc3.put((byte) 0);
-    }
-    acc3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 136) { throw new IllegalArgumentException("acc3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<17; i++) { acc3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc3.put(bs.get(j)); }
 
     return this;
   }
@@ -265,11 +275,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc4.put((byte) 0);
-    }
-    acc4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 136) { throw new IllegalArgumentException("acc4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<17; i++) { acc4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc4.put(bs.get(j)); }
 
     return this;
   }
@@ -281,11 +294,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accA.put((byte) 0);
-    }
-    accA.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 136) { throw new IllegalArgumentException("accA has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<17; i++) { accA.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accA.put(bs.get(j)); }
 
     return this;
   }
@@ -297,11 +313,14 @@ public class Trace {
       filled.set(5);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accQ.put((byte) 0);
-    }
-    accQ.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 136) { throw new IllegalArgumentException("accQ has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<17; i++) { accQ.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accQ.put(bs.get(j)); }
 
     return this;
   }
@@ -313,11 +332,14 @@ public class Trace {
       filled.set(6);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accW.put((byte) 0);
-    }
-    accW.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 136) { throw new IllegalArgumentException("accW has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<17; i++) { accW.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accW.put(bs.get(j)); }
 
     return this;
   }
@@ -437,11 +459,14 @@ public class Trace {
       filled.set(19);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      cMem.put((byte) 0);
-    }
-    cMem.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("cMem has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { cMem.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { cMem.put(bs.get(j)); }
 
     return this;
   }
@@ -453,11 +478,14 @@ public class Trace {
       filled.set(20);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      cMemNew.put((byte) 0);
-    }
-    cMemNew.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("cMemNew has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { cMemNew.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { cMemNew.put(bs.get(j)); }
 
     return this;
   }
@@ -469,11 +497,14 @@ public class Trace {
       filled.set(16);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      cn.put((byte) 0);
-    }
-    cn.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("cn has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { cn.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { cn.put(bs.get(j)); }
 
     return this;
   }
@@ -490,14 +521,16 @@ public class Trace {
     return this;
   }
 
-  public Trace ct(final short b) {
+  public Trace ct(final long b) {
     if (filled.get(18)) {
       throw new IllegalStateException("mxp.CT already set");
     } else {
       filled.set(18);
     }
 
-    ct.putShort(b);
+    if(b >= 32L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    ct.put((byte) b);
+
 
     return this;
   }
@@ -533,11 +566,14 @@ public class Trace {
       filled.set(23);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gasMxp.put((byte) 0);
-    }
-    gasMxp.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("gasMxp has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { gasMxp.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gasMxp.put(bs.get(j)); }
 
     return this;
   }
@@ -549,11 +585,14 @@ public class Trace {
       filled.set(24);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gbyte.put((byte) 0);
-    }
-    gbyte.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("gbyte has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { gbyte.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gbyte.put(bs.get(j)); }
 
     return this;
   }
@@ -565,11 +604,14 @@ public class Trace {
       filled.set(25);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gword.put((byte) 0);
-    }
-    gword.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("gword has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { gword.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gword.put(bs.get(j)); }
 
     return this;
   }
@@ -593,11 +635,14 @@ public class Trace {
       filled.set(27);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      linCost.put((byte) 0);
-    }
-    linCost.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("linCost has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { linCost.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { linCost.put(bs.get(j)); }
 
     return this;
   }
@@ -609,11 +654,14 @@ public class Trace {
       filled.set(28);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      maxOffset.put((byte) 0);
-    }
-    maxOffset.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("maxOffset has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { maxOffset.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { maxOffset.put(bs.get(j)); }
 
     return this;
   }
@@ -625,11 +673,14 @@ public class Trace {
       filled.set(29);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      maxOffset1.put((byte) 0);
-    }
-    maxOffset1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("maxOffset1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { maxOffset1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { maxOffset1.put(bs.get(j)); }
 
     return this;
   }
@@ -641,11 +692,14 @@ public class Trace {
       filled.set(30);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      maxOffset2.put((byte) 0);
-    }
-    maxOffset2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("maxOffset2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { maxOffset2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { maxOffset2.put(bs.get(j)); }
 
     return this;
   }
@@ -753,11 +807,14 @@ public class Trace {
       filled.set(39);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      offset1Hi.put((byte) 0);
-    }
-    offset1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("offset1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { offset1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { offset1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -769,11 +826,14 @@ public class Trace {
       filled.set(40);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      offset1Lo.put((byte) 0);
-    }
-    offset1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("offset1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { offset1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { offset1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -785,11 +845,14 @@ public class Trace {
       filled.set(41);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      offset2Hi.put((byte) 0);
-    }
-    offset2Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("offset2Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { offset2Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { offset2Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -801,11 +864,14 @@ public class Trace {
       filled.set(42);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      offset2Lo.put((byte) 0);
-    }
-    offset2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("offset2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { offset2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { offset2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -817,11 +883,14 @@ public class Trace {
       filled.set(43);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      quadCost.put((byte) 0);
-    }
-    quadCost.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("quadCost has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { quadCost.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { quadCost.put(bs.get(j)); }
 
     return this;
   }
@@ -845,11 +914,14 @@ public class Trace {
       filled.set(45);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      size1Hi.put((byte) 0);
-    }
-    size1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("size1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { size1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { size1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -861,11 +933,14 @@ public class Trace {
       filled.set(46);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      size1Lo.put((byte) 0);
-    }
-    size1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("size1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { size1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { size1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -877,11 +952,14 @@ public class Trace {
       filled.set(47);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      size2Hi.put((byte) 0);
-    }
-    size2Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("size2Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { size2Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { size2Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -893,11 +971,14 @@ public class Trace {
       filled.set(48);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      size2Lo.put((byte) 0);
-    }
-    size2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("size2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { size2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { size2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -909,7 +990,12 @@ public class Trace {
       filled.set(49);
     }
 
-    stamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    stamp.put((byte) (b >> 24));
+    stamp.put((byte) (b >> 16));
+    stamp.put((byte) (b >> 8));
+    stamp.put((byte) b);
+
 
     return this;
   }
@@ -921,11 +1007,14 @@ public class Trace {
       filled.set(50);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      words.put((byte) 0);
-    }
-    words.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("words has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { words.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { words.put(bs.get(j)); }
 
     return this;
   }
@@ -937,11 +1026,14 @@ public class Trace {
       filled.set(51);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      wordsNew.put((byte) 0);
-    }
-    wordsNew.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("wordsNew has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { wordsNew.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { wordsNew.put(bs.get(j)); }
 
     return this;
   }
@@ -1163,31 +1255,31 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      acc1.position(acc1.position() + 32);
+      acc1.position(acc1.position() + 17);
     }
 
     if (!filled.get(1)) {
-      acc2.position(acc2.position() + 32);
+      acc2.position(acc2.position() + 17);
     }
 
     if (!filled.get(2)) {
-      acc3.position(acc3.position() + 32);
+      acc3.position(acc3.position() + 17);
     }
 
     if (!filled.get(3)) {
-      acc4.position(acc4.position() + 32);
+      acc4.position(acc4.position() + 17);
     }
 
     if (!filled.get(4)) {
-      accA.position(accA.position() + 32);
+      accA.position(accA.position() + 17);
     }
 
     if (!filled.get(5)) {
-      accQ.position(accQ.position() + 32);
+      accQ.position(accQ.position() + 17);
     }
 
     if (!filled.get(6)) {
-      accW.position(accW.position() + 32);
+      accW.position(accW.position() + 17);
     }
 
     if (!filled.get(7)) {
@@ -1227,15 +1319,15 @@ public class Trace {
     }
 
     if (!filled.get(19)) {
-      cMem.position(cMem.position() + 32);
+      cMem.position(cMem.position() + 8);
     }
 
     if (!filled.get(20)) {
-      cMemNew.position(cMemNew.position() + 32);
+      cMemNew.position(cMemNew.position() + 8);
     }
 
     if (!filled.get(16)) {
-      cn.position(cn.position() + 32);
+      cn.position(cn.position() + 8);
     }
 
     if (!filled.get(17)) {
@@ -1243,7 +1335,7 @@ public class Trace {
     }
 
     if (!filled.get(18)) {
-      ct.position(ct.position() + 2);
+      ct.position(ct.position() + 1);
     }
 
     if (!filled.get(21)) {
@@ -1255,15 +1347,15 @@ public class Trace {
     }
 
     if (!filled.get(23)) {
-      gasMxp.position(gasMxp.position() + 32);
+      gasMxp.position(gasMxp.position() + 8);
     }
 
     if (!filled.get(24)) {
-      gbyte.position(gbyte.position() + 32);
+      gbyte.position(gbyte.position() + 8);
     }
 
     if (!filled.get(25)) {
-      gword.position(gword.position() + 32);
+      gword.position(gword.position() + 8);
     }
 
     if (!filled.get(26)) {
@@ -1271,7 +1363,7 @@ public class Trace {
     }
 
     if (!filled.get(27)) {
-      linCost.position(linCost.position() + 32);
+      linCost.position(linCost.position() + 8);
     }
 
     if (!filled.get(28)) {
@@ -1319,23 +1411,23 @@ public class Trace {
     }
 
     if (!filled.get(39)) {
-      offset1Hi.position(offset1Hi.position() + 32);
+      offset1Hi.position(offset1Hi.position() + 16);
     }
 
     if (!filled.get(40)) {
-      offset1Lo.position(offset1Lo.position() + 32);
+      offset1Lo.position(offset1Lo.position() + 16);
     }
 
     if (!filled.get(41)) {
-      offset2Hi.position(offset2Hi.position() + 32);
+      offset2Hi.position(offset2Hi.position() + 16);
     }
 
     if (!filled.get(42)) {
-      offset2Lo.position(offset2Lo.position() + 32);
+      offset2Lo.position(offset2Lo.position() + 16);
     }
 
     if (!filled.get(43)) {
-      quadCost.position(quadCost.position() + 32);
+      quadCost.position(quadCost.position() + 8);
     }
 
     if (!filled.get(44)) {
@@ -1343,31 +1435,31 @@ public class Trace {
     }
 
     if (!filled.get(45)) {
-      size1Hi.position(size1Hi.position() + 32);
+      size1Hi.position(size1Hi.position() + 16);
     }
 
     if (!filled.get(46)) {
-      size1Lo.position(size1Lo.position() + 32);
+      size1Lo.position(size1Lo.position() + 16);
     }
 
     if (!filled.get(47)) {
-      size2Hi.position(size2Hi.position() + 32);
+      size2Hi.position(size2Hi.position() + 16);
     }
 
     if (!filled.get(48)) {
-      size2Lo.position(size2Lo.position() + 32);
+      size2Lo.position(size2Lo.position() + 16);
     }
 
     if (!filled.get(49)) {
-      stamp.position(stamp.position() + 8);
+      stamp.position(stamp.position() + 4);
     }
 
     if (!filled.get(50)) {
-      words.position(words.position() + 32);
+      words.position(words.position() + 8);
     }
 
     if (!filled.get(51)) {
-      wordsNew.position(wordsNew.position() + 32);
+      wordsNew.position(wordsNew.position() + 8);
     }
 
     filled.clear();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.mxp;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -221,11 +220,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 136) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 136) {
+      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<17; i++) { acc1.put((byte) 0); }
+    for (int i = bs.size(); i < 17; i++) {
+      acc1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -240,11 +245,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 136) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 136) {
+      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<17; i++) { acc2.put((byte) 0); }
+    for (int i = bs.size(); i < 17; i++) {
+      acc2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -259,11 +270,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 136) { throw new IllegalArgumentException("acc3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 136) {
+      throw new IllegalArgumentException("acc3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<17; i++) { acc3.put((byte) 0); }
+    for (int i = bs.size(); i < 17; i++) {
+      acc3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -278,11 +295,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 136) { throw new IllegalArgumentException("acc4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 136) {
+      throw new IllegalArgumentException("acc4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<17; i++) { acc4.put((byte) 0); }
+    for (int i = bs.size(); i < 17; i++) {
+      acc4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -297,11 +320,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 136) { throw new IllegalArgumentException("accA has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 136) {
+      throw new IllegalArgumentException("accA has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<17; i++) { accA.put((byte) 0); }
+    for (int i = bs.size(); i < 17; i++) {
+      accA.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accA.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accA.put(bs.get(j));
+    }
 
     return this;
   }
@@ -316,11 +345,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 136) { throw new IllegalArgumentException("accQ has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 136) {
+      throw new IllegalArgumentException("accQ has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<17; i++) { accQ.put((byte) 0); }
+    for (int i = bs.size(); i < 17; i++) {
+      accQ.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accQ.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accQ.put(bs.get(j));
+    }
 
     return this;
   }
@@ -335,11 +370,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 136) { throw new IllegalArgumentException("accW has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 136) {
+      throw new IllegalArgumentException("accW has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<17; i++) { accW.put((byte) 0); }
+    for (int i = bs.size(); i < 17; i++) {
+      accW.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accW.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accW.put(bs.get(j));
+    }
 
     return this;
   }
@@ -462,11 +503,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("cMem has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("cMem has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { cMem.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      cMem.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { cMem.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      cMem.put(bs.get(j));
+    }
 
     return this;
   }
@@ -481,11 +528,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("cMemNew has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("cMemNew has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { cMemNew.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      cMemNew.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { cMemNew.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      cMemNew.put(bs.get(j));
+    }
 
     return this;
   }
@@ -500,11 +553,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("cn has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("cn has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { cn.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      cn.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { cn.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      cn.put(bs.get(j));
+    }
 
     return this;
   }
@@ -528,9 +587,10 @@ public class Trace {
       filled.set(18);
     }
 
-    if(b >= 32L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    if (b >= 32L) {
+      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+    }
     ct.put((byte) b);
-
 
     return this;
   }
@@ -569,11 +629,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("gasMxp has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("gasMxp has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { gasMxp.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      gasMxp.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gasMxp.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gasMxp.put(bs.get(j));
+    }
 
     return this;
   }
@@ -588,11 +654,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("gbyte has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("gbyte has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { gbyte.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      gbyte.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gbyte.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gbyte.put(bs.get(j));
+    }
 
     return this;
   }
@@ -607,11 +679,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("gword has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("gword has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { gword.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      gword.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gword.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gword.put(bs.get(j));
+    }
 
     return this;
   }
@@ -638,11 +716,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("linCost has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("linCost has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { linCost.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      linCost.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { linCost.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      linCost.put(bs.get(j));
+    }
 
     return this;
   }
@@ -657,11 +741,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("maxOffset has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "maxOffset has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { maxOffset.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      maxOffset.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { maxOffset.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      maxOffset.put(bs.get(j));
+    }
 
     return this;
   }
@@ -676,11 +767,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("maxOffset1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "maxOffset1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { maxOffset1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      maxOffset1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { maxOffset1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      maxOffset1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -695,11 +793,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("maxOffset2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "maxOffset2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { maxOffset2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      maxOffset2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { maxOffset2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      maxOffset2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -810,11 +915,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("offset1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "offset1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { offset1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      offset1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { offset1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      offset1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -829,11 +941,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("offset1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "offset1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { offset1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      offset1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { offset1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      offset1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -848,11 +967,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("offset2Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "offset2Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { offset2Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      offset2Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { offset2Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      offset2Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -867,11 +993,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("offset2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "offset2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { offset2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      offset2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { offset2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      offset2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -886,11 +1019,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("quadCost has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("quadCost has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { quadCost.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      quadCost.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { quadCost.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      quadCost.put(bs.get(j));
+    }
 
     return this;
   }
@@ -917,11 +1056,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("size1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("size1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { size1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      size1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { size1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      size1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -936,11 +1081,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("size1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("size1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { size1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      size1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { size1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      size1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -955,11 +1106,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("size2Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("size2Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { size2Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      size2Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { size2Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      size2Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -974,11 +1131,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("size2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("size2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { size2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      size2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { size2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      size2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -990,12 +1153,13 @@ public class Trace {
       filled.set(49);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+    }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));
     stamp.put((byte) b);
-
 
     return this;
   }
@@ -1010,11 +1174,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("words has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("words has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { words.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      words.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { words.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      words.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1029,11 +1199,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("wordsNew has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("wordsNew has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { wordsNew.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      wordsNew.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { wordsNew.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      wordsNew.put(bs.get(j));
+    }
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/oob/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/oob/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.oob;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -226,9 +225,10 @@ public class Trace {
       filled.set(1);
     }
 
-    if(b >= 8L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    if (b >= 8L) {
+      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+    }
     ct.put((byte) b);
-
 
     return this;
   }
@@ -240,9 +240,10 @@ public class Trace {
       filled.set(2);
     }
 
-    if(b >= 8L) { throw new IllegalArgumentException("ctMax has invalid value (" + b + ")"); }
+    if (b >= 8L) {
+      throw new IllegalArgumentException("ctMax has invalid value (" + b + ")");
+    }
     ctMax.put((byte) b);
-
 
     return this;
   }
@@ -257,11 +258,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("data1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { data1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      data1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { data1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      data1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -276,11 +283,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("data2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { data2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      data2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { data2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      data2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -295,11 +308,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("data3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { data3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      data3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { data3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      data3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -314,11 +333,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("data4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { data4.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      data4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { data4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      data4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -333,11 +358,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data5 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("data5 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { data5.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      data5.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { data5.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      data5.put(bs.get(j));
+    }
 
     return this;
   }
@@ -352,11 +383,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data6 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("data6 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { data6.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      data6.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { data6.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      data6.put(bs.get(j));
+    }
 
     return this;
   }
@@ -371,11 +408,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data7 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("data7 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { data7.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      data7.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { data7.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      data7.put(bs.get(j));
+    }
 
     return this;
   }
@@ -390,11 +433,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data8 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("data8 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { data8.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      data8.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { data8.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      data8.put(bs.get(j));
+    }
 
     return this;
   }
@@ -697,11 +746,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("oobInst has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("oobInst has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { oobInst.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      oobInst.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { oobInst.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      oobInst.put(bs.get(j));
+    }
 
     return this;
   }
@@ -716,11 +771,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("outgoingData1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "outgoingData1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { outgoingData1.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      outgoingData1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { outgoingData1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      outgoingData1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -735,11 +797,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("outgoingData2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "outgoingData2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { outgoingData2.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      outgoingData2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { outgoingData2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      outgoingData2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -754,11 +823,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("outgoingData3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "outgoingData3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { outgoingData3.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      outgoingData3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { outgoingData3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      outgoingData3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -773,11 +849,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("outgoingData4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "outgoingData4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { outgoingData4.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      outgoingData4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { outgoingData4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      outgoingData4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -804,11 +887,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("outgoingResLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "outgoingResLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { outgoingResLo.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      outgoingResLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { outgoingResLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      outgoingResLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -820,12 +910,13 @@ public class Trace {
       filled.set(42);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+    }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));
     stamp.put((byte) b);
-
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/oob/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/oob/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.oob;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -106,8 +107,8 @@ public class Trace {
   static List<ColumnHeader> headers(int length) {
     return List.of(
         new ColumnHeader("oob.ADD_FLAG", 1, length),
-        new ColumnHeader("oob.CT", 2, length),
-        new ColumnHeader("oob.CT_MAX", 2, length),
+        new ColumnHeader("oob.CT", 1, length),
+        new ColumnHeader("oob.CT_MAX", 1, length),
         new ColumnHeader("oob.DATA_1", 32, length),
         new ColumnHeader("oob.DATA_2", 32, length),
         new ColumnHeader("oob.DATA_3", 32, length),
@@ -147,7 +148,7 @@ public class Trace {
         new ColumnHeader("oob.OUTGOING_DATA_4", 32, length),
         new ColumnHeader("oob.OUTGOING_INST", 1, length),
         new ColumnHeader("oob.OUTGOING_RES_LO", 32, length),
-        new ColumnHeader("oob.STAMP", 8, length),
+        new ColumnHeader("oob.STAMP", 4, length),
         new ColumnHeader("oob.WCP_FLAG", 1, length));
   }
 
@@ -218,26 +219,30 @@ public class Trace {
     return this;
   }
 
-  public Trace ct(final short b) {
+  public Trace ct(final long b) {
     if (filled.get(1)) {
       throw new IllegalStateException("oob.CT already set");
     } else {
       filled.set(1);
     }
 
-    ct.putShort(b);
+    if(b >= 8L) { throw new IllegalArgumentException("ct has invalid value (" + b + ")"); }
+    ct.put((byte) b);
+
 
     return this;
   }
 
-  public Trace ctMax(final short b) {
+  public Trace ctMax(final long b) {
     if (filled.get(2)) {
       throw new IllegalStateException("oob.CT_MAX already set");
     } else {
       filled.set(2);
     }
 
-    ctMax.putShort(b);
+    if(b >= 8L) { throw new IllegalArgumentException("ctMax has invalid value (" + b + ")"); }
+    ctMax.put((byte) b);
+
 
     return this;
   }
@@ -249,11 +254,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      data1.put((byte) 0);
-    }
-    data1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { data1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { data1.put(bs.get(j)); }
 
     return this;
   }
@@ -265,11 +273,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      data2.put((byte) 0);
-    }
-    data2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { data2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { data2.put(bs.get(j)); }
 
     return this;
   }
@@ -281,11 +292,14 @@ public class Trace {
       filled.set(5);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      data3.put((byte) 0);
-    }
-    data3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { data3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { data3.put(bs.get(j)); }
 
     return this;
   }
@@ -297,11 +311,14 @@ public class Trace {
       filled.set(6);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      data4.put((byte) 0);
-    }
-    data4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { data4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { data4.put(bs.get(j)); }
 
     return this;
   }
@@ -313,11 +330,14 @@ public class Trace {
       filled.set(7);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      data5.put((byte) 0);
-    }
-    data5.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data5 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { data5.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { data5.put(bs.get(j)); }
 
     return this;
   }
@@ -329,11 +349,14 @@ public class Trace {
       filled.set(8);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      data6.put((byte) 0);
-    }
-    data6.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data6 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { data6.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { data6.put(bs.get(j)); }
 
     return this;
   }
@@ -345,11 +368,14 @@ public class Trace {
       filled.set(9);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      data7.put((byte) 0);
-    }
-    data7.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data7 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { data7.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { data7.put(bs.get(j)); }
 
     return this;
   }
@@ -361,11 +387,14 @@ public class Trace {
       filled.set(10);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      data8.put((byte) 0);
-    }
-    data8.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("data8 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { data8.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { data8.put(bs.get(j)); }
 
     return this;
   }
@@ -665,11 +694,14 @@ public class Trace {
       filled.set(35);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      oobInst.put((byte) 0);
-    }
-    oobInst.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("oobInst has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { oobInst.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { oobInst.put(bs.get(j)); }
 
     return this;
   }
@@ -681,11 +713,14 @@ public class Trace {
       filled.set(36);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      outgoingData1.put((byte) 0);
-    }
-    outgoingData1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("outgoingData1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { outgoingData1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { outgoingData1.put(bs.get(j)); }
 
     return this;
   }
@@ -697,11 +732,14 @@ public class Trace {
       filled.set(37);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      outgoingData2.put((byte) 0);
-    }
-    outgoingData2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("outgoingData2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { outgoingData2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { outgoingData2.put(bs.get(j)); }
 
     return this;
   }
@@ -713,11 +751,14 @@ public class Trace {
       filled.set(38);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      outgoingData3.put((byte) 0);
-    }
-    outgoingData3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("outgoingData3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { outgoingData3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { outgoingData3.put(bs.get(j)); }
 
     return this;
   }
@@ -729,11 +770,14 @@ public class Trace {
       filled.set(39);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      outgoingData4.put((byte) 0);
-    }
-    outgoingData4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("outgoingData4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { outgoingData4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { outgoingData4.put(bs.get(j)); }
 
     return this;
   }
@@ -757,11 +801,14 @@ public class Trace {
       filled.set(41);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      outgoingResLo.put((byte) 0);
-    }
-    outgoingResLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("outgoingResLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { outgoingResLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { outgoingResLo.put(bs.get(j)); }
 
     return this;
   }
@@ -773,7 +820,12 @@ public class Trace {
       filled.set(42);
     }
 
-    stamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    stamp.put((byte) (b >> 24));
+    stamp.put((byte) (b >> 16));
+    stamp.put((byte) (b >> 8));
+    stamp.put((byte) b);
+
 
     return this;
   }
@@ -979,11 +1031,11 @@ public class Trace {
     }
 
     if (!filled.get(1)) {
-      ct.position(ct.position() + 2);
+      ct.position(ct.position() + 1);
     }
 
     if (!filled.get(2)) {
-      ctMax.position(ctMax.position() + 2);
+      ctMax.position(ctMax.position() + 1);
     }
 
     if (!filled.get(3)) {
@@ -1143,7 +1195,7 @@ public class Trace {
     }
 
     if (!filled.get(42)) {
-      stamp.position(stamp.position() + 8);
+      stamp.position(stamp.position() + 4);
     }
 
     if (!filled.get(43)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpaddr/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpaddr/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.rlpaddr;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -144,11 +143,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("acc has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("acc has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { acc.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      acc.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc.put(bs.get(j));
+    }
 
     return this;
   }
@@ -172,12 +177,13 @@ public class Trace {
       filled.set(2);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("addrHi has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("addrHi has invalid value (" + b + ")");
+    }
     addrHi.put((byte) (b >> 24));
     addrHi.put((byte) (b >> 16));
     addrHi.put((byte) (b >> 8));
     addrHi.put((byte) b);
-
 
     return this;
   }
@@ -192,11 +198,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("addrLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("addrLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { addrLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      addrLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { addrLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      addrLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -256,12 +268,13 @@ public class Trace {
       filled.set(8);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("depAddrHi has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("depAddrHi has invalid value (" + b + ")");
+    }
     depAddrHi.put((byte) (b >> 24));
     depAddrHi.put((byte) (b >> 16));
     depAddrHi.put((byte) (b >> 8));
     depAddrHi.put((byte) b);
-
 
     return this;
   }
@@ -276,11 +289,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("depAddrLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "depAddrLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { depAddrLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      depAddrLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { depAddrLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      depAddrLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -307,11 +327,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("kecHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("kecHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { kecHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      kecHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { kecHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      kecHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -326,11 +352,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("kecLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("kecLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { kecLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      kecLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { kecLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      kecLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -357,11 +389,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      limb.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      limb.put(bs.get(j));
+    }
 
     return this;
   }
@@ -388,11 +426,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("nonce has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("nonce has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { nonce.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      nonce.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { nonce.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      nonce.put(bs.get(j));
+    }
 
     return this;
   }
@@ -407,11 +451,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("power has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("power has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { power.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      power.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { power.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      power.put(bs.get(j));
+    }
 
     return this;
   }
@@ -426,11 +476,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("rawAddrHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "rawAddrHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { rawAddrHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      rawAddrHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { rawAddrHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      rawAddrHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -481,11 +538,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("saltHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("saltHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { saltHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      saltHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { saltHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      saltHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -500,11 +563,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("saltLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("saltLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { saltLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      saltLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { saltLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      saltLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -528,11 +597,12 @@ public class Trace {
       filled.set(24);
     }
 
-    if(b >= 16777216L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    if (b >= 16777216L) {
+      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+    }
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));
     stamp.put((byte) b);
-
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpaddr/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpaddr/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.rlpaddr;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -66,32 +67,32 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("rlpaddr.ACC", 32, length),
+        new ColumnHeader("rlpaddr.ACC", 8, length),
         new ColumnHeader("rlpaddr.ACC_BYTESIZE", 1, length),
-        new ColumnHeader("rlpaddr.ADDR_HI", 8, length),
-        new ColumnHeader("rlpaddr.ADDR_LO", 32, length),
+        new ColumnHeader("rlpaddr.ADDR_HI", 4, length),
+        new ColumnHeader("rlpaddr.ADDR_LO", 16, length),
         new ColumnHeader("rlpaddr.BIT1", 1, length),
         new ColumnHeader("rlpaddr.BIT_ACC", 1, length),
         new ColumnHeader("rlpaddr.BYTE1", 1, length),
         new ColumnHeader("rlpaddr.COUNTER", 1, length),
-        new ColumnHeader("rlpaddr.DEP_ADDR_HI", 8, length),
-        new ColumnHeader("rlpaddr.DEP_ADDR_LO", 32, length),
+        new ColumnHeader("rlpaddr.DEP_ADDR_HI", 4, length),
+        new ColumnHeader("rlpaddr.DEP_ADDR_LO", 16, length),
         new ColumnHeader("rlpaddr.INDEX", 1, length),
-        new ColumnHeader("rlpaddr.KEC_HI", 32, length),
-        new ColumnHeader("rlpaddr.KEC_LO", 32, length),
+        new ColumnHeader("rlpaddr.KEC_HI", 16, length),
+        new ColumnHeader("rlpaddr.KEC_LO", 16, length),
         new ColumnHeader("rlpaddr.LC", 1, length),
-        new ColumnHeader("rlpaddr.LIMB", 32, length),
+        new ColumnHeader("rlpaddr.LIMB", 16, length),
         new ColumnHeader("rlpaddr.nBYTES", 1, length),
-        new ColumnHeader("rlpaddr.NONCE", 32, length),
-        new ColumnHeader("rlpaddr.POWER", 32, length),
-        new ColumnHeader("rlpaddr.RAW_ADDR_HI", 32, length),
+        new ColumnHeader("rlpaddr.NONCE", 8, length),
+        new ColumnHeader("rlpaddr.POWER", 16, length),
+        new ColumnHeader("rlpaddr.RAW_ADDR_HI", 16, length),
         new ColumnHeader("rlpaddr.RECIPE", 1, length),
         new ColumnHeader("rlpaddr.RECIPE_1", 1, length),
         new ColumnHeader("rlpaddr.RECIPE_2", 1, length),
-        new ColumnHeader("rlpaddr.SALT_HI", 32, length),
-        new ColumnHeader("rlpaddr.SALT_LO", 32, length),
+        new ColumnHeader("rlpaddr.SALT_HI", 16, length),
+        new ColumnHeader("rlpaddr.SALT_LO", 16, length),
         new ColumnHeader("rlpaddr.SELECTOR_KECCAK_RES", 1, length),
-        new ColumnHeader("rlpaddr.STAMP", 4, length),
+        new ColumnHeader("rlpaddr.STAMP", 3, length),
         new ColumnHeader("rlpaddr.TINY_NON_ZERO_NONCE", 1, length));
   }
 
@@ -140,11 +141,14 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc.put((byte) 0);
-    }
-    acc.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("acc has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { acc.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc.put(bs.get(j)); }
 
     return this;
   }
@@ -168,7 +172,12 @@ public class Trace {
       filled.set(2);
     }
 
-    addrHi.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("addrHi has invalid value (" + b + ")"); }
+    addrHi.put((byte) (b >> 24));
+    addrHi.put((byte) (b >> 16));
+    addrHi.put((byte) (b >> 8));
+    addrHi.put((byte) b);
+
 
     return this;
   }
@@ -180,11 +189,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      addrLo.put((byte) 0);
-    }
-    addrLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("addrLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { addrLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { addrLo.put(bs.get(j)); }
 
     return this;
   }
@@ -244,7 +256,12 @@ public class Trace {
       filled.set(8);
     }
 
-    depAddrHi.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("depAddrHi has invalid value (" + b + ")"); }
+    depAddrHi.put((byte) (b >> 24));
+    depAddrHi.put((byte) (b >> 16));
+    depAddrHi.put((byte) (b >> 8));
+    depAddrHi.put((byte) b);
+
 
     return this;
   }
@@ -256,11 +273,14 @@ public class Trace {
       filled.set(9);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      depAddrLo.put((byte) 0);
-    }
-    depAddrLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("depAddrLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { depAddrLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { depAddrLo.put(bs.get(j)); }
 
     return this;
   }
@@ -284,11 +304,14 @@ public class Trace {
       filled.set(11);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      kecHi.put((byte) 0);
-    }
-    kecHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("kecHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { kecHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { kecHi.put(bs.get(j)); }
 
     return this;
   }
@@ -300,11 +323,14 @@ public class Trace {
       filled.set(12);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      kecLo.put((byte) 0);
-    }
-    kecLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("kecLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { kecLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { kecLo.put(bs.get(j)); }
 
     return this;
   }
@@ -328,11 +354,14 @@ public class Trace {
       filled.set(14);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      limb.put((byte) 0);
-    }
-    limb.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
 
     return this;
   }
@@ -356,11 +385,14 @@ public class Trace {
       filled.set(15);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      nonce.put((byte) 0);
-    }
-    nonce.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("nonce has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { nonce.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { nonce.put(bs.get(j)); }
 
     return this;
   }
@@ -372,11 +404,14 @@ public class Trace {
       filled.set(16);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      power.put((byte) 0);
-    }
-    power.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("power has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { power.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { power.put(bs.get(j)); }
 
     return this;
   }
@@ -388,11 +423,14 @@ public class Trace {
       filled.set(17);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      rawAddrHi.put((byte) 0);
-    }
-    rawAddrHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("rawAddrHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { rawAddrHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { rawAddrHi.put(bs.get(j)); }
 
     return this;
   }
@@ -440,11 +478,14 @@ public class Trace {
       filled.set(21);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      saltHi.put((byte) 0);
-    }
-    saltHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("saltHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { saltHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { saltHi.put(bs.get(j)); }
 
     return this;
   }
@@ -456,11 +497,14 @@ public class Trace {
       filled.set(22);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      saltLo.put((byte) 0);
-    }
-    saltLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("saltLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { saltLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { saltLo.put(bs.get(j)); }
 
     return this;
   }
@@ -477,14 +521,18 @@ public class Trace {
     return this;
   }
 
-  public Trace stamp(final int b) {
+  public Trace stamp(final long b) {
     if (filled.get(24)) {
       throw new IllegalStateException("rlpaddr.STAMP already set");
     } else {
       filled.set(24);
     }
 
-    stamp.putInt(b);
+    if(b >= 16777216L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    stamp.put((byte) (b >> 16));
+    stamp.put((byte) (b >> 8));
+    stamp.put((byte) b);
+
 
     return this;
   }
@@ -618,7 +666,7 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      acc.position(acc.position() + 32);
+      acc.position(acc.position() + 8);
     }
 
     if (!filled.get(1)) {
@@ -626,11 +674,11 @@ public class Trace {
     }
 
     if (!filled.get(2)) {
-      addrHi.position(addrHi.position() + 8);
+      addrHi.position(addrHi.position() + 4);
     }
 
     if (!filled.get(3)) {
-      addrLo.position(addrLo.position() + 32);
+      addrLo.position(addrLo.position() + 16);
     }
 
     if (!filled.get(4)) {
@@ -650,11 +698,11 @@ public class Trace {
     }
 
     if (!filled.get(8)) {
-      depAddrHi.position(depAddrHi.position() + 8);
+      depAddrHi.position(depAddrHi.position() + 4);
     }
 
     if (!filled.get(9)) {
-      depAddrLo.position(depAddrLo.position() + 32);
+      depAddrLo.position(depAddrLo.position() + 16);
     }
 
     if (!filled.get(10)) {
@@ -662,11 +710,11 @@ public class Trace {
     }
 
     if (!filled.get(11)) {
-      kecHi.position(kecHi.position() + 32);
+      kecHi.position(kecHi.position() + 16);
     }
 
     if (!filled.get(12)) {
-      kecLo.position(kecLo.position() + 32);
+      kecLo.position(kecLo.position() + 16);
     }
 
     if (!filled.get(13)) {
@@ -674,7 +722,7 @@ public class Trace {
     }
 
     if (!filled.get(14)) {
-      limb.position(limb.position() + 32);
+      limb.position(limb.position() + 16);
     }
 
     if (!filled.get(26)) {
@@ -682,15 +730,15 @@ public class Trace {
     }
 
     if (!filled.get(15)) {
-      nonce.position(nonce.position() + 32);
+      nonce.position(nonce.position() + 8);
     }
 
     if (!filled.get(16)) {
-      power.position(power.position() + 32);
+      power.position(power.position() + 16);
     }
 
     if (!filled.get(17)) {
-      rawAddrHi.position(rawAddrHi.position() + 32);
+      rawAddrHi.position(rawAddrHi.position() + 16);
     }
 
     if (!filled.get(18)) {
@@ -706,11 +754,11 @@ public class Trace {
     }
 
     if (!filled.get(21)) {
-      saltHi.position(saltHi.position() + 32);
+      saltHi.position(saltHi.position() + 16);
     }
 
     if (!filled.get(22)) {
-      saltLo.position(saltLo.position() + 32);
+      saltLo.position(saltLo.position() + 16);
     }
 
     if (!filled.get(23)) {
@@ -718,7 +766,7 @@ public class Trace {
     }
 
     if (!filled.get(24)) {
-      stamp.position(stamp.position() + 4);
+      stamp.position(stamp.position() + 3);
     }
 
     if (!filled.get(25)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.rlptxn;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -97,31 +98,31 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("rlptxn.ABS_TX_NUM", 4, length),
-        new ColumnHeader("rlptxn.ABS_TX_NUM_INFINY", 4, length),
-        new ColumnHeader("rlptxn.ACC_1", 32, length),
-        new ColumnHeader("rlptxn.ACC_2", 32, length),
-        new ColumnHeader("rlptxn.ACC_BYTESIZE", 2, length),
-        new ColumnHeader("rlptxn.ACCESS_TUPLE_BYTESIZE", 4, length),
-        new ColumnHeader("rlptxn.ADDR_HI", 8, length),
-        new ColumnHeader("rlptxn.ADDR_LO", 32, length),
+        new ColumnHeader("rlptxn.ABS_TX_NUM", 2, length),
+        new ColumnHeader("rlptxn.ABS_TX_NUM_INFINY", 2, length),
+        new ColumnHeader("rlptxn.ACC_1", 16, length),
+        new ColumnHeader("rlptxn.ACC_2", 16, length),
+        new ColumnHeader("rlptxn.ACC_BYTESIZE", 1, length),
+        new ColumnHeader("rlptxn.ACCESS_TUPLE_BYTESIZE", 3, length),
+        new ColumnHeader("rlptxn.ADDR_HI", 4, length),
+        new ColumnHeader("rlptxn.ADDR_LO", 16, length),
         new ColumnHeader("rlptxn.BIT", 1, length),
         new ColumnHeader("rlptxn.BIT_ACC", 1, length),
         new ColumnHeader("rlptxn.BYTE_1", 1, length),
         new ColumnHeader("rlptxn.BYTE_2", 1, length),
-        new ColumnHeader("rlptxn.CODE_FRAGMENT_INDEX", 8, length),
-        new ColumnHeader("rlptxn.COUNTER", 2, length),
-        new ColumnHeader("rlptxn.DATA_GAS_COST", 8, length),
-        new ColumnHeader("rlptxn.DATA_HI", 32, length),
-        new ColumnHeader("rlptxn.DATA_LO", 32, length),
+        new ColumnHeader("rlptxn.CODE_FRAGMENT_INDEX", 4, length),
+        new ColumnHeader("rlptxn.COUNTER", 1, length),
+        new ColumnHeader("rlptxn.DATA_GAS_COST", 4, length),
+        new ColumnHeader("rlptxn.DATA_HI", 16, length),
+        new ColumnHeader("rlptxn.DATA_LO", 16, length),
         new ColumnHeader("rlptxn.DEPTH_1", 1, length),
         new ColumnHeader("rlptxn.DEPTH_2", 1, length),
         new ColumnHeader("rlptxn.DONE", 1, length),
-        new ColumnHeader("rlptxn.INDEX_DATA", 8, length),
-        new ColumnHeader("rlptxn.INDEX_LT", 8, length),
-        new ColumnHeader("rlptxn.INDEX_LX", 8, length),
-        new ColumnHeader("rlptxn.INPUT_1", 32, length),
-        new ColumnHeader("rlptxn.INPUT_2", 32, length),
+        new ColumnHeader("rlptxn.INDEX_DATA", 4, length),
+        new ColumnHeader("rlptxn.INDEX_LT", 4, length),
+        new ColumnHeader("rlptxn.INDEX_LX", 4, length),
+        new ColumnHeader("rlptxn.INPUT_1", 16, length),
+        new ColumnHeader("rlptxn.INPUT_2", 16, length),
         new ColumnHeader("rlptxn.IS_PHASE_ACCESS_LIST", 1, length),
         new ColumnHeader("rlptxn.IS_PHASE_BETA", 1, length),
         new ColumnHeader("rlptxn.IS_PHASE_CHAIN_ID", 1, length),
@@ -139,24 +140,24 @@ public class Trace {
         new ColumnHeader("rlptxn.IS_PHASE_Y", 1, length),
         new ColumnHeader("rlptxn.IS_PREFIX", 1, length),
         new ColumnHeader("rlptxn.LC_CORRECTION", 1, length),
-        new ColumnHeader("rlptxn.LIMB", 32, length),
+        new ColumnHeader("rlptxn.LIMB", 16, length),
         new ColumnHeader("rlptxn.LIMB_CONSTRUCTED", 1, length),
         new ColumnHeader("rlptxn.LT", 1, length),
         new ColumnHeader("rlptxn.LX", 1, length),
-        new ColumnHeader("rlptxn.nADDR", 4, length),
-        new ColumnHeader("rlptxn.nBYTES", 2, length),
-        new ColumnHeader("rlptxn.nKEYS", 4, length),
-        new ColumnHeader("rlptxn.nKEYS_PER_ADDR", 4, length),
-        new ColumnHeader("rlptxn.nSTEP", 2, length),
-        new ColumnHeader("rlptxn.PHASE", 2, length),
+        new ColumnHeader("rlptxn.nADDR", 2, length),
+        new ColumnHeader("rlptxn.nBYTES", 1, length),
+        new ColumnHeader("rlptxn.nKEYS", 2, length),
+        new ColumnHeader("rlptxn.nKEYS_PER_ADDR", 2, length),
+        new ColumnHeader("rlptxn.nSTEP", 1, length),
+        new ColumnHeader("rlptxn.PHASE", 1, length),
         new ColumnHeader("rlptxn.PHASE_END", 1, length),
-        new ColumnHeader("rlptxn.PHASE_SIZE", 8, length),
-        new ColumnHeader("rlptxn.POWER", 32, length),
+        new ColumnHeader("rlptxn.PHASE_SIZE", 4, length),
+        new ColumnHeader("rlptxn.POWER", 16, length),
         new ColumnHeader("rlptxn.REQUIRES_EVM_EXECUTION", 1, length),
-        new ColumnHeader("rlptxn.RLP_LT_BYTESIZE", 4, length),
-        new ColumnHeader("rlptxn.RLP_LX_BYTESIZE", 4, length),
+        new ColumnHeader("rlptxn.RLP_LT_BYTESIZE", 3, length),
+        new ColumnHeader("rlptxn.RLP_LX_BYTESIZE", 3, length),
         new ColumnHeader("rlptxn.TO_HASH_BY_PROVER", 1, length),
-        new ColumnHeader("rlptxn.TYPE", 2, length));
+        new ColumnHeader("rlptxn.TYPE", 1, length));
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -230,26 +231,32 @@ public class Trace {
     return this.currentLine;
   }
 
-  public Trace absTxNum(final int b) {
+  public Trace absTxNum(final long b) {
     if (filled.get(0)) {
       throw new IllegalStateException("rlptxn.ABS_TX_NUM already set");
     } else {
       filled.set(0);
     }
 
-    absTxNum.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("absTxNum has invalid value (" + b + ")"); }
+    absTxNum.put((byte) (b >> 8));
+    absTxNum.put((byte) b);
+
 
     return this;
   }
 
-  public Trace absTxNumInfiny(final int b) {
+  public Trace absTxNumInfiny(final long b) {
     if (filled.get(1)) {
       throw new IllegalStateException("rlptxn.ABS_TX_NUM_INFINY already set");
     } else {
       filled.set(1);
     }
 
-    absTxNumInfiny.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("absTxNumInfiny has invalid value (" + b + ")"); }
+    absTxNumInfiny.put((byte) (b >> 8));
+    absTxNumInfiny.put((byte) b);
+
 
     return this;
   }
@@ -261,11 +268,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc1.put((byte) 0);
-    }
-    acc1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
 
     return this;
   }
@@ -277,35 +287,44 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc2.put((byte) 0);
-    }
-    acc2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
 
     return this;
   }
 
-  public Trace accBytesize(final short b) {
+  public Trace accBytesize(final long b) {
     if (filled.get(5)) {
       throw new IllegalStateException("rlptxn.ACC_BYTESIZE already set");
     } else {
       filled.set(5);
     }
 
-    accBytesize.putShort(b);
+    if(b >= 32L) { throw new IllegalArgumentException("accBytesize has invalid value (" + b + ")"); }
+    accBytesize.put((byte) b);
+
 
     return this;
   }
 
-  public Trace accessTupleBytesize(final int b) {
+  public Trace accessTupleBytesize(final long b) {
     if (filled.get(2)) {
       throw new IllegalStateException("rlptxn.ACCESS_TUPLE_BYTESIZE already set");
     } else {
       filled.set(2);
     }
 
-    accessTupleBytesize.putInt(b);
+    if(b >= 16777216L) { throw new IllegalArgumentException("accessTupleBytesize has invalid value (" + b + ")"); }
+    accessTupleBytesize.put((byte) (b >> 16));
+    accessTupleBytesize.put((byte) (b >> 8));
+    accessTupleBytesize.put((byte) b);
+
 
     return this;
   }
@@ -317,7 +336,12 @@ public class Trace {
       filled.set(6);
     }
 
-    addrHi.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("addrHi has invalid value (" + b + ")"); }
+    addrHi.put((byte) (b >> 24));
+    addrHi.put((byte) (b >> 16));
+    addrHi.put((byte) (b >> 8));
+    addrHi.put((byte) b);
+
 
     return this;
   }
@@ -329,11 +353,14 @@ public class Trace {
       filled.set(7);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      addrLo.put((byte) 0);
-    }
-    addrLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("addrLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { addrLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { addrLo.put(bs.get(j)); }
 
     return this;
   }
@@ -393,19 +420,26 @@ public class Trace {
       filled.set(12);
     }
 
-    codeFragmentIndex.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")"); }
+    codeFragmentIndex.put((byte) (b >> 24));
+    codeFragmentIndex.put((byte) (b >> 16));
+    codeFragmentIndex.put((byte) (b >> 8));
+    codeFragmentIndex.put((byte) b);
+
 
     return this;
   }
 
-  public Trace counter(final short b) {
+  public Trace counter(final long b) {
     if (filled.get(13)) {
       throw new IllegalStateException("rlptxn.COUNTER already set");
     } else {
       filled.set(13);
     }
 
-    counter.putShort(b);
+    if(b >= 32L) { throw new IllegalArgumentException("counter has invalid value (" + b + ")"); }
+    counter.put((byte) b);
+
 
     return this;
   }
@@ -417,7 +451,12 @@ public class Trace {
       filled.set(14);
     }
 
-    dataGasCost.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("dataGasCost has invalid value (" + b + ")"); }
+    dataGasCost.put((byte) (b >> 24));
+    dataGasCost.put((byte) (b >> 16));
+    dataGasCost.put((byte) (b >> 8));
+    dataGasCost.put((byte) b);
+
 
     return this;
   }
@@ -429,11 +468,14 @@ public class Trace {
       filled.set(15);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      dataHi.put((byte) 0);
-    }
-    dataHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("dataHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { dataHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { dataHi.put(bs.get(j)); }
 
     return this;
   }
@@ -445,11 +487,14 @@ public class Trace {
       filled.set(16);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      dataLo.put((byte) 0);
-    }
-    dataLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("dataLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { dataLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { dataLo.put(bs.get(j)); }
 
     return this;
   }
@@ -497,7 +542,12 @@ public class Trace {
       filled.set(20);
     }
 
-    indexData.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("indexData has invalid value (" + b + ")"); }
+    indexData.put((byte) (b >> 24));
+    indexData.put((byte) (b >> 16));
+    indexData.put((byte) (b >> 8));
+    indexData.put((byte) b);
+
 
     return this;
   }
@@ -509,7 +559,12 @@ public class Trace {
       filled.set(21);
     }
 
-    indexLt.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("indexLt has invalid value (" + b + ")"); }
+    indexLt.put((byte) (b >> 24));
+    indexLt.put((byte) (b >> 16));
+    indexLt.put((byte) (b >> 8));
+    indexLt.put((byte) b);
+
 
     return this;
   }
@@ -521,7 +576,12 @@ public class Trace {
       filled.set(22);
     }
 
-    indexLx.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("indexLx has invalid value (" + b + ")"); }
+    indexLx.put((byte) (b >> 24));
+    indexLx.put((byte) (b >> 16));
+    indexLx.put((byte) (b >> 8));
+    indexLx.put((byte) b);
+
 
     return this;
   }
@@ -533,11 +593,14 @@ public class Trace {
       filled.set(23);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      input1.put((byte) 0);
-    }
-    input1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("input1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { input1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { input1.put(bs.get(j)); }
 
     return this;
   }
@@ -549,11 +612,14 @@ public class Trace {
       filled.set(24);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      input2.put((byte) 0);
-    }
-    input2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("input2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { input2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { input2.put(bs.get(j)); }
 
     return this;
   }
@@ -769,11 +835,14 @@ public class Trace {
       filled.set(42);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      limb.put((byte) 0);
-    }
-    limb.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
 
     return this;
   }
@@ -814,74 +883,89 @@ public class Trace {
     return this;
   }
 
-  public Trace nAddr(final int b) {
+  public Trace nAddr(final long b) {
     if (filled.get(55)) {
       throw new IllegalStateException("rlptxn.nADDR already set");
     } else {
       filled.set(55);
     }
 
-    nAddr.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("nAddr has invalid value (" + b + ")"); }
+    nAddr.put((byte) (b >> 8));
+    nAddr.put((byte) b);
+
 
     return this;
   }
 
-  public Trace nBytes(final short b) {
+  public Trace nBytes(final long b) {
     if (filled.get(56)) {
       throw new IllegalStateException("rlptxn.nBYTES already set");
     } else {
       filled.set(56);
     }
 
-    nBytes.putShort(b);
+    if(b >= 32L) { throw new IllegalArgumentException("nBytes has invalid value (" + b + ")"); }
+    nBytes.put((byte) b);
+
 
     return this;
   }
 
-  public Trace nKeys(final int b) {
+  public Trace nKeys(final long b) {
     if (filled.get(57)) {
       throw new IllegalStateException("rlptxn.nKEYS already set");
     } else {
       filled.set(57);
     }
 
-    nKeys.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("nKeys has invalid value (" + b + ")"); }
+    nKeys.put((byte) (b >> 8));
+    nKeys.put((byte) b);
+
 
     return this;
   }
 
-  public Trace nKeysPerAddr(final int b) {
+  public Trace nKeysPerAddr(final long b) {
     if (filled.get(58)) {
       throw new IllegalStateException("rlptxn.nKEYS_PER_ADDR already set");
     } else {
       filled.set(58);
     }
 
-    nKeysPerAddr.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("nKeysPerAddr has invalid value (" + b + ")"); }
+    nKeysPerAddr.put((byte) (b >> 8));
+    nKeysPerAddr.put((byte) b);
+
 
     return this;
   }
 
-  public Trace nStep(final short b) {
+  public Trace nStep(final long b) {
     if (filled.get(59)) {
       throw new IllegalStateException("rlptxn.nSTEP already set");
     } else {
       filled.set(59);
     }
 
-    nStep.putShort(b);
+    if(b >= 32L) { throw new IllegalArgumentException("nStep has invalid value (" + b + ")"); }
+    nStep.put((byte) b);
+
 
     return this;
   }
 
-  public Trace phase(final short b) {
+  public Trace phase(final long b) {
     if (filled.get(46)) {
       throw new IllegalStateException("rlptxn.PHASE already set");
     } else {
       filled.set(46);
     }
 
-    phase.putShort(b);
+    if(b >= 32L) { throw new IllegalArgumentException("phase has invalid value (" + b + ")"); }
+    phase.put((byte) b);
+
 
     return this;
   }
@@ -905,7 +989,12 @@ public class Trace {
       filled.set(48);
     }
 
-    phaseSize.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("phaseSize has invalid value (" + b + ")"); }
+    phaseSize.put((byte) (b >> 24));
+    phaseSize.put((byte) (b >> 16));
+    phaseSize.put((byte) (b >> 8));
+    phaseSize.put((byte) b);
+
 
     return this;
   }
@@ -917,11 +1006,14 @@ public class Trace {
       filled.set(49);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      power.put((byte) 0);
-    }
-    power.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("power has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { power.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { power.put(bs.get(j)); }
 
     return this;
   }
@@ -938,26 +1030,34 @@ public class Trace {
     return this;
   }
 
-  public Trace rlpLtBytesize(final int b) {
+  public Trace rlpLtBytesize(final long b) {
     if (filled.get(51)) {
       throw new IllegalStateException("rlptxn.RLP_LT_BYTESIZE already set");
     } else {
       filled.set(51);
     }
 
-    rlpLtBytesize.putInt(b);
+    if(b >= 16777216L) { throw new IllegalArgumentException("rlpLtBytesize has invalid value (" + b + ")"); }
+    rlpLtBytesize.put((byte) (b >> 16));
+    rlpLtBytesize.put((byte) (b >> 8));
+    rlpLtBytesize.put((byte) b);
+
 
     return this;
   }
 
-  public Trace rlpLxBytesize(final int b) {
+  public Trace rlpLxBytesize(final long b) {
     if (filled.get(52)) {
       throw new IllegalStateException("rlptxn.RLP_LX_BYTESIZE already set");
     } else {
       filled.set(52);
     }
 
-    rlpLxBytesize.putInt(b);
+    if(b >= 16777216L) { throw new IllegalArgumentException("rlpLxBytesize has invalid value (" + b + ")"); }
+    rlpLxBytesize.put((byte) (b >> 16));
+    rlpLxBytesize.put((byte) (b >> 8));
+    rlpLxBytesize.put((byte) b);
+
 
     return this;
   }
@@ -974,14 +1074,16 @@ public class Trace {
     return this;
   }
 
-  public Trace type(final short b) {
+  public Trace type(final long b) {
     if (filled.get(54)) {
       throw new IllegalStateException("rlptxn.TYPE already set");
     } else {
       filled.set(54);
     }
 
-    type.putShort(b);
+    if(b >= 8L) { throw new IllegalArgumentException("type has invalid value (" + b + ")"); }
+    type.put((byte) b);
+
 
     return this;
   }
@@ -1116,8 +1218,7 @@ public class Trace {
     }
 
     if (!filled.get(32)) {
-      throw new IllegalStateException(
-          "rlptxn.IS_PHASE_MAX_PRIORITY_FEE_PER_GAS has not been filled");
+      throw new IllegalStateException("rlptxn.IS_PHASE_MAX_PRIORITY_FEE_PER_GAS has not been filled");
     }
 
     if (!filled.get(33)) {
@@ -1236,35 +1337,35 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      absTxNum.position(absTxNum.position() + 4);
+      absTxNum.position(absTxNum.position() + 2);
     }
 
     if (!filled.get(1)) {
-      absTxNumInfiny.position(absTxNumInfiny.position() + 4);
+      absTxNumInfiny.position(absTxNumInfiny.position() + 2);
     }
 
     if (!filled.get(3)) {
-      acc1.position(acc1.position() + 32);
+      acc1.position(acc1.position() + 16);
     }
 
     if (!filled.get(4)) {
-      acc2.position(acc2.position() + 32);
+      acc2.position(acc2.position() + 16);
     }
 
     if (!filled.get(5)) {
-      accBytesize.position(accBytesize.position() + 2);
+      accBytesize.position(accBytesize.position() + 1);
     }
 
     if (!filled.get(2)) {
-      accessTupleBytesize.position(accessTupleBytesize.position() + 4);
+      accessTupleBytesize.position(accessTupleBytesize.position() + 3);
     }
 
     if (!filled.get(6)) {
-      addrHi.position(addrHi.position() + 8);
+      addrHi.position(addrHi.position() + 4);
     }
 
     if (!filled.get(7)) {
-      addrLo.position(addrLo.position() + 32);
+      addrLo.position(addrLo.position() + 16);
     }
 
     if (!filled.get(8)) {
@@ -1284,23 +1385,23 @@ public class Trace {
     }
 
     if (!filled.get(12)) {
-      codeFragmentIndex.position(codeFragmentIndex.position() + 8);
+      codeFragmentIndex.position(codeFragmentIndex.position() + 4);
     }
 
     if (!filled.get(13)) {
-      counter.position(counter.position() + 2);
+      counter.position(counter.position() + 1);
     }
 
     if (!filled.get(14)) {
-      dataGasCost.position(dataGasCost.position() + 8);
+      dataGasCost.position(dataGasCost.position() + 4);
     }
 
     if (!filled.get(15)) {
-      dataHi.position(dataHi.position() + 32);
+      dataHi.position(dataHi.position() + 16);
     }
 
     if (!filled.get(16)) {
-      dataLo.position(dataLo.position() + 32);
+      dataLo.position(dataLo.position() + 16);
     }
 
     if (!filled.get(17)) {
@@ -1316,23 +1417,23 @@ public class Trace {
     }
 
     if (!filled.get(20)) {
-      indexData.position(indexData.position() + 8);
+      indexData.position(indexData.position() + 4);
     }
 
     if (!filled.get(21)) {
-      indexLt.position(indexLt.position() + 8);
+      indexLt.position(indexLt.position() + 4);
     }
 
     if (!filled.get(22)) {
-      indexLx.position(indexLx.position() + 8);
+      indexLx.position(indexLx.position() + 4);
     }
 
     if (!filled.get(23)) {
-      input1.position(input1.position() + 32);
+      input1.position(input1.position() + 16);
     }
 
     if (!filled.get(24)) {
-      input2.position(input2.position() + 32);
+      input2.position(input2.position() + 16);
     }
 
     if (!filled.get(25)) {
@@ -1404,7 +1505,7 @@ public class Trace {
     }
 
     if (!filled.get(42)) {
-      limb.position(limb.position() + 32);
+      limb.position(limb.position() + 16);
     }
 
     if (!filled.get(43)) {
@@ -1420,27 +1521,27 @@ public class Trace {
     }
 
     if (!filled.get(55)) {
-      nAddr.position(nAddr.position() + 4);
+      nAddr.position(nAddr.position() + 2);
     }
 
     if (!filled.get(56)) {
-      nBytes.position(nBytes.position() + 2);
+      nBytes.position(nBytes.position() + 1);
     }
 
     if (!filled.get(57)) {
-      nKeys.position(nKeys.position() + 4);
+      nKeys.position(nKeys.position() + 2);
     }
 
     if (!filled.get(58)) {
-      nKeysPerAddr.position(nKeysPerAddr.position() + 4);
+      nKeysPerAddr.position(nKeysPerAddr.position() + 2);
     }
 
     if (!filled.get(59)) {
-      nStep.position(nStep.position() + 2);
+      nStep.position(nStep.position() + 1);
     }
 
     if (!filled.get(46)) {
-      phase.position(phase.position() + 2);
+      phase.position(phase.position() + 1);
     }
 
     if (!filled.get(47)) {
@@ -1448,11 +1549,11 @@ public class Trace {
     }
 
     if (!filled.get(48)) {
-      phaseSize.position(phaseSize.position() + 8);
+      phaseSize.position(phaseSize.position() + 4);
     }
 
     if (!filled.get(49)) {
-      power.position(power.position() + 32);
+      power.position(power.position() + 16);
     }
 
     if (!filled.get(50)) {
@@ -1460,11 +1561,11 @@ public class Trace {
     }
 
     if (!filled.get(51)) {
-      rlpLtBytesize.position(rlpLtBytesize.position() + 4);
+      rlpLtBytesize.position(rlpLtBytesize.position() + 3);
     }
 
     if (!filled.get(52)) {
-      rlpLxBytesize.position(rlpLxBytesize.position() + 4);
+      rlpLxBytesize.position(rlpLxBytesize.position() + 3);
     }
 
     if (!filled.get(53)) {
@@ -1472,7 +1573,7 @@ public class Trace {
     }
 
     if (!filled.get(54)) {
-      type.position(type.position() + 2);
+      type.position(type.position() + 1);
     }
 
     filled.clear();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.rlptxn;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -238,10 +237,11 @@ public class Trace {
       filled.set(0);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("absTxNum has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("absTxNum has invalid value (" + b + ")");
+    }
     absTxNum.put((byte) (b >> 8));
     absTxNum.put((byte) b);
-
 
     return this;
   }
@@ -253,10 +253,11 @@ public class Trace {
       filled.set(1);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("absTxNumInfiny has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("absTxNumInfiny has invalid value (" + b + ")");
+    }
     absTxNumInfiny.put((byte) (b >> 8));
     absTxNumInfiny.put((byte) b);
-
 
     return this;
   }
@@ -271,11 +272,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc1.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -290,11 +297,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc2.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -306,9 +319,10 @@ public class Trace {
       filled.set(5);
     }
 
-    if(b >= 32L) { throw new IllegalArgumentException("accBytesize has invalid value (" + b + ")"); }
+    if (b >= 32L) {
+      throw new IllegalArgumentException("accBytesize has invalid value (" + b + ")");
+    }
     accBytesize.put((byte) b);
-
 
     return this;
   }
@@ -320,11 +334,12 @@ public class Trace {
       filled.set(2);
     }
 
-    if(b >= 16777216L) { throw new IllegalArgumentException("accessTupleBytesize has invalid value (" + b + ")"); }
+    if (b >= 16777216L) {
+      throw new IllegalArgumentException("accessTupleBytesize has invalid value (" + b + ")");
+    }
     accessTupleBytesize.put((byte) (b >> 16));
     accessTupleBytesize.put((byte) (b >> 8));
     accessTupleBytesize.put((byte) b);
-
 
     return this;
   }
@@ -336,12 +351,13 @@ public class Trace {
       filled.set(6);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("addrHi has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("addrHi has invalid value (" + b + ")");
+    }
     addrHi.put((byte) (b >> 24));
     addrHi.put((byte) (b >> 16));
     addrHi.put((byte) (b >> 8));
     addrHi.put((byte) b);
-
 
     return this;
   }
@@ -356,11 +372,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("addrLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("addrLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { addrLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      addrLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { addrLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      addrLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -420,12 +442,13 @@ public class Trace {
       filled.set(12);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")");
+    }
     codeFragmentIndex.put((byte) (b >> 24));
     codeFragmentIndex.put((byte) (b >> 16));
     codeFragmentIndex.put((byte) (b >> 8));
     codeFragmentIndex.put((byte) b);
-
 
     return this;
   }
@@ -437,9 +460,10 @@ public class Trace {
       filled.set(13);
     }
 
-    if(b >= 32L) { throw new IllegalArgumentException("counter has invalid value (" + b + ")"); }
+    if (b >= 32L) {
+      throw new IllegalArgumentException("counter has invalid value (" + b + ")");
+    }
     counter.put((byte) b);
-
 
     return this;
   }
@@ -451,12 +475,13 @@ public class Trace {
       filled.set(14);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("dataGasCost has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("dataGasCost has invalid value (" + b + ")");
+    }
     dataGasCost.put((byte) (b >> 24));
     dataGasCost.put((byte) (b >> 16));
     dataGasCost.put((byte) (b >> 8));
     dataGasCost.put((byte) b);
-
 
     return this;
   }
@@ -471,11 +496,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("dataHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("dataHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { dataHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      dataHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { dataHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      dataHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -490,11 +521,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("dataLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("dataLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { dataLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      dataLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { dataLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      dataLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -542,12 +579,13 @@ public class Trace {
       filled.set(20);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("indexData has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("indexData has invalid value (" + b + ")");
+    }
     indexData.put((byte) (b >> 24));
     indexData.put((byte) (b >> 16));
     indexData.put((byte) (b >> 8));
     indexData.put((byte) b);
-
 
     return this;
   }
@@ -559,12 +597,13 @@ public class Trace {
       filled.set(21);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("indexLt has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("indexLt has invalid value (" + b + ")");
+    }
     indexLt.put((byte) (b >> 24));
     indexLt.put((byte) (b >> 16));
     indexLt.put((byte) (b >> 8));
     indexLt.put((byte) b);
-
 
     return this;
   }
@@ -576,12 +615,13 @@ public class Trace {
       filled.set(22);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("indexLx has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("indexLx has invalid value (" + b + ")");
+    }
     indexLx.put((byte) (b >> 24));
     indexLx.put((byte) (b >> 16));
     indexLx.put((byte) (b >> 8));
     indexLx.put((byte) b);
-
 
     return this;
   }
@@ -596,11 +636,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("input1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("input1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { input1.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      input1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { input1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      input1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -615,11 +661,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("input2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("input2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { input2.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      input2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { input2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      input2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -838,11 +890,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      limb.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      limb.put(bs.get(j));
+    }
 
     return this;
   }
@@ -890,10 +948,11 @@ public class Trace {
       filled.set(55);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("nAddr has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("nAddr has invalid value (" + b + ")");
+    }
     nAddr.put((byte) (b >> 8));
     nAddr.put((byte) b);
-
 
     return this;
   }
@@ -905,9 +964,10 @@ public class Trace {
       filled.set(56);
     }
 
-    if(b >= 32L) { throw new IllegalArgumentException("nBytes has invalid value (" + b + ")"); }
+    if (b >= 32L) {
+      throw new IllegalArgumentException("nBytes has invalid value (" + b + ")");
+    }
     nBytes.put((byte) b);
-
 
     return this;
   }
@@ -919,10 +979,11 @@ public class Trace {
       filled.set(57);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("nKeys has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("nKeys has invalid value (" + b + ")");
+    }
     nKeys.put((byte) (b >> 8));
     nKeys.put((byte) b);
-
 
     return this;
   }
@@ -934,10 +995,11 @@ public class Trace {
       filled.set(58);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("nKeysPerAddr has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("nKeysPerAddr has invalid value (" + b + ")");
+    }
     nKeysPerAddr.put((byte) (b >> 8));
     nKeysPerAddr.put((byte) b);
-
 
     return this;
   }
@@ -949,9 +1011,10 @@ public class Trace {
       filled.set(59);
     }
 
-    if(b >= 32L) { throw new IllegalArgumentException("nStep has invalid value (" + b + ")"); }
+    if (b >= 32L) {
+      throw new IllegalArgumentException("nStep has invalid value (" + b + ")");
+    }
     nStep.put((byte) b);
-
 
     return this;
   }
@@ -963,9 +1026,10 @@ public class Trace {
       filled.set(46);
     }
 
-    if(b >= 32L) { throw new IllegalArgumentException("phase has invalid value (" + b + ")"); }
+    if (b >= 32L) {
+      throw new IllegalArgumentException("phase has invalid value (" + b + ")");
+    }
     phase.put((byte) b);
-
 
     return this;
   }
@@ -989,12 +1053,13 @@ public class Trace {
       filled.set(48);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("phaseSize has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("phaseSize has invalid value (" + b + ")");
+    }
     phaseSize.put((byte) (b >> 24));
     phaseSize.put((byte) (b >> 16));
     phaseSize.put((byte) (b >> 8));
     phaseSize.put((byte) b);
-
 
     return this;
   }
@@ -1009,11 +1074,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("power has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("power has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { power.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      power.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { power.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      power.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1037,11 +1108,12 @@ public class Trace {
       filled.set(51);
     }
 
-    if(b >= 16777216L) { throw new IllegalArgumentException("rlpLtBytesize has invalid value (" + b + ")"); }
+    if (b >= 16777216L) {
+      throw new IllegalArgumentException("rlpLtBytesize has invalid value (" + b + ")");
+    }
     rlpLtBytesize.put((byte) (b >> 16));
     rlpLtBytesize.put((byte) (b >> 8));
     rlpLtBytesize.put((byte) b);
-
 
     return this;
   }
@@ -1053,11 +1125,12 @@ public class Trace {
       filled.set(52);
     }
 
-    if(b >= 16777216L) { throw new IllegalArgumentException("rlpLxBytesize has invalid value (" + b + ")"); }
+    if (b >= 16777216L) {
+      throw new IllegalArgumentException("rlpLxBytesize has invalid value (" + b + ")");
+    }
     rlpLxBytesize.put((byte) (b >> 16));
     rlpLxBytesize.put((byte) (b >> 8));
     rlpLxBytesize.put((byte) b);
-
 
     return this;
   }
@@ -1081,9 +1154,10 @@ public class Trace {
       filled.set(54);
     }
 
-    if(b >= 8L) { throw new IllegalArgumentException("type has invalid value (" + b + ")"); }
+    if (b >= 8L) {
+      throw new IllegalArgumentException("type has invalid value (" + b + ")");
+    }
     type.put((byte) b);
-
 
     return this;
   }
@@ -1218,7 +1292,8 @@ public class Trace {
     }
 
     if (!filled.get(32)) {
-      throw new IllegalStateException("rlptxn.IS_PHASE_MAX_PRIORITY_FEE_PER_GAS has not been filled");
+      throw new IllegalStateException(
+          "rlptxn.IS_PHASE_MAX_PRIORITY_FEE_PER_GAS has not been filled");
     }
 
     if (!filled.get(33)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxrcpt/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxrcpt/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.rlptxrcpt;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -195,12 +194,13 @@ public class Trace {
       filled.set(0);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("absLogNum has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("absLogNum has invalid value (" + b + ")");
+    }
     absLogNum.put((byte) (b >> 24));
     absLogNum.put((byte) (b >> 16));
     absLogNum.put((byte) (b >> 8));
     absLogNum.put((byte) b);
-
 
     return this;
   }
@@ -212,12 +212,13 @@ public class Trace {
       filled.set(1);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("absLogNumMax has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("absLogNumMax has invalid value (" + b + ")");
+    }
     absLogNumMax.put((byte) (b >> 24));
     absLogNumMax.put((byte) (b >> 16));
     absLogNumMax.put((byte) (b >> 8));
     absLogNumMax.put((byte) b);
-
 
     return this;
   }
@@ -229,12 +230,13 @@ public class Trace {
       filled.set(2);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("absTxNum has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("absTxNum has invalid value (" + b + ")");
+    }
     absTxNum.put((byte) (b >> 24));
     absTxNum.put((byte) (b >> 16));
     absTxNum.put((byte) (b >> 8));
     absTxNum.put((byte) b);
-
 
     return this;
   }
@@ -246,12 +248,13 @@ public class Trace {
       filled.set(3);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("absTxNumMax has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("absTxNumMax has invalid value (" + b + ")");
+    }
     absTxNumMax.put((byte) (b >> 24));
     absTxNumMax.put((byte) (b >> 16));
     absTxNumMax.put((byte) (b >> 8));
     absTxNumMax.put((byte) b);
-
 
     return this;
   }
@@ -266,11 +269,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc1.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -285,11 +294,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc2.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -304,11 +319,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc3.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -323,11 +344,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc4.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -339,9 +366,10 @@ public class Trace {
       filled.set(8);
     }
 
-    if(b >= 32L) { throw new IllegalArgumentException("accSize has invalid value (" + b + ")"); }
+    if (b >= 32L) {
+      throw new IllegalArgumentException("accSize has invalid value (" + b + ")");
+    }
     accSize.put((byte) b);
-
 
     return this;
   }
@@ -425,12 +453,13 @@ public class Trace {
       filled.set(15);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("counter has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("counter has invalid value (" + b + ")");
+    }
     counter.put((byte) (b >> 24));
     counter.put((byte) (b >> 16));
     counter.put((byte) (b >> 8));
     counter.put((byte) b);
-
 
     return this;
   }
@@ -466,11 +495,12 @@ public class Trace {
       filled.set(18);
     }
 
-    if(b >= 16777216L) { throw new IllegalArgumentException("index has invalid value (" + b + ")"); }
+    if (b >= 16777216L) {
+      throw new IllegalArgumentException("index has invalid value (" + b + ")");
+    }
     index.put((byte) (b >> 16));
     index.put((byte) (b >> 8));
     index.put((byte) b);
-
 
     return this;
   }
@@ -482,10 +512,11 @@ public class Trace {
       filled.set(19);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("indexLocal has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("indexLocal has invalid value (" + b + ")");
+    }
     indexLocal.put((byte) (b >> 8));
     indexLocal.put((byte) b);
-
 
     return this;
   }
@@ -500,11 +531,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("input1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("input1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { input1.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      input1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { input1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      input1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -519,11 +556,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("input2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("input2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { input2.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      input2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { input2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      input2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -538,11 +581,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("input3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("input3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { input3.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      input3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { input3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      input3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -557,11 +606,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("input4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("input4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { input4.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      input4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { input4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      input4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -624,11 +679,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      limb.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      limb.put(bs.get(j));
+    }
 
     return this;
   }
@@ -652,12 +713,13 @@ public class Trace {
       filled.set(30);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("localSize has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("localSize has invalid value (" + b + ")");
+    }
     localSize.put((byte) (b >> 24));
     localSize.put((byte) (b >> 16));
     localSize.put((byte) (b >> 8));
     localSize.put((byte) b);
-
 
     return this;
   }
@@ -669,12 +731,13 @@ public class Trace {
       filled.set(31);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("logEntrySize has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("logEntrySize has invalid value (" + b + ")");
+    }
     logEntrySize.put((byte) (b >> 24));
     logEntrySize.put((byte) (b >> 16));
     logEntrySize.put((byte) (b >> 8));
     logEntrySize.put((byte) b);
-
 
     return this;
   }
@@ -686,9 +749,10 @@ public class Trace {
       filled.set(42);
     }
 
-    if(b >= 32L) { throw new IllegalArgumentException("nBytes has invalid value (" + b + ")"); }
+    if (b >= 32L) {
+      throw new IllegalArgumentException("nBytes has invalid value (" + b + ")");
+    }
     nBytes.put((byte) b);
-
 
     return this;
   }
@@ -700,12 +764,13 @@ public class Trace {
       filled.set(43);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("nStep has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("nStep has invalid value (" + b + ")");
+    }
     nStep.put((byte) (b >> 24));
     nStep.put((byte) (b >> 16));
     nStep.put((byte) (b >> 8));
     nStep.put((byte) b);
-
 
     return this;
   }
@@ -789,10 +854,11 @@ public class Trace {
       filled.set(38);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("phaseId has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("phaseId has invalid value (" + b + ")");
+    }
     phaseId.put((byte) (b >> 8));
     phaseId.put((byte) b);
-
 
     return this;
   }
@@ -804,12 +870,13 @@ public class Trace {
       filled.set(39);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("phaseSize has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("phaseSize has invalid value (" + b + ")");
+    }
     phaseSize.put((byte) (b >> 24));
     phaseSize.put((byte) (b >> 16));
     phaseSize.put((byte) (b >> 8));
     phaseSize.put((byte) b);
-
 
     return this;
   }
@@ -824,11 +891,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("power has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("power has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { power.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      power.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { power.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      power.put(bs.get(j));
+    }
 
     return this;
   }
@@ -840,12 +913,13 @@ public class Trace {
       filled.set(41);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("txrcptSize has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("txrcptSize has invalid value (" + b + ")");
+    }
     txrcptSize.put((byte) (b >> 24));
     txrcptSize.put((byte) (b >> 16));
     txrcptSize.put((byte) (b >> 8));
     txrcptSize.put((byte) b);
-
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxrcpt/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxrcpt/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.rlptxrcpt;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -86,50 +87,50 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("rlptxrcpt.ABS_LOG_NUM", 8, length),
-        new ColumnHeader("rlptxrcpt.ABS_LOG_NUM_MAX", 8, length),
-        new ColumnHeader("rlptxrcpt.ABS_TX_NUM", 8, length),
-        new ColumnHeader("rlptxrcpt.ABS_TX_NUM_MAX", 8, length),
-        new ColumnHeader("rlptxrcpt.ACC_1", 32, length),
-        new ColumnHeader("rlptxrcpt.ACC_2", 32, length),
-        new ColumnHeader("rlptxrcpt.ACC_3", 32, length),
-        new ColumnHeader("rlptxrcpt.ACC_4", 32, length),
-        new ColumnHeader("rlptxrcpt.ACC_SIZE", 2, length),
+        new ColumnHeader("rlptxrcpt.ABS_LOG_NUM", 4, length),
+        new ColumnHeader("rlptxrcpt.ABS_LOG_NUM_MAX", 4, length),
+        new ColumnHeader("rlptxrcpt.ABS_TX_NUM", 4, length),
+        new ColumnHeader("rlptxrcpt.ABS_TX_NUM_MAX", 4, length),
+        new ColumnHeader("rlptxrcpt.ACC_1", 16, length),
+        new ColumnHeader("rlptxrcpt.ACC_2", 16, length),
+        new ColumnHeader("rlptxrcpt.ACC_3", 16, length),
+        new ColumnHeader("rlptxrcpt.ACC_4", 16, length),
+        new ColumnHeader("rlptxrcpt.ACC_SIZE", 1, length),
         new ColumnHeader("rlptxrcpt.BIT", 1, length),
         new ColumnHeader("rlptxrcpt.BIT_ACC", 1, length),
         new ColumnHeader("rlptxrcpt.BYTE_1", 1, length),
         new ColumnHeader("rlptxrcpt.BYTE_2", 1, length),
         new ColumnHeader("rlptxrcpt.BYTE_3", 1, length),
         new ColumnHeader("rlptxrcpt.BYTE_4", 1, length),
-        new ColumnHeader("rlptxrcpt.COUNTER", 8, length),
+        new ColumnHeader("rlptxrcpt.COUNTER", 4, length),
         new ColumnHeader("rlptxrcpt.DEPTH_1", 1, length),
         new ColumnHeader("rlptxrcpt.DONE", 1, length),
-        new ColumnHeader("rlptxrcpt.INDEX", 4, length),
-        new ColumnHeader("rlptxrcpt.INDEX_LOCAL", 4, length),
-        new ColumnHeader("rlptxrcpt.INPUT_1", 32, length),
-        new ColumnHeader("rlptxrcpt.INPUT_2", 32, length),
-        new ColumnHeader("rlptxrcpt.INPUT_3", 32, length),
-        new ColumnHeader("rlptxrcpt.INPUT_4", 32, length),
+        new ColumnHeader("rlptxrcpt.INDEX", 3, length),
+        new ColumnHeader("rlptxrcpt.INDEX_LOCAL", 2, length),
+        new ColumnHeader("rlptxrcpt.INPUT_1", 16, length),
+        new ColumnHeader("rlptxrcpt.INPUT_2", 16, length),
+        new ColumnHeader("rlptxrcpt.INPUT_3", 16, length),
+        new ColumnHeader("rlptxrcpt.INPUT_4", 16, length),
         new ColumnHeader("rlptxrcpt.IS_DATA", 1, length),
         new ColumnHeader("rlptxrcpt.IS_PREFIX", 1, length),
         new ColumnHeader("rlptxrcpt.IS_TOPIC", 1, length),
         new ColumnHeader("rlptxrcpt.LC_CORRECTION", 1, length),
-        new ColumnHeader("rlptxrcpt.LIMB", 32, length),
+        new ColumnHeader("rlptxrcpt.LIMB", 16, length),
         new ColumnHeader("rlptxrcpt.LIMB_CONSTRUCTED", 1, length),
-        new ColumnHeader("rlptxrcpt.LOCAL_SIZE", 8, length),
-        new ColumnHeader("rlptxrcpt.LOG_ENTRY_SIZE", 8, length),
-        new ColumnHeader("rlptxrcpt.nBYTES", 2, length),
-        new ColumnHeader("rlptxrcpt.nSTEP", 8, length),
+        new ColumnHeader("rlptxrcpt.LOCAL_SIZE", 4, length),
+        new ColumnHeader("rlptxrcpt.LOG_ENTRY_SIZE", 4, length),
+        new ColumnHeader("rlptxrcpt.nBYTES", 1, length),
+        new ColumnHeader("rlptxrcpt.nSTEP", 4, length),
         new ColumnHeader("rlptxrcpt.PHASE_1", 1, length),
         new ColumnHeader("rlptxrcpt.PHASE_2", 1, length),
         new ColumnHeader("rlptxrcpt.PHASE_3", 1, length),
         new ColumnHeader("rlptxrcpt.PHASE_4", 1, length),
         new ColumnHeader("rlptxrcpt.PHASE_5", 1, length),
         new ColumnHeader("rlptxrcpt.PHASE_END", 1, length),
-        new ColumnHeader("rlptxrcpt.PHASE_ID", 4, length),
-        new ColumnHeader("rlptxrcpt.PHASE_SIZE", 8, length),
-        new ColumnHeader("rlptxrcpt.POWER", 32, length),
-        new ColumnHeader("rlptxrcpt.TXRCPT_SIZE", 8, length));
+        new ColumnHeader("rlptxrcpt.PHASE_ID", 2, length),
+        new ColumnHeader("rlptxrcpt.PHASE_SIZE", 4, length),
+        new ColumnHeader("rlptxrcpt.POWER", 16, length),
+        new ColumnHeader("rlptxrcpt.TXRCPT_SIZE", 4, length));
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -194,7 +195,12 @@ public class Trace {
       filled.set(0);
     }
 
-    absLogNum.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("absLogNum has invalid value (" + b + ")"); }
+    absLogNum.put((byte) (b >> 24));
+    absLogNum.put((byte) (b >> 16));
+    absLogNum.put((byte) (b >> 8));
+    absLogNum.put((byte) b);
+
 
     return this;
   }
@@ -206,7 +212,12 @@ public class Trace {
       filled.set(1);
     }
 
-    absLogNumMax.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("absLogNumMax has invalid value (" + b + ")"); }
+    absLogNumMax.put((byte) (b >> 24));
+    absLogNumMax.put((byte) (b >> 16));
+    absLogNumMax.put((byte) (b >> 8));
+    absLogNumMax.put((byte) b);
+
 
     return this;
   }
@@ -218,7 +229,12 @@ public class Trace {
       filled.set(2);
     }
 
-    absTxNum.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("absTxNum has invalid value (" + b + ")"); }
+    absTxNum.put((byte) (b >> 24));
+    absTxNum.put((byte) (b >> 16));
+    absTxNum.put((byte) (b >> 8));
+    absTxNum.put((byte) b);
+
 
     return this;
   }
@@ -230,7 +246,12 @@ public class Trace {
       filled.set(3);
     }
 
-    absTxNumMax.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("absTxNumMax has invalid value (" + b + ")"); }
+    absTxNumMax.put((byte) (b >> 24));
+    absTxNumMax.put((byte) (b >> 16));
+    absTxNumMax.put((byte) (b >> 8));
+    absTxNumMax.put((byte) b);
+
 
     return this;
   }
@@ -242,11 +263,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc1.put((byte) 0);
-    }
-    acc1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
 
     return this;
   }
@@ -258,11 +282,14 @@ public class Trace {
       filled.set(5);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc2.put((byte) 0);
-    }
-    acc2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
 
     return this;
   }
@@ -274,11 +301,14 @@ public class Trace {
       filled.set(6);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc3.put((byte) 0);
-    }
-    acc3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc3.put(bs.get(j)); }
 
     return this;
   }
@@ -290,23 +320,28 @@ public class Trace {
       filled.set(7);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc4.put((byte) 0);
-    }
-    acc4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc4.put(bs.get(j)); }
 
     return this;
   }
 
-  public Trace accSize(final short b) {
+  public Trace accSize(final long b) {
     if (filled.get(8)) {
       throw new IllegalStateException("rlptxrcpt.ACC_SIZE already set");
     } else {
       filled.set(8);
     }
 
-    accSize.putShort(b);
+    if(b >= 32L) { throw new IllegalArgumentException("accSize has invalid value (" + b + ")"); }
+    accSize.put((byte) b);
+
 
     return this;
   }
@@ -390,7 +425,12 @@ public class Trace {
       filled.set(15);
     }
 
-    counter.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("counter has invalid value (" + b + ")"); }
+    counter.put((byte) (b >> 24));
+    counter.put((byte) (b >> 16));
+    counter.put((byte) (b >> 8));
+    counter.put((byte) b);
+
 
     return this;
   }
@@ -419,26 +459,33 @@ public class Trace {
     return this;
   }
 
-  public Trace index(final int b) {
+  public Trace index(final long b) {
     if (filled.get(18)) {
       throw new IllegalStateException("rlptxrcpt.INDEX already set");
     } else {
       filled.set(18);
     }
 
-    index.putInt(b);
+    if(b >= 16777216L) { throw new IllegalArgumentException("index has invalid value (" + b + ")"); }
+    index.put((byte) (b >> 16));
+    index.put((byte) (b >> 8));
+    index.put((byte) b);
+
 
     return this;
   }
 
-  public Trace indexLocal(final int b) {
+  public Trace indexLocal(final long b) {
     if (filled.get(19)) {
       throw new IllegalStateException("rlptxrcpt.INDEX_LOCAL already set");
     } else {
       filled.set(19);
     }
 
-    indexLocal.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("indexLocal has invalid value (" + b + ")"); }
+    indexLocal.put((byte) (b >> 8));
+    indexLocal.put((byte) b);
+
 
     return this;
   }
@@ -450,11 +497,14 @@ public class Trace {
       filled.set(20);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      input1.put((byte) 0);
-    }
-    input1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("input1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { input1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { input1.put(bs.get(j)); }
 
     return this;
   }
@@ -466,11 +516,14 @@ public class Trace {
       filled.set(21);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      input2.put((byte) 0);
-    }
-    input2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("input2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { input2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { input2.put(bs.get(j)); }
 
     return this;
   }
@@ -482,11 +535,14 @@ public class Trace {
       filled.set(22);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      input3.put((byte) 0);
-    }
-    input3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("input3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { input3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { input3.put(bs.get(j)); }
 
     return this;
   }
@@ -498,11 +554,14 @@ public class Trace {
       filled.set(23);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      input4.put((byte) 0);
-    }
-    input4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("input4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { input4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { input4.put(bs.get(j)); }
 
     return this;
   }
@@ -562,11 +621,14 @@ public class Trace {
       filled.set(28);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      limb.put((byte) 0);
-    }
-    limb.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
 
     return this;
   }
@@ -590,7 +652,12 @@ public class Trace {
       filled.set(30);
     }
 
-    localSize.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("localSize has invalid value (" + b + ")"); }
+    localSize.put((byte) (b >> 24));
+    localSize.put((byte) (b >> 16));
+    localSize.put((byte) (b >> 8));
+    localSize.put((byte) b);
+
 
     return this;
   }
@@ -602,19 +669,26 @@ public class Trace {
       filled.set(31);
     }
 
-    logEntrySize.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("logEntrySize has invalid value (" + b + ")"); }
+    logEntrySize.put((byte) (b >> 24));
+    logEntrySize.put((byte) (b >> 16));
+    logEntrySize.put((byte) (b >> 8));
+    logEntrySize.put((byte) b);
+
 
     return this;
   }
 
-  public Trace nBytes(final short b) {
+  public Trace nBytes(final long b) {
     if (filled.get(42)) {
       throw new IllegalStateException("rlptxrcpt.nBYTES already set");
     } else {
       filled.set(42);
     }
 
-    nBytes.putShort(b);
+    if(b >= 32L) { throw new IllegalArgumentException("nBytes has invalid value (" + b + ")"); }
+    nBytes.put((byte) b);
+
 
     return this;
   }
@@ -626,7 +700,12 @@ public class Trace {
       filled.set(43);
     }
 
-    nStep.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("nStep has invalid value (" + b + ")"); }
+    nStep.put((byte) (b >> 24));
+    nStep.put((byte) (b >> 16));
+    nStep.put((byte) (b >> 8));
+    nStep.put((byte) b);
+
 
     return this;
   }
@@ -703,14 +782,17 @@ public class Trace {
     return this;
   }
 
-  public Trace phaseId(final int b) {
+  public Trace phaseId(final long b) {
     if (filled.get(38)) {
       throw new IllegalStateException("rlptxrcpt.PHASE_ID already set");
     } else {
       filled.set(38);
     }
 
-    phaseId.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("phaseId has invalid value (" + b + ")"); }
+    phaseId.put((byte) (b >> 8));
+    phaseId.put((byte) b);
+
 
     return this;
   }
@@ -722,7 +804,12 @@ public class Trace {
       filled.set(39);
     }
 
-    phaseSize.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("phaseSize has invalid value (" + b + ")"); }
+    phaseSize.put((byte) (b >> 24));
+    phaseSize.put((byte) (b >> 16));
+    phaseSize.put((byte) (b >> 8));
+    phaseSize.put((byte) b);
+
 
     return this;
   }
@@ -734,11 +821,14 @@ public class Trace {
       filled.set(40);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      power.put((byte) 0);
-    }
-    power.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("power has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { power.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { power.put(bs.get(j)); }
 
     return this;
   }
@@ -750,7 +840,12 @@ public class Trace {
       filled.set(41);
     }
 
-    txrcptSize.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("txrcptSize has invalid value (" + b + ")"); }
+    txrcptSize.put((byte) (b >> 24));
+    txrcptSize.put((byte) (b >> 16));
+    txrcptSize.put((byte) (b >> 8));
+    txrcptSize.put((byte) b);
+
 
     return this;
   }
@@ -940,39 +1035,39 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      absLogNum.position(absLogNum.position() + 8);
+      absLogNum.position(absLogNum.position() + 4);
     }
 
     if (!filled.get(1)) {
-      absLogNumMax.position(absLogNumMax.position() + 8);
+      absLogNumMax.position(absLogNumMax.position() + 4);
     }
 
     if (!filled.get(2)) {
-      absTxNum.position(absTxNum.position() + 8);
+      absTxNum.position(absTxNum.position() + 4);
     }
 
     if (!filled.get(3)) {
-      absTxNumMax.position(absTxNumMax.position() + 8);
+      absTxNumMax.position(absTxNumMax.position() + 4);
     }
 
     if (!filled.get(4)) {
-      acc1.position(acc1.position() + 32);
+      acc1.position(acc1.position() + 16);
     }
 
     if (!filled.get(5)) {
-      acc2.position(acc2.position() + 32);
+      acc2.position(acc2.position() + 16);
     }
 
     if (!filled.get(6)) {
-      acc3.position(acc3.position() + 32);
+      acc3.position(acc3.position() + 16);
     }
 
     if (!filled.get(7)) {
-      acc4.position(acc4.position() + 32);
+      acc4.position(acc4.position() + 16);
     }
 
     if (!filled.get(8)) {
-      accSize.position(accSize.position() + 2);
+      accSize.position(accSize.position() + 1);
     }
 
     if (!filled.get(9)) {
@@ -1000,7 +1095,7 @@ public class Trace {
     }
 
     if (!filled.get(15)) {
-      counter.position(counter.position() + 8);
+      counter.position(counter.position() + 4);
     }
 
     if (!filled.get(16)) {
@@ -1012,27 +1107,27 @@ public class Trace {
     }
 
     if (!filled.get(18)) {
-      index.position(index.position() + 4);
+      index.position(index.position() + 3);
     }
 
     if (!filled.get(19)) {
-      indexLocal.position(indexLocal.position() + 4);
+      indexLocal.position(indexLocal.position() + 2);
     }
 
     if (!filled.get(20)) {
-      input1.position(input1.position() + 32);
+      input1.position(input1.position() + 16);
     }
 
     if (!filled.get(21)) {
-      input2.position(input2.position() + 32);
+      input2.position(input2.position() + 16);
     }
 
     if (!filled.get(22)) {
-      input3.position(input3.position() + 32);
+      input3.position(input3.position() + 16);
     }
 
     if (!filled.get(23)) {
-      input4.position(input4.position() + 32);
+      input4.position(input4.position() + 16);
     }
 
     if (!filled.get(24)) {
@@ -1052,7 +1147,7 @@ public class Trace {
     }
 
     if (!filled.get(28)) {
-      limb.position(limb.position() + 32);
+      limb.position(limb.position() + 16);
     }
 
     if (!filled.get(29)) {
@@ -1060,19 +1155,19 @@ public class Trace {
     }
 
     if (!filled.get(30)) {
-      localSize.position(localSize.position() + 8);
+      localSize.position(localSize.position() + 4);
     }
 
     if (!filled.get(31)) {
-      logEntrySize.position(logEntrySize.position() + 8);
+      logEntrySize.position(logEntrySize.position() + 4);
     }
 
     if (!filled.get(42)) {
-      nBytes.position(nBytes.position() + 2);
+      nBytes.position(nBytes.position() + 1);
     }
 
     if (!filled.get(43)) {
-      nStep.position(nStep.position() + 8);
+      nStep.position(nStep.position() + 4);
     }
 
     if (!filled.get(32)) {
@@ -1100,19 +1195,19 @@ public class Trace {
     }
 
     if (!filled.get(38)) {
-      phaseId.position(phaseId.position() + 4);
+      phaseId.position(phaseId.position() + 2);
     }
 
     if (!filled.get(39)) {
-      phaseSize.position(phaseSize.position() + 8);
+      phaseSize.position(phaseSize.position() + 4);
     }
 
     if (!filled.get(40)) {
-      power.position(power.position() + 32);
+      power.position(power.position() + 16);
     }
 
     if (!filled.get(41)) {
-      txrcptSize.position(txrcptSize.position() + 8);
+      txrcptSize.position(txrcptSize.position() + 4);
     }
 
     filled.clear();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rom/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rom/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.rom;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -60,29 +61,29 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("rom.ACC", 32, length),
-        new ColumnHeader("rom.CODE_FRAGMENT_INDEX", 8, length),
-        new ColumnHeader("rom.CODE_FRAGMENT_INDEX_INFTY", 8, length),
-        new ColumnHeader("rom.CODE_SIZE", 8, length),
+        new ColumnHeader("rom.ACC", 16, length),
+        new ColumnHeader("rom.CODE_FRAGMENT_INDEX", 4, length),
+        new ColumnHeader("rom.CODE_FRAGMENT_INDEX_INFTY", 4, length),
+        new ColumnHeader("rom.CODE_SIZE", 4, length),
         new ColumnHeader("rom.CODESIZE_REACHED", 1, length),
         new ColumnHeader("rom.COUNTER", 1, length),
         new ColumnHeader("rom.COUNTER_MAX", 1, length),
         new ColumnHeader("rom.COUNTER_PUSH", 1, length),
-        new ColumnHeader("rom.INDEX", 8, length),
+        new ColumnHeader("rom.INDEX", 4, length),
         new ColumnHeader("rom.IS_JUMPDEST", 1, length),
         new ColumnHeader("rom.IS_PUSH", 1, length),
         new ColumnHeader("rom.IS_PUSH_DATA", 1, length),
-        new ColumnHeader("rom.LIMB", 32, length),
+        new ColumnHeader("rom.LIMB", 16, length),
         new ColumnHeader("rom.nBYTES", 1, length),
         new ColumnHeader("rom.nBYTES_ACC", 1, length),
         new ColumnHeader("rom.OPCODE", 1, length),
         new ColumnHeader("rom.PADDED_BYTECODE_BYTE", 1, length),
-        new ColumnHeader("rom.PROGRAM_COUNTER", 8, length),
+        new ColumnHeader("rom.PROGRAM_COUNTER", 4, length),
         new ColumnHeader("rom.PUSH_FUNNEL_BIT", 1, length),
         new ColumnHeader("rom.PUSH_PARAMETER", 1, length),
-        new ColumnHeader("rom.PUSH_VALUE_ACC", 32, length),
-        new ColumnHeader("rom.PUSH_VALUE_HI", 32, length),
-        new ColumnHeader("rom.PUSH_VALUE_LO", 32, length));
+        new ColumnHeader("rom.PUSH_VALUE_ACC", 16, length),
+        new ColumnHeader("rom.PUSH_VALUE_HI", 16, length),
+        new ColumnHeader("rom.PUSH_VALUE_LO", 16, length));
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -126,11 +127,14 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc.put((byte) 0);
-    }
-    acc.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc.put(bs.get(j)); }
 
     return this;
   }
@@ -142,7 +146,12 @@ public class Trace {
       filled.set(2);
     }
 
-    codeFragmentIndex.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")"); }
+    codeFragmentIndex.put((byte) (b >> 24));
+    codeFragmentIndex.put((byte) (b >> 16));
+    codeFragmentIndex.put((byte) (b >> 8));
+    codeFragmentIndex.put((byte) b);
+
 
     return this;
   }
@@ -154,7 +163,12 @@ public class Trace {
       filled.set(3);
     }
 
-    codeFragmentIndexInfty.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("codeFragmentIndexInfty has invalid value (" + b + ")"); }
+    codeFragmentIndexInfty.put((byte) (b >> 24));
+    codeFragmentIndexInfty.put((byte) (b >> 16));
+    codeFragmentIndexInfty.put((byte) (b >> 8));
+    codeFragmentIndexInfty.put((byte) b);
+
 
     return this;
   }
@@ -166,7 +180,12 @@ public class Trace {
       filled.set(4);
     }
 
-    codeSize.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("codeSize has invalid value (" + b + ")"); }
+    codeSize.put((byte) (b >> 24));
+    codeSize.put((byte) (b >> 16));
+    codeSize.put((byte) (b >> 8));
+    codeSize.put((byte) b);
+
 
     return this;
   }
@@ -226,7 +245,12 @@ public class Trace {
       filled.set(8);
     }
 
-    index.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("index has invalid value (" + b + ")"); }
+    index.put((byte) (b >> 24));
+    index.put((byte) (b >> 16));
+    index.put((byte) (b >> 8));
+    index.put((byte) b);
+
 
     return this;
   }
@@ -274,11 +298,14 @@ public class Trace {
       filled.set(12);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      limb.put((byte) 0);
-    }
-    limb.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
 
     return this;
   }
@@ -338,7 +365,12 @@ public class Trace {
       filled.set(15);
     }
 
-    programCounter.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("programCounter has invalid value (" + b + ")"); }
+    programCounter.put((byte) (b >> 24));
+    programCounter.put((byte) (b >> 16));
+    programCounter.put((byte) (b >> 8));
+    programCounter.put((byte) b);
+
 
     return this;
   }
@@ -374,11 +406,14 @@ public class Trace {
       filled.set(18);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      pushValueAcc.put((byte) 0);
-    }
-    pushValueAcc.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("pushValueAcc has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { pushValueAcc.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { pushValueAcc.put(bs.get(j)); }
 
     return this;
   }
@@ -390,11 +425,14 @@ public class Trace {
       filled.set(19);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      pushValueHi.put((byte) 0);
-    }
-    pushValueHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("pushValueHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { pushValueHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { pushValueHi.put(bs.get(j)); }
 
     return this;
   }
@@ -406,11 +444,14 @@ public class Trace {
       filled.set(20);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      pushValueLo.put((byte) 0);
-    }
-    pushValueLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("pushValueLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { pushValueLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { pushValueLo.put(bs.get(j)); }
 
     return this;
   }
@@ -516,19 +557,19 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      acc.position(acc.position() + 32);
+      acc.position(acc.position() + 16);
     }
 
     if (!filled.get(2)) {
-      codeFragmentIndex.position(codeFragmentIndex.position() + 8);
+      codeFragmentIndex.position(codeFragmentIndex.position() + 4);
     }
 
     if (!filled.get(3)) {
-      codeFragmentIndexInfty.position(codeFragmentIndexInfty.position() + 8);
+      codeFragmentIndexInfty.position(codeFragmentIndexInfty.position() + 4);
     }
 
     if (!filled.get(4)) {
-      codeSize.position(codeSize.position() + 8);
+      codeSize.position(codeSize.position() + 4);
     }
 
     if (!filled.get(1)) {
@@ -548,7 +589,7 @@ public class Trace {
     }
 
     if (!filled.get(8)) {
-      index.position(index.position() + 8);
+      index.position(index.position() + 4);
     }
 
     if (!filled.get(9)) {
@@ -564,7 +605,7 @@ public class Trace {
     }
 
     if (!filled.get(12)) {
-      limb.position(limb.position() + 32);
+      limb.position(limb.position() + 16);
     }
 
     if (!filled.get(21)) {
@@ -584,7 +625,7 @@ public class Trace {
     }
 
     if (!filled.get(15)) {
-      programCounter.position(programCounter.position() + 8);
+      programCounter.position(programCounter.position() + 4);
     }
 
     if (!filled.get(16)) {
@@ -596,15 +637,15 @@ public class Trace {
     }
 
     if (!filled.get(18)) {
-      pushValueAcc.position(pushValueAcc.position() + 32);
+      pushValueAcc.position(pushValueAcc.position() + 16);
     }
 
     if (!filled.get(19)) {
-      pushValueHi.position(pushValueHi.position() + 32);
+      pushValueHi.position(pushValueHi.position() + 16);
     }
 
     if (!filled.get(20)) {
-      pushValueLo.position(pushValueLo.position() + 32);
+      pushValueLo.position(pushValueLo.position() + 16);
     }
 
     filled.clear();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rom/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rom/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.rom;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -130,11 +129,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc.put(bs.get(j));
+    }
 
     return this;
   }
@@ -146,12 +151,13 @@ public class Trace {
       filled.set(2);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")");
+    }
     codeFragmentIndex.put((byte) (b >> 24));
     codeFragmentIndex.put((byte) (b >> 16));
     codeFragmentIndex.put((byte) (b >> 8));
     codeFragmentIndex.put((byte) b);
-
 
     return this;
   }
@@ -163,12 +169,13 @@ public class Trace {
       filled.set(3);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("codeFragmentIndexInfty has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("codeFragmentIndexInfty has invalid value (" + b + ")");
+    }
     codeFragmentIndexInfty.put((byte) (b >> 24));
     codeFragmentIndexInfty.put((byte) (b >> 16));
     codeFragmentIndexInfty.put((byte) (b >> 8));
     codeFragmentIndexInfty.put((byte) b);
-
 
     return this;
   }
@@ -180,12 +187,13 @@ public class Trace {
       filled.set(4);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("codeSize has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("codeSize has invalid value (" + b + ")");
+    }
     codeSize.put((byte) (b >> 24));
     codeSize.put((byte) (b >> 16));
     codeSize.put((byte) (b >> 8));
     codeSize.put((byte) b);
-
 
     return this;
   }
@@ -245,12 +253,13 @@ public class Trace {
       filled.set(8);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("index has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("index has invalid value (" + b + ")");
+    }
     index.put((byte) (b >> 24));
     index.put((byte) (b >> 16));
     index.put((byte) (b >> 8));
     index.put((byte) b);
-
 
     return this;
   }
@@ -301,11 +310,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      limb.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      limb.put(bs.get(j));
+    }
 
     return this;
   }
@@ -365,12 +380,13 @@ public class Trace {
       filled.set(15);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("programCounter has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("programCounter has invalid value (" + b + ")");
+    }
     programCounter.put((byte) (b >> 24));
     programCounter.put((byte) (b >> 16));
     programCounter.put((byte) (b >> 8));
     programCounter.put((byte) b);
-
 
     return this;
   }
@@ -409,11 +425,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("pushValueAcc has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "pushValueAcc has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { pushValueAcc.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      pushValueAcc.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { pushValueAcc.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      pushValueAcc.put(bs.get(j));
+    }
 
     return this;
   }
@@ -428,11 +451,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("pushValueHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "pushValueHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { pushValueHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      pushValueHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { pushValueHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      pushValueHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -447,11 +477,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("pushValueLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "pushValueLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { pushValueLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      pushValueLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { pushValueLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      pushValueLo.put(bs.get(j));
+    }
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/Trace.java
@@ -15,13 +15,11 @@
 
 package net.consensys.linea.zktracer.module.romlex;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
 
 import net.consensys.linea.zktracer.ColumnHeader;
-import net.consensys.linea.zktracer.types.UnsignedByte;
 import org.apache.tuweni.bytes.Bytes;
 
 /**
@@ -91,12 +89,13 @@ public class Trace {
       filled.set(0);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("addressHi has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("addressHi has invalid value (" + b + ")");
+    }
     addressHi.put((byte) (b >> 24));
     addressHi.put((byte) (b >> 16));
     addressHi.put((byte) (b >> 8));
     addressHi.put((byte) b);
-
 
     return this;
   }
@@ -111,11 +110,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("addressLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "addressLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { addressLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      addressLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { addressLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      addressLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -127,12 +133,13 @@ public class Trace {
       filled.set(2);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")");
+    }
     codeFragmentIndex.put((byte) (b >> 24));
     codeFragmentIndex.put((byte) (b >> 16));
     codeFragmentIndex.put((byte) (b >> 8));
     codeFragmentIndex.put((byte) b);
-
 
     return this;
   }
@@ -144,12 +151,13 @@ public class Trace {
       filled.set(3);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("codeFragmentIndexInfty has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("codeFragmentIndexInfty has invalid value (" + b + ")");
+    }
     codeFragmentIndexInfty.put((byte) (b >> 24));
     codeFragmentIndexInfty.put((byte) (b >> 16));
     codeFragmentIndexInfty.put((byte) (b >> 8));
     codeFragmentIndexInfty.put((byte) b);
-
 
     return this;
   }
@@ -164,11 +172,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("codeHashHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "codeHashHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { codeHashHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      codeHashHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { codeHashHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      codeHashHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -183,11 +198,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("codeHashLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "codeHashLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { codeHashLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      codeHashLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { codeHashLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      codeHashLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -199,12 +221,13 @@ public class Trace {
       filled.set(6);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("codeSize has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("codeSize has invalid value (" + b + ")");
+    }
     codeSize.put((byte) (b >> 24));
     codeSize.put((byte) (b >> 16));
     codeSize.put((byte) (b >> 8));
     codeSize.put((byte) b);
-
 
     return this;
   }
@@ -228,10 +251,11 @@ public class Trace {
       filled.set(8);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("deploymentNumber has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("deploymentNumber has invalid value (" + b + ")");
+    }
     deploymentNumber.put((byte) (b >> 8));
     deploymentNumber.put((byte) b);
-
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/Trace.java
@@ -15,11 +15,13 @@
 
 package net.consensys.linea.zktracer.module.romlex;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
 
 import net.consensys.linea.zktracer.ColumnHeader;
+import net.consensys.linea.zktracer.types.UnsignedByte;
 import org.apache.tuweni.bytes.Bytes;
 
 /**
@@ -47,15 +49,15 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("romlex.ADDRESS_HI", 8, length),
-        new ColumnHeader("romlex.ADDRESS_LO", 32, length),
-        new ColumnHeader("romlex.CODE_FRAGMENT_INDEX", 8, length),
-        new ColumnHeader("romlex.CODE_FRAGMENT_INDEX_INFTY", 8, length),
-        new ColumnHeader("romlex.CODE_HASH_HI", 32, length),
-        new ColumnHeader("romlex.CODE_HASH_LO", 32, length),
-        new ColumnHeader("romlex.CODE_SIZE", 8, length),
+        new ColumnHeader("romlex.ADDRESS_HI", 4, length),
+        new ColumnHeader("romlex.ADDRESS_LO", 16, length),
+        new ColumnHeader("romlex.CODE_FRAGMENT_INDEX", 4, length),
+        new ColumnHeader("romlex.CODE_FRAGMENT_INDEX_INFTY", 4, length),
+        new ColumnHeader("romlex.CODE_HASH_HI", 16, length),
+        new ColumnHeader("romlex.CODE_HASH_LO", 16, length),
+        new ColumnHeader("romlex.CODE_SIZE", 4, length),
         new ColumnHeader("romlex.COMMIT_TO_STATE", 1, length),
-        new ColumnHeader("romlex.DEPLOYMENT_NUMBER", 4, length),
+        new ColumnHeader("romlex.DEPLOYMENT_NUMBER", 2, length),
         new ColumnHeader("romlex.DEPLOYMENT_STATUS", 1, length),
         new ColumnHeader("romlex.READ_FROM_STATE", 1, length));
   }
@@ -89,7 +91,12 @@ public class Trace {
       filled.set(0);
     }
 
-    addressHi.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("addressHi has invalid value (" + b + ")"); }
+    addressHi.put((byte) (b >> 24));
+    addressHi.put((byte) (b >> 16));
+    addressHi.put((byte) (b >> 8));
+    addressHi.put((byte) b);
+
 
     return this;
   }
@@ -101,11 +108,14 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      addressLo.put((byte) 0);
-    }
-    addressLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("addressLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { addressLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { addressLo.put(bs.get(j)); }
 
     return this;
   }
@@ -117,7 +127,12 @@ public class Trace {
       filled.set(2);
     }
 
-    codeFragmentIndex.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")"); }
+    codeFragmentIndex.put((byte) (b >> 24));
+    codeFragmentIndex.put((byte) (b >> 16));
+    codeFragmentIndex.put((byte) (b >> 8));
+    codeFragmentIndex.put((byte) b);
+
 
     return this;
   }
@@ -129,7 +144,12 @@ public class Trace {
       filled.set(3);
     }
 
-    codeFragmentIndexInfty.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("codeFragmentIndexInfty has invalid value (" + b + ")"); }
+    codeFragmentIndexInfty.put((byte) (b >> 24));
+    codeFragmentIndexInfty.put((byte) (b >> 16));
+    codeFragmentIndexInfty.put((byte) (b >> 8));
+    codeFragmentIndexInfty.put((byte) b);
+
 
     return this;
   }
@@ -141,11 +161,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      codeHashHi.put((byte) 0);
-    }
-    codeHashHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("codeHashHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { codeHashHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { codeHashHi.put(bs.get(j)); }
 
     return this;
   }
@@ -157,11 +180,14 @@ public class Trace {
       filled.set(5);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      codeHashLo.put((byte) 0);
-    }
-    codeHashLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("codeHashLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { codeHashLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { codeHashLo.put(bs.get(j)); }
 
     return this;
   }
@@ -173,7 +199,12 @@ public class Trace {
       filled.set(6);
     }
 
-    codeSize.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("codeSize has invalid value (" + b + ")"); }
+    codeSize.put((byte) (b >> 24));
+    codeSize.put((byte) (b >> 16));
+    codeSize.put((byte) (b >> 8));
+    codeSize.put((byte) b);
+
 
     return this;
   }
@@ -190,14 +221,17 @@ public class Trace {
     return this;
   }
 
-  public Trace deploymentNumber(final int b) {
+  public Trace deploymentNumber(final long b) {
     if (filled.get(8)) {
       throw new IllegalStateException("romlex.DEPLOYMENT_NUMBER already set");
     } else {
       filled.set(8);
     }
 
-    deploymentNumber.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("deploymentNumber has invalid value (" + b + ")"); }
+    deploymentNumber.put((byte) (b >> 8));
+    deploymentNumber.put((byte) b);
+
 
     return this;
   }
@@ -279,31 +313,31 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      addressHi.position(addressHi.position() + 8);
+      addressHi.position(addressHi.position() + 4);
     }
 
     if (!filled.get(1)) {
-      addressLo.position(addressLo.position() + 32);
+      addressLo.position(addressLo.position() + 16);
     }
 
     if (!filled.get(2)) {
-      codeFragmentIndex.position(codeFragmentIndex.position() + 8);
+      codeFragmentIndex.position(codeFragmentIndex.position() + 4);
     }
 
     if (!filled.get(3)) {
-      codeFragmentIndexInfty.position(codeFragmentIndexInfty.position() + 8);
+      codeFragmentIndexInfty.position(codeFragmentIndexInfty.position() + 4);
     }
 
     if (!filled.get(4)) {
-      codeHashHi.position(codeHashHi.position() + 32);
+      codeHashHi.position(codeHashHi.position() + 16);
     }
 
     if (!filled.get(5)) {
-      codeHashLo.position(codeHashLo.position() + 32);
+      codeHashLo.position(codeHashLo.position() + 16);
     }
 
     if (!filled.get(6)) {
-      codeSize.position(codeSize.position() + 8);
+      codeSize.position(codeSize.position() + 4);
     }
 
     if (!filled.get(7)) {
@@ -311,7 +345,7 @@ public class Trace {
     }
 
     if (!filled.get(8)) {
-      deploymentNumber.position(deploymentNumber.position() + 4);
+      deploymentNumber.position(deploymentNumber.position() + 2);
     }
 
     if (!filled.get(9)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shakiradata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shakiradata/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.shakiradata;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -56,24 +57,24 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("shakiradata.ID", 8, length),
-        new ColumnHeader("shakiradata.INDEX", 8, length),
-        new ColumnHeader("shakiradata.INDEX_MAX", 8, length),
+        new ColumnHeader("shakiradata.ID", 4, length),
+        new ColumnHeader("shakiradata.INDEX", 4, length),
+        new ColumnHeader("shakiradata.INDEX_MAX", 4, length),
         new ColumnHeader("shakiradata.IS_KECCAK_DATA", 1, length),
         new ColumnHeader("shakiradata.IS_KECCAK_RESULT", 1, length),
         new ColumnHeader("shakiradata.IS_RIPEMD_DATA", 1, length),
         new ColumnHeader("shakiradata.IS_RIPEMD_RESULT", 1, length),
         new ColumnHeader("shakiradata.IS_SHA2_DATA", 1, length),
         new ColumnHeader("shakiradata.IS_SHA2_RESULT", 1, length),
-        new ColumnHeader("shakiradata.LIMB", 32, length),
-        new ColumnHeader("shakiradata.nBYTES", 2, length),
-        new ColumnHeader("shakiradata.nBYTES_ACC", 8, length),
+        new ColumnHeader("shakiradata.LIMB", 16, length),
+        new ColumnHeader("shakiradata.nBYTES", 1, length),
+        new ColumnHeader("shakiradata.nBYTES_ACC", 4, length),
         new ColumnHeader("shakiradata.PHASE", 1, length),
-        new ColumnHeader("shakiradata.RIPSHA_STAMP", 8, length),
+        new ColumnHeader("shakiradata.RIPSHA_STAMP", 4, length),
         new ColumnHeader("shakiradata.SELECTOR_KECCAK_RES_HI", 1, length),
         new ColumnHeader("shakiradata.SELECTOR_RIPEMD_RES_HI", 1, length),
         new ColumnHeader("shakiradata.SELECTOR_SHA2_RES_HI", 1, length),
-        new ColumnHeader("shakiradata.TOTAL_SIZE", 8, length));
+        new ColumnHeader("shakiradata.TOTAL_SIZE", 4, length));
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -112,7 +113,12 @@ public class Trace {
       filled.set(0);
     }
 
-    id.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("id has invalid value (" + b + ")"); }
+    id.put((byte) (b >> 24));
+    id.put((byte) (b >> 16));
+    id.put((byte) (b >> 8));
+    id.put((byte) b);
+
 
     return this;
   }
@@ -124,7 +130,12 @@ public class Trace {
       filled.set(1);
     }
 
-    index.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("index has invalid value (" + b + ")"); }
+    index.put((byte) (b >> 24));
+    index.put((byte) (b >> 16));
+    index.put((byte) (b >> 8));
+    index.put((byte) b);
+
 
     return this;
   }
@@ -136,7 +147,12 @@ public class Trace {
       filled.set(2);
     }
 
-    indexMax.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("indexMax has invalid value (" + b + ")"); }
+    indexMax.put((byte) (b >> 24));
+    indexMax.put((byte) (b >> 16));
+    indexMax.put((byte) (b >> 8));
+    indexMax.put((byte) b);
+
 
     return this;
   }
@@ -220,23 +236,28 @@ public class Trace {
       filled.set(9);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      limb.put((byte) 0);
-    }
-    limb.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
 
     return this;
   }
 
-  public Trace nBytes(final short b) {
+  public Trace nBytes(final long b) {
     if (filled.get(16)) {
       throw new IllegalStateException("shakiradata.nBYTES already set");
     } else {
       filled.set(16);
     }
 
-    nBytes.putShort(b);
+    if(b >= 256L) { throw new IllegalArgumentException("nBytes has invalid value (" + b + ")"); }
+    nBytes.put((byte) b);
+
 
     return this;
   }
@@ -248,7 +269,12 @@ public class Trace {
       filled.set(17);
     }
 
-    nBytesAcc.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("nBytesAcc has invalid value (" + b + ")"); }
+    nBytesAcc.put((byte) (b >> 24));
+    nBytesAcc.put((byte) (b >> 16));
+    nBytesAcc.put((byte) (b >> 8));
+    nBytesAcc.put((byte) b);
+
 
     return this;
   }
@@ -272,7 +298,12 @@ public class Trace {
       filled.set(11);
     }
 
-    ripshaStamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("ripshaStamp has invalid value (" + b + ")"); }
+    ripshaStamp.put((byte) (b >> 24));
+    ripshaStamp.put((byte) (b >> 16));
+    ripshaStamp.put((byte) (b >> 8));
+    ripshaStamp.put((byte) b);
+
 
     return this;
   }
@@ -320,7 +351,12 @@ public class Trace {
       filled.set(15);
     }
 
-    totalSize.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("totalSize has invalid value (" + b + ")"); }
+    totalSize.put((byte) (b >> 24));
+    totalSize.put((byte) (b >> 16));
+    totalSize.put((byte) (b >> 8));
+    totalSize.put((byte) b);
+
 
     return this;
   }
@@ -406,15 +442,15 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      id.position(id.position() + 8);
+      id.position(id.position() + 4);
     }
 
     if (!filled.get(1)) {
-      index.position(index.position() + 8);
+      index.position(index.position() + 4);
     }
 
     if (!filled.get(2)) {
-      indexMax.position(indexMax.position() + 8);
+      indexMax.position(indexMax.position() + 4);
     }
 
     if (!filled.get(3)) {
@@ -442,15 +478,15 @@ public class Trace {
     }
 
     if (!filled.get(9)) {
-      limb.position(limb.position() + 32);
+      limb.position(limb.position() + 16);
     }
 
     if (!filled.get(16)) {
-      nBytes.position(nBytes.position() + 2);
+      nBytes.position(nBytes.position() + 1);
     }
 
     if (!filled.get(17)) {
-      nBytesAcc.position(nBytesAcc.position() + 8);
+      nBytesAcc.position(nBytesAcc.position() + 4);
     }
 
     if (!filled.get(10)) {
@@ -458,7 +494,7 @@ public class Trace {
     }
 
     if (!filled.get(11)) {
-      ripshaStamp.position(ripshaStamp.position() + 8);
+      ripshaStamp.position(ripshaStamp.position() + 4);
     }
 
     if (!filled.get(12)) {
@@ -474,7 +510,7 @@ public class Trace {
     }
 
     if (!filled.get(15)) {
-      totalSize.position(totalSize.position() + 8);
+      totalSize.position(totalSize.position() + 4);
     }
 
     filled.clear();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shakiradata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shakiradata/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.shakiradata;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -113,12 +112,13 @@ public class Trace {
       filled.set(0);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("id has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("id has invalid value (" + b + ")");
+    }
     id.put((byte) (b >> 24));
     id.put((byte) (b >> 16));
     id.put((byte) (b >> 8));
     id.put((byte) b);
-
 
     return this;
   }
@@ -130,12 +130,13 @@ public class Trace {
       filled.set(1);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("index has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("index has invalid value (" + b + ")");
+    }
     index.put((byte) (b >> 24));
     index.put((byte) (b >> 16));
     index.put((byte) (b >> 8));
     index.put((byte) b);
-
 
     return this;
   }
@@ -147,12 +148,13 @@ public class Trace {
       filled.set(2);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("indexMax has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("indexMax has invalid value (" + b + ")");
+    }
     indexMax.put((byte) (b >> 24));
     indexMax.put((byte) (b >> 16));
     indexMax.put((byte) (b >> 8));
     indexMax.put((byte) b);
-
 
     return this;
   }
@@ -239,11 +241,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("limb has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { limb.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      limb.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { limb.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      limb.put(bs.get(j));
+    }
 
     return this;
   }
@@ -255,9 +263,10 @@ public class Trace {
       filled.set(16);
     }
 
-    if(b >= 256L) { throw new IllegalArgumentException("nBytes has invalid value (" + b + ")"); }
+    if (b >= 256L) {
+      throw new IllegalArgumentException("nBytes has invalid value (" + b + ")");
+    }
     nBytes.put((byte) b);
-
 
     return this;
   }
@@ -269,12 +278,13 @@ public class Trace {
       filled.set(17);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("nBytesAcc has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("nBytesAcc has invalid value (" + b + ")");
+    }
     nBytesAcc.put((byte) (b >> 24));
     nBytesAcc.put((byte) (b >> 16));
     nBytesAcc.put((byte) (b >> 8));
     nBytesAcc.put((byte) b);
-
 
     return this;
   }
@@ -298,12 +308,13 @@ public class Trace {
       filled.set(11);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("ripshaStamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("ripshaStamp has invalid value (" + b + ")");
+    }
     ripshaStamp.put((byte) (b >> 24));
     ripshaStamp.put((byte) (b >> 16));
     ripshaStamp.put((byte) (b >> 8));
     ripshaStamp.put((byte) b);
-
 
     return this;
   }
@@ -351,12 +362,13 @@ public class Trace {
       filled.set(15);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("totalSize has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("totalSize has invalid value (" + b + ")");
+    }
     totalSize.put((byte) (b >> 24));
     totalSize.put((byte) (b >> 16));
     totalSize.put((byte) (b >> 8));
     totalSize.put((byte) b);
-
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.shf;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -214,11 +213,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc1.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -233,11 +238,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc2.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -252,11 +263,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc3.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -271,11 +288,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc4.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -290,11 +313,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc5 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc5 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc5.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc5.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc5.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc5.put(bs.get(j));
+    }
 
     return this;
   }
@@ -309,11 +338,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -328,11 +363,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -347,11 +388,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg2Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg2Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg2Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg2Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -366,11 +413,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -562,9 +615,10 @@ public class Trace {
       filled.set(24);
     }
 
-    if(b >= 256L) { throw new IllegalArgumentException("counter has invalid value (" + b + ")"); }
+    if (b >= 256L) {
+      throw new IllegalArgumentException("counter has invalid value (" + b + ")");
+    }
     counter.put((byte) b);
-
 
     return this;
   }
@@ -639,11 +693,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("low3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("low3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { low3.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      low3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { low3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      low3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -655,9 +715,10 @@ public class Trace {
       filled.set(31);
     }
 
-    if(b >= 256L) { throw new IllegalArgumentException("microShiftParameter has invalid value (" + b + ")"); }
+    if (b >= 256L) {
+      throw new IllegalArgumentException("microShiftParameter has invalid value (" + b + ")");
+    }
     microShiftParameter.put((byte) b);
-
 
     return this;
   }
@@ -708,11 +769,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("resHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { resHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      resHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -727,11 +794,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("resLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { resLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      resLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -770,11 +843,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb3Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("shb3Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { shb3Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      shb3Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { shb3Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      shb3Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -789,11 +868,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb3Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("shb3Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { shb3Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      shb3Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { shb3Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      shb3Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -808,11 +893,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb4Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("shb4Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { shb4Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      shb4Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { shb4Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      shb4Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -827,11 +918,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb4Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("shb4Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { shb4Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      shb4Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { shb4Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      shb4Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -846,11 +943,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb5Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("shb5Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { shb5Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      shb5Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { shb5Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      shb5Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -865,11 +968,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb5Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("shb5Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { shb5Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      shb5Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { shb5Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      shb5Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -884,11 +993,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb6Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("shb6Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { shb6Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      shb6Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { shb6Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      shb6Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -903,11 +1018,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb6Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("shb6Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { shb6Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      shb6Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { shb6Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      shb6Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -922,11 +1043,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb7Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("shb7Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { shb7Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      shb7Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { shb7Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      shb7Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -941,11 +1068,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb7Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("shb7Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { shb7Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      shb7Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { shb7Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      shb7Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -969,12 +1102,13 @@ public class Trace {
       filled.set(50);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("shiftStamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("shiftStamp has invalid value (" + b + ")");
+    }
     shiftStamp.put((byte) (b >> 24));
     shiftStamp.put((byte) (b >> 16));
     shiftStamp.put((byte) (b >> 8));
     shiftStamp.put((byte) b);
-
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.shf;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -88,15 +89,15 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("shf.ACC_1", 32, length),
-        new ColumnHeader("shf.ACC_2", 32, length),
-        new ColumnHeader("shf.ACC_3", 32, length),
-        new ColumnHeader("shf.ACC_4", 32, length),
-        new ColumnHeader("shf.ACC_5", 32, length),
-        new ColumnHeader("shf.ARG_1_HI", 32, length),
-        new ColumnHeader("shf.ARG_1_LO", 32, length),
-        new ColumnHeader("shf.ARG_2_HI", 32, length),
-        new ColumnHeader("shf.ARG_2_LO", 32, length),
+        new ColumnHeader("shf.ACC_1", 16, length),
+        new ColumnHeader("shf.ACC_2", 16, length),
+        new ColumnHeader("shf.ACC_3", 16, length),
+        new ColumnHeader("shf.ACC_4", 16, length),
+        new ColumnHeader("shf.ACC_5", 16, length),
+        new ColumnHeader("shf.ARG_1_HI", 16, length),
+        new ColumnHeader("shf.ARG_1_LO", 16, length),
+        new ColumnHeader("shf.ARG_2_HI", 16, length),
+        new ColumnHeader("shf.ARG_2_LO", 16, length),
         new ColumnHeader("shf.BIT_1", 1, length),
         new ColumnHeader("shf.BIT_2", 1, length),
         new ColumnHeader("shf.BIT_3", 1, length),
@@ -112,33 +113,33 @@ public class Trace {
         new ColumnHeader("shf.BYTE_3", 1, length),
         new ColumnHeader("shf.BYTE_4", 1, length),
         new ColumnHeader("shf.BYTE_5", 1, length),
-        new ColumnHeader("shf.COUNTER", 2, length),
+        new ColumnHeader("shf.COUNTER", 1, length),
         new ColumnHeader("shf.INST", 1, length),
         new ColumnHeader("shf.IOMF", 1, length),
         new ColumnHeader("shf.KNOWN", 1, length),
         new ColumnHeader("shf.LEFT_ALIGNED_SUFFIX_HIGH", 1, length),
         new ColumnHeader("shf.LEFT_ALIGNED_SUFFIX_LOW", 1, length),
-        new ColumnHeader("shf.LOW_3", 32, length),
-        new ColumnHeader("shf.MICRO_SHIFT_PARAMETER", 2, length),
+        new ColumnHeader("shf.LOW_3", 16, length),
+        new ColumnHeader("shf.MICRO_SHIFT_PARAMETER", 1, length),
         new ColumnHeader("shf.NEG", 1, length),
         new ColumnHeader("shf.ONE_LINE_INSTRUCTION", 1, length),
         new ColumnHeader("shf.ONES", 1, length),
-        new ColumnHeader("shf.RES_HI", 32, length),
-        new ColumnHeader("shf.RES_LO", 32, length),
+        new ColumnHeader("shf.RES_HI", 16, length),
+        new ColumnHeader("shf.RES_LO", 16, length),
         new ColumnHeader("shf.RIGHT_ALIGNED_PREFIX_HIGH", 1, length),
         new ColumnHeader("shf.RIGHT_ALIGNED_PREFIX_LOW", 1, length),
-        new ColumnHeader("shf.SHB_3_HI", 32, length),
-        new ColumnHeader("shf.SHB_3_LO", 32, length),
-        new ColumnHeader("shf.SHB_4_HI", 32, length),
-        new ColumnHeader("shf.SHB_4_LO", 32, length),
-        new ColumnHeader("shf.SHB_5_HI", 32, length),
-        new ColumnHeader("shf.SHB_5_LO", 32, length),
-        new ColumnHeader("shf.SHB_6_HI", 32, length),
-        new ColumnHeader("shf.SHB_6_LO", 32, length),
-        new ColumnHeader("shf.SHB_7_HI", 32, length),
-        new ColumnHeader("shf.SHB_7_LO", 32, length),
+        new ColumnHeader("shf.SHB_3_HI", 16, length),
+        new ColumnHeader("shf.SHB_3_LO", 16, length),
+        new ColumnHeader("shf.SHB_4_HI", 16, length),
+        new ColumnHeader("shf.SHB_4_LO", 16, length),
+        new ColumnHeader("shf.SHB_5_HI", 16, length),
+        new ColumnHeader("shf.SHB_5_LO", 16, length),
+        new ColumnHeader("shf.SHB_6_HI", 16, length),
+        new ColumnHeader("shf.SHB_6_LO", 16, length),
+        new ColumnHeader("shf.SHB_7_HI", 16, length),
+        new ColumnHeader("shf.SHB_7_LO", 16, length),
         new ColumnHeader("shf.SHIFT_DIRECTION", 1, length),
-        new ColumnHeader("shf.SHIFT_STAMP", 8, length));
+        new ColumnHeader("shf.SHIFT_STAMP", 4, length));
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -210,11 +211,14 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc1.put((byte) 0);
-    }
-    acc1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
 
     return this;
   }
@@ -226,11 +230,14 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc2.put((byte) 0);
-    }
-    acc2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
 
     return this;
   }
@@ -242,11 +249,14 @@ public class Trace {
       filled.set(2);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc3.put((byte) 0);
-    }
-    acc3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc3.put(bs.get(j)); }
 
     return this;
   }
@@ -258,11 +268,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc4.put((byte) 0);
-    }
-    acc4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc4.put(bs.get(j)); }
 
     return this;
   }
@@ -274,11 +287,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc5.put((byte) 0);
-    }
-    acc5.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc5 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc5.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc5.put(bs.get(j)); }
 
     return this;
   }
@@ -290,11 +306,14 @@ public class Trace {
       filled.set(5);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg1Hi.put((byte) 0);
-    }
-    arg1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -306,11 +325,14 @@ public class Trace {
       filled.set(6);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg1Lo.put((byte) 0);
-    }
-    arg1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -322,11 +344,14 @@ public class Trace {
       filled.set(7);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg2Hi.put((byte) 0);
-    }
-    arg2Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg2Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg2Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -338,11 +363,14 @@ public class Trace {
       filled.set(8);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg2Lo.put((byte) 0);
-    }
-    arg2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -527,14 +555,16 @@ public class Trace {
     return this;
   }
 
-  public Trace counter(final short b) {
+  public Trace counter(final long b) {
     if (filled.get(24)) {
       throw new IllegalStateException("shf.COUNTER already set");
     } else {
       filled.set(24);
     }
 
-    counter.putShort(b);
+    if(b >= 256L) { throw new IllegalArgumentException("counter has invalid value (" + b + ")"); }
+    counter.put((byte) b);
+
 
     return this;
   }
@@ -606,23 +636,28 @@ public class Trace {
       filled.set(30);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      low3.put((byte) 0);
-    }
-    low3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("low3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { low3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { low3.put(bs.get(j)); }
 
     return this;
   }
 
-  public Trace microShiftParameter(final short b) {
+  public Trace microShiftParameter(final long b) {
     if (filled.get(31)) {
       throw new IllegalStateException("shf.MICRO_SHIFT_PARAMETER already set");
     } else {
       filled.set(31);
     }
 
-    microShiftParameter.putShort(b);
+    if(b >= 256L) { throw new IllegalArgumentException("microShiftParameter has invalid value (" + b + ")"); }
+    microShiftParameter.put((byte) b);
+
 
     return this;
   }
@@ -670,11 +705,14 @@ public class Trace {
       filled.set(35);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resHi.put((byte) 0);
-    }
-    resHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { resHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resHi.put(bs.get(j)); }
 
     return this;
   }
@@ -686,11 +724,14 @@ public class Trace {
       filled.set(36);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resLo.put((byte) 0);
-    }
-    resLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { resLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resLo.put(bs.get(j)); }
 
     return this;
   }
@@ -726,11 +767,14 @@ public class Trace {
       filled.set(39);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      shb3Hi.put((byte) 0);
-    }
-    shb3Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb3Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { shb3Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { shb3Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -742,11 +786,14 @@ public class Trace {
       filled.set(40);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      shb3Lo.put((byte) 0);
-    }
-    shb3Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb3Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { shb3Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { shb3Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -758,11 +805,14 @@ public class Trace {
       filled.set(41);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      shb4Hi.put((byte) 0);
-    }
-    shb4Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb4Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { shb4Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { shb4Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -774,11 +824,14 @@ public class Trace {
       filled.set(42);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      shb4Lo.put((byte) 0);
-    }
-    shb4Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb4Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { shb4Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { shb4Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -790,11 +843,14 @@ public class Trace {
       filled.set(43);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      shb5Hi.put((byte) 0);
-    }
-    shb5Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb5Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { shb5Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { shb5Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -806,11 +862,14 @@ public class Trace {
       filled.set(44);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      shb5Lo.put((byte) 0);
-    }
-    shb5Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb5Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { shb5Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { shb5Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -822,11 +881,14 @@ public class Trace {
       filled.set(45);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      shb6Hi.put((byte) 0);
-    }
-    shb6Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb6Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { shb6Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { shb6Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -838,11 +900,14 @@ public class Trace {
       filled.set(46);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      shb6Lo.put((byte) 0);
-    }
-    shb6Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb6Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { shb6Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { shb6Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -854,11 +919,14 @@ public class Trace {
       filled.set(47);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      shb7Hi.put((byte) 0);
-    }
-    shb7Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb7Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { shb7Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { shb7Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -870,11 +938,14 @@ public class Trace {
       filled.set(48);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      shb7Lo.put((byte) 0);
-    }
-    shb7Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("shb7Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { shb7Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { shb7Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -898,7 +969,12 @@ public class Trace {
       filled.set(50);
     }
 
-    shiftStamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("shiftStamp has invalid value (" + b + ")"); }
+    shiftStamp.put((byte) (b >> 24));
+    shiftStamp.put((byte) (b >> 16));
+    shiftStamp.put((byte) (b >> 8));
+    shiftStamp.put((byte) b);
+
 
     return this;
   }
@@ -1116,39 +1192,39 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      acc1.position(acc1.position() + 32);
+      acc1.position(acc1.position() + 16);
     }
 
     if (!filled.get(1)) {
-      acc2.position(acc2.position() + 32);
+      acc2.position(acc2.position() + 16);
     }
 
     if (!filled.get(2)) {
-      acc3.position(acc3.position() + 32);
+      acc3.position(acc3.position() + 16);
     }
 
     if (!filled.get(3)) {
-      acc4.position(acc4.position() + 32);
+      acc4.position(acc4.position() + 16);
     }
 
     if (!filled.get(4)) {
-      acc5.position(acc5.position() + 32);
+      acc5.position(acc5.position() + 16);
     }
 
     if (!filled.get(5)) {
-      arg1Hi.position(arg1Hi.position() + 32);
+      arg1Hi.position(arg1Hi.position() + 16);
     }
 
     if (!filled.get(6)) {
-      arg1Lo.position(arg1Lo.position() + 32);
+      arg1Lo.position(arg1Lo.position() + 16);
     }
 
     if (!filled.get(7)) {
-      arg2Hi.position(arg2Hi.position() + 32);
+      arg2Hi.position(arg2Hi.position() + 16);
     }
 
     if (!filled.get(8)) {
-      arg2Lo.position(arg2Lo.position() + 32);
+      arg2Lo.position(arg2Lo.position() + 16);
     }
 
     if (!filled.get(10)) {
@@ -1212,7 +1288,7 @@ public class Trace {
     }
 
     if (!filled.get(24)) {
-      counter.position(counter.position() + 2);
+      counter.position(counter.position() + 1);
     }
 
     if (!filled.get(25)) {
@@ -1236,11 +1312,11 @@ public class Trace {
     }
 
     if (!filled.get(30)) {
-      low3.position(low3.position() + 32);
+      low3.position(low3.position() + 16);
     }
 
     if (!filled.get(31)) {
-      microShiftParameter.position(microShiftParameter.position() + 2);
+      microShiftParameter.position(microShiftParameter.position() + 1);
     }
 
     if (!filled.get(32)) {
@@ -1256,11 +1332,11 @@ public class Trace {
     }
 
     if (!filled.get(35)) {
-      resHi.position(resHi.position() + 32);
+      resHi.position(resHi.position() + 16);
     }
 
     if (!filled.get(36)) {
-      resLo.position(resLo.position() + 32);
+      resLo.position(resLo.position() + 16);
     }
 
     if (!filled.get(37)) {
@@ -1272,43 +1348,43 @@ public class Trace {
     }
 
     if (!filled.get(39)) {
-      shb3Hi.position(shb3Hi.position() + 32);
+      shb3Hi.position(shb3Hi.position() + 16);
     }
 
     if (!filled.get(40)) {
-      shb3Lo.position(shb3Lo.position() + 32);
+      shb3Lo.position(shb3Lo.position() + 16);
     }
 
     if (!filled.get(41)) {
-      shb4Hi.position(shb4Hi.position() + 32);
+      shb4Hi.position(shb4Hi.position() + 16);
     }
 
     if (!filled.get(42)) {
-      shb4Lo.position(shb4Lo.position() + 32);
+      shb4Lo.position(shb4Lo.position() + 16);
     }
 
     if (!filled.get(43)) {
-      shb5Hi.position(shb5Hi.position() + 32);
+      shb5Hi.position(shb5Hi.position() + 16);
     }
 
     if (!filled.get(44)) {
-      shb5Lo.position(shb5Lo.position() + 32);
+      shb5Lo.position(shb5Lo.position() + 16);
     }
 
     if (!filled.get(45)) {
-      shb6Hi.position(shb6Hi.position() + 32);
+      shb6Hi.position(shb6Hi.position() + 16);
     }
 
     if (!filled.get(46)) {
-      shb6Lo.position(shb6Lo.position() + 32);
+      shb6Lo.position(shb6Lo.position() + 16);
     }
 
     if (!filled.get(47)) {
-      shb7Hi.position(shb7Hi.position() + 32);
+      shb7Hi.position(shb7Hi.position() + 16);
     }
 
     if (!filled.get(48)) {
-      shb7Lo.position(shb7Lo.position() + 32);
+      shb7Lo.position(shb7Lo.position() + 16);
     }
 
     if (!filled.get(49)) {
@@ -1316,7 +1392,7 @@ public class Trace {
     }
 
     if (!filled.get(50)) {
-      shiftStamp.position(shiftStamp.position() + 8);
+      shiftStamp.position(shiftStamp.position() + 4);
     }
 
     filled.clear();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.stp;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -148,11 +147,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -167,11 +172,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -186,11 +197,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { arg2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      arg2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { arg2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      arg2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -253,11 +270,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("gasActual has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "gasActual has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { gasActual.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      gasActual.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gasActual.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gasActual.put(bs.get(j));
+    }
 
     return this;
   }
@@ -272,11 +296,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("gasHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("gasHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { gasHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      gasHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gasHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gasHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -291,11 +321,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("gasLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("gasLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { gasLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      gasLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gasLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gasLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -310,11 +346,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("gasMxp has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException("gasMxp has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { gasMxp.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      gasMxp.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gasMxp.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gasMxp.put(bs.get(j));
+    }
 
     return this;
   }
@@ -329,11 +371,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("gasOutOfPocket has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "gasOutOfPocket has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { gasOutOfPocket.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      gasOutOfPocket.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gasOutOfPocket.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gasOutOfPocket.put(bs.get(j));
+    }
 
     return this;
   }
@@ -348,11 +397,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("gasStipend has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "gasStipend has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { gasStipend.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      gasStipend.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gasStipend.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gasStipend.put(bs.get(j));
+    }
 
     return this;
   }
@@ -367,11 +423,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 32) { throw new IllegalArgumentException("gasUpfront has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 256) {
+      throw new IllegalArgumentException(
+          "gasUpfront has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<4; i++) { gasUpfront.put((byte) 0); }
+    for (int i = bs.size(); i < 32; i++) {
+      gasUpfront.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gasUpfront.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gasUpfront.put(bs.get(j));
+    }
 
     return this;
   }
@@ -494,11 +557,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("resLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { resLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      resLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { resLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      resLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -510,11 +579,12 @@ public class Trace {
       filled.set(24);
     }
 
-    if(b >= 16777216L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    if (b >= 16777216L) {
+      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+    }
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));
     stamp.put((byte) b);
-
 
     return this;
   }
@@ -529,11 +599,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("valHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { valHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      valHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { valHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      valHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -548,11 +624,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("valLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { valLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      valLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { valLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      valLo.put(bs.get(j));
+    }
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.stp;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -66,16 +67,16 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("stp.ARG_1_HI", 32, length),
-        new ColumnHeader("stp.ARG_1_LO", 32, length),
-        new ColumnHeader("stp.ARG_2_LO", 32, length),
+        new ColumnHeader("stp.ARG_1_HI", 16, length),
+        new ColumnHeader("stp.ARG_1_LO", 16, length),
+        new ColumnHeader("stp.ARG_2_LO", 16, length),
         new ColumnHeader("stp.CT", 1, length),
         new ColumnHeader("stp.CT_MAX", 1, length),
         new ColumnHeader("stp.EXISTS", 1, length),
         new ColumnHeader("stp.EXOGENOUS_MODULE_INSTRUCTION", 1, length),
         new ColumnHeader("stp.GAS_ACTUAL", 32, length),
-        new ColumnHeader("stp.GAS_HI", 32, length),
-        new ColumnHeader("stp.GAS_LO", 32, length),
+        new ColumnHeader("stp.GAS_HI", 16, length),
+        new ColumnHeader("stp.GAS_LO", 16, length),
         new ColumnHeader("stp.GAS_MXP", 32, length),
         new ColumnHeader("stp.GAS_OUT_OF_POCKET", 32, length),
         new ColumnHeader("stp.GAS_STIPEND", 32, length),
@@ -89,10 +90,10 @@ public class Trace {
         new ColumnHeader("stp.IS_STATICCALL", 1, length),
         new ColumnHeader("stp.MOD_FLAG", 1, length),
         new ColumnHeader("stp.OUT_OF_GAS_EXCEPTION", 1, length),
-        new ColumnHeader("stp.RES_LO", 32, length),
-        new ColumnHeader("stp.STAMP", 4, length),
-        new ColumnHeader("stp.VAL_HI", 32, length),
-        new ColumnHeader("stp.VAL_LO", 32, length),
+        new ColumnHeader("stp.RES_LO", 16, length),
+        new ColumnHeader("stp.STAMP", 3, length),
+        new ColumnHeader("stp.VAL_HI", 16, length),
+        new ColumnHeader("stp.VAL_LO", 16, length),
         new ColumnHeader("stp.WARM", 1, length),
         new ColumnHeader("stp.WCP_FLAG", 1, length));
   }
@@ -144,11 +145,14 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg1Hi.put((byte) 0);
-    }
-    arg1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -160,11 +164,14 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg1Lo.put((byte) 0);
-    }
-    arg1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -176,11 +183,14 @@ public class Trace {
       filled.set(2);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      arg2Lo.put((byte) 0);
-    }
-    arg2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { arg2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { arg2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -240,11 +250,14 @@ public class Trace {
       filled.set(7);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gasActual.put((byte) 0);
-    }
-    gasActual.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("gasActual has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { gasActual.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gasActual.put(bs.get(j)); }
 
     return this;
   }
@@ -256,11 +269,14 @@ public class Trace {
       filled.set(8);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gasHi.put((byte) 0);
-    }
-    gasHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("gasHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { gasHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gasHi.put(bs.get(j)); }
 
     return this;
   }
@@ -272,11 +288,14 @@ public class Trace {
       filled.set(9);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gasLo.put((byte) 0);
-    }
-    gasLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("gasLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { gasLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gasLo.put(bs.get(j)); }
 
     return this;
   }
@@ -288,11 +307,14 @@ public class Trace {
       filled.set(10);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gasMxp.put((byte) 0);
-    }
-    gasMxp.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("gasMxp has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { gasMxp.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gasMxp.put(bs.get(j)); }
 
     return this;
   }
@@ -304,11 +326,14 @@ public class Trace {
       filled.set(11);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gasOutOfPocket.put((byte) 0);
-    }
-    gasOutOfPocket.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("gasOutOfPocket has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { gasOutOfPocket.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gasOutOfPocket.put(bs.get(j)); }
 
     return this;
   }
@@ -320,11 +345,14 @@ public class Trace {
       filled.set(12);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gasStipend.put((byte) 0);
-    }
-    gasStipend.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("gasStipend has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { gasStipend.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gasStipend.put(bs.get(j)); }
 
     return this;
   }
@@ -336,11 +364,14 @@ public class Trace {
       filled.set(13);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gasUpfront.put((byte) 0);
-    }
-    gasUpfront.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 32) { throw new IllegalArgumentException("gasUpfront has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<4; i++) { gasUpfront.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gasUpfront.put(bs.get(j)); }
 
     return this;
   }
@@ -460,23 +491,30 @@ public class Trace {
       filled.set(23);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      resLo.put((byte) 0);
-    }
-    resLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("resLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { resLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { resLo.put(bs.get(j)); }
 
     return this;
   }
 
-  public Trace stamp(final int b) {
+  public Trace stamp(final long b) {
     if (filled.get(24)) {
       throw new IllegalStateException("stp.STAMP already set");
     } else {
       filled.set(24);
     }
 
-    stamp.putInt(b);
+    if(b >= 16777216L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    stamp.put((byte) (b >> 16));
+    stamp.put((byte) (b >> 8));
+    stamp.put((byte) b);
+
 
     return this;
   }
@@ -488,11 +526,14 @@ public class Trace {
       filled.set(25);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      valHi.put((byte) 0);
-    }
-    valHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { valHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { valHi.put(bs.get(j)); }
 
     return this;
   }
@@ -504,11 +545,14 @@ public class Trace {
       filled.set(26);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      valLo.put((byte) 0);
-    }
-    valLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("valLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { valLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { valLo.put(bs.get(j)); }
 
     return this;
   }
@@ -662,15 +706,15 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      arg1Hi.position(arg1Hi.position() + 32);
+      arg1Hi.position(arg1Hi.position() + 16);
     }
 
     if (!filled.get(1)) {
-      arg1Lo.position(arg1Lo.position() + 32);
+      arg1Lo.position(arg1Lo.position() + 16);
     }
 
     if (!filled.get(2)) {
-      arg2Lo.position(arg2Lo.position() + 32);
+      arg2Lo.position(arg2Lo.position() + 16);
     }
 
     if (!filled.get(3)) {
@@ -694,11 +738,11 @@ public class Trace {
     }
 
     if (!filled.get(8)) {
-      gasHi.position(gasHi.position() + 32);
+      gasHi.position(gasHi.position() + 16);
     }
 
     if (!filled.get(9)) {
-      gasLo.position(gasLo.position() + 32);
+      gasLo.position(gasLo.position() + 16);
     }
 
     if (!filled.get(10)) {
@@ -754,19 +798,19 @@ public class Trace {
     }
 
     if (!filled.get(23)) {
-      resLo.position(resLo.position() + 32);
+      resLo.position(resLo.position() + 16);
     }
 
     if (!filled.get(24)) {
-      stamp.position(stamp.position() + 4);
+      stamp.position(stamp.position() + 3);
     }
 
     if (!filled.get(25)) {
-      valHi.position(valHi.position() + 32);
+      valHi.position(valHi.position() + 16);
     }
 
     if (!filled.get(26)) {
-      valLo.position(valLo.position() + 32);
+      valLo.position(valLo.position() + 16);
     }
 
     if (!filled.get(27)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/trm/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/trm/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.trm;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -100,11 +99,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("accHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("accHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { accHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      accHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -119,11 +124,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("accLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("accLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { accLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      accLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { accLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      accLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -135,12 +146,13 @@ public class Trace {
       filled.set(2);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("accT has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("accT has invalid value (" + b + ")");
+    }
     accT.put((byte) (b >> 24));
     accT.put((byte) (b >> 16));
     accT.put((byte) (b >> 8));
     accT.put((byte) b);
-
 
     return this;
   }
@@ -227,11 +239,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("rawAddressHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "rawAddressHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { rawAddressHi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      rawAddressHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { rawAddressHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      rawAddressHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -246,11 +265,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("rawAddressLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "rawAddressLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { rawAddressLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      rawAddressLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { rawAddressLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      rawAddressLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -262,11 +288,12 @@ public class Trace {
       filled.set(11);
     }
 
-    if(b >= 16777216L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    if (b >= 16777216L) {
+      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+    }
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));
     stamp.put((byte) b);
-
 
     return this;
   }
@@ -278,12 +305,13 @@ public class Trace {
       filled.set(12);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("trmAddressHi has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("trmAddressHi has invalid value (" + b + ")");
+    }
     trmAddressHi.put((byte) (b >> 24));
     trmAddressHi.put((byte) (b >> 16));
     trmAddressHi.put((byte) (b >> 8));
     trmAddressHi.put((byte) b);
-
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/trm/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/trm/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.trm;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -50,19 +51,19 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("trm.ACC_HI", 32, length),
-        new ColumnHeader("trm.ACC_LO", 32, length),
-        new ColumnHeader("trm.ACC_T", 8, length),
+        new ColumnHeader("trm.ACC_HI", 16, length),
+        new ColumnHeader("trm.ACC_LO", 16, length),
+        new ColumnHeader("trm.ACC_T", 4, length),
         new ColumnHeader("trm.BYTE_HI", 1, length),
         new ColumnHeader("trm.BYTE_LO", 1, length),
         new ColumnHeader("trm.CT", 1, length),
         new ColumnHeader("trm.IS_PRECOMPILE", 1, length),
         new ColumnHeader("trm.ONE", 1, length),
         new ColumnHeader("trm.PBIT", 1, length),
-        new ColumnHeader("trm.RAW_ADDRESS_HI", 32, length),
-        new ColumnHeader("trm.RAW_ADDRESS_LO", 32, length),
-        new ColumnHeader("trm.STAMP", 4, length),
-        new ColumnHeader("trm.TRM_ADDRESS_HI", 8, length));
+        new ColumnHeader("trm.RAW_ADDRESS_HI", 16, length),
+        new ColumnHeader("trm.RAW_ADDRESS_LO", 16, length),
+        new ColumnHeader("trm.STAMP", 3, length),
+        new ColumnHeader("trm.TRM_ADDRESS_HI", 4, length));
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -96,11 +97,14 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accHi.put((byte) 0);
-    }
-    accHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("accHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { accHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accHi.put(bs.get(j)); }
 
     return this;
   }
@@ -112,11 +116,14 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      accLo.put((byte) 0);
-    }
-    accLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("accLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { accLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { accLo.put(bs.get(j)); }
 
     return this;
   }
@@ -128,7 +135,12 @@ public class Trace {
       filled.set(2);
     }
 
-    accT.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("accT has invalid value (" + b + ")"); }
+    accT.put((byte) (b >> 24));
+    accT.put((byte) (b >> 16));
+    accT.put((byte) (b >> 8));
+    accT.put((byte) b);
+
 
     return this;
   }
@@ -212,11 +224,14 @@ public class Trace {
       filled.set(9);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      rawAddressHi.put((byte) 0);
-    }
-    rawAddressHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("rawAddressHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { rawAddressHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { rawAddressHi.put(bs.get(j)); }
 
     return this;
   }
@@ -228,23 +243,30 @@ public class Trace {
       filled.set(10);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      rawAddressLo.put((byte) 0);
-    }
-    rawAddressLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("rawAddressLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { rawAddressLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { rawAddressLo.put(bs.get(j)); }
 
     return this;
   }
 
-  public Trace stamp(final int b) {
+  public Trace stamp(final long b) {
     if (filled.get(11)) {
       throw new IllegalStateException("trm.STAMP already set");
     } else {
       filled.set(11);
     }
 
-    stamp.putInt(b);
+    if(b >= 16777216L) { throw new IllegalArgumentException("stamp has invalid value (" + b + ")"); }
+    stamp.put((byte) (b >> 16));
+    stamp.put((byte) (b >> 8));
+    stamp.put((byte) b);
+
 
     return this;
   }
@@ -256,7 +278,12 @@ public class Trace {
       filled.set(12);
     }
 
-    trmAddressHi.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("trmAddressHi has invalid value (" + b + ")"); }
+    trmAddressHi.put((byte) (b >> 24));
+    trmAddressHi.put((byte) (b >> 16));
+    trmAddressHi.put((byte) (b >> 8));
+    trmAddressHi.put((byte) b);
+
 
     return this;
   }
@@ -322,15 +349,15 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      accHi.position(accHi.position() + 32);
+      accHi.position(accHi.position() + 16);
     }
 
     if (!filled.get(1)) {
-      accLo.position(accLo.position() + 32);
+      accLo.position(accLo.position() + 16);
     }
 
     if (!filled.get(2)) {
-      accT.position(accT.position() + 8);
+      accT.position(accT.position() + 4);
     }
 
     if (!filled.get(3)) {
@@ -358,19 +385,19 @@ public class Trace {
     }
 
     if (!filled.get(9)) {
-      rawAddressHi.position(rawAddressHi.position() + 32);
+      rawAddressHi.position(rawAddressHi.position() + 16);
     }
 
     if (!filled.get(10)) {
-      rawAddressLo.position(rawAddressLo.position() + 32);
+      rawAddressLo.position(rawAddressLo.position() + 16);
     }
 
     if (!filled.get(11)) {
-      stamp.position(stamp.position() + 4);
+      stamp.position(stamp.position() + 3);
     }
 
     if (!filled.get(12)) {
-      trmAddressHi.position(trmAddressHi.position() + 8);
+      trmAddressHi.position(trmAddressHi.position() + 4);
     }
 
     filled.clear();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/Trace.java
@@ -31,24 +31,21 @@ import org.apache.tuweni.bytes.Bytes;
  * Please DO NOT ATTEMPT TO MODIFY this code directly.
  */
 public class Trace {
+  public static final int BLOCKHASH_MAX_HISTORY = 0x100;
   public static final int COMMON_RLP_TXN_PHASE_NUMBER_0 = 0x1;
   public static final int COMMON_RLP_TXN_PHASE_NUMBER_1 = 0x8;
   public static final int COMMON_RLP_TXN_PHASE_NUMBER_2 = 0x3;
   public static final int COMMON_RLP_TXN_PHASE_NUMBER_3 = 0x9;
   public static final int COMMON_RLP_TXN_PHASE_NUMBER_4 = 0xa;
   public static final int COMMON_RLP_TXN_PHASE_NUMBER_5 = 0x7;
+  public static final int CREATE2_SHIFT = 0xff;
   public static final int EIP_3541_MARKER = 0xef;
-  public static final BigInteger EMPTY_KECCAK_HI =
-      new BigInteger("16434357337474432580558001204043214908");
-  public static final BigInteger EMPTY_KECCAK_LO =
-      new BigInteger("19024806816994025362060938983270537799");
-  public static final int EMPTY_RIPEMD_HI = 0x9c1185a;
-  public static final BigInteger EMPTY_RIPEMD_LO =
-      new BigInteger("16442052386882578548602430796343695571");
-  public static final BigInteger EMPTY_SHA2_HI =
-      new BigInteger("18915786244935348617899154533661473682");
-  public static final BigInteger EMPTY_SHA2_LO =
-      new BigInteger("3296542996298665609207448061432114053");
+  public static final BigInteger EMPTY_KECCAK_HI = new BigInteger("262949717399590921288928019264691438528");
+  public static final BigInteger EMPTY_KECCAK_LO = new BigInteger("304396909071904405792975023732328604784");
+  public static final int EMPTY_RIPEMD_HI = 0x9c1185a5;
+  public static final BigInteger EMPTY_RIPEMD_LO = new BigInteger("263072838190121256777638892741499129137");
+  public static final BigInteger EMPTY_SHA2_HI = new BigInteger("302652579918965577886386472538583578916");
+  public static final BigInteger EMPTY_SHA2_LO = new BigInteger("52744687940778649747319168982913824853");
   public static final int EVM_INST_ADD = 0x1;
   public static final int EVM_INST_ADDMOD = 0x8;
   public static final int EVM_INST_ADDRESS = 0x30;
@@ -56,7 +53,6 @@ public class Trace {
   public static final int EVM_INST_BALANCE = 0x31;
   public static final int EVM_INST_BASEFEE = 0x48;
   public static final int EVM_INST_BLOCKHASH = 0x40;
-  public static final int EVM_INST_BLOCKHASH_MAX_HISTORY = 0x100;
   public static final int EVM_INST_BYTE = 0x1a;
   public static final int EVM_INST_CALL = 0xf1;
   public static final int EVM_INST_CALLCODE = 0xf2;
@@ -252,6 +248,7 @@ public class Trace {
   public static final int LLARGE = 0x10;
   public static final int LLARGEMO = 0xf;
   public static final int LLARGEPO = 0x11;
+  public static final int MAX_CODE_SIZE = 0x6000;
   public static final int MAX_REFUND_QUOTIENT = 0x5;
   public static final int MISC_WEIGHT_EXP = 0x1;
   public static final int MISC_WEIGHT_MMU = 0x2;
@@ -427,52 +424,52 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("txndata.ABS_TX_NUM", 4, length),
-        new ColumnHeader("txndata.ABS_TX_NUM_MAX", 4, length),
-        new ColumnHeader("txndata.ARG_ONE_LO", 32, length),
-        new ColumnHeader("txndata.ARG_TWO_LO", 32, length),
-        new ColumnHeader("txndata.BASEFEE", 32, length),
-        new ColumnHeader("txndata.BLOCK_GAS_LIMIT", 32, length),
-        new ColumnHeader("txndata.CALL_DATA_SIZE", 8, length),
-        new ColumnHeader("txndata.CODE_FRAGMENT_INDEX", 8, length),
-        new ColumnHeader("txndata.COINBASE_HI", 8, length),
-        new ColumnHeader("txndata.COINBASE_LO", 32, length),
+        new ColumnHeader("txndata.ABS_TX_NUM", 2, length),
+        new ColumnHeader("txndata.ABS_TX_NUM_MAX", 2, length),
+        new ColumnHeader("txndata.ARG_ONE_LO", 16, length),
+        new ColumnHeader("txndata.ARG_TWO_LO", 16, length),
+        new ColumnHeader("txndata.BASEFEE", 16, length),
+        new ColumnHeader("txndata.BLOCK_GAS_LIMIT", 8, length),
+        new ColumnHeader("txndata.CALL_DATA_SIZE", 4, length),
+        new ColumnHeader("txndata.CODE_FRAGMENT_INDEX", 4, length),
+        new ColumnHeader("txndata.COINBASE_HI", 4, length),
+        new ColumnHeader("txndata.COINBASE_LO", 16, length),
         new ColumnHeader("txndata.COPY_TXCD", 1, length),
         new ColumnHeader("txndata.CT", 1, length),
         new ColumnHeader("txndata.EUC_FLAG", 1, length),
-        new ColumnHeader("txndata.FROM_HI", 8, length),
-        new ColumnHeader("txndata.FROM_LO", 32, length),
-        new ColumnHeader("txndata.GAS_CUMULATIVE", 32, length),
-        new ColumnHeader("txndata.GAS_INITIALLY_AVAILABLE", 32, length),
-        new ColumnHeader("txndata.GAS_LEFTOVER", 32, length),
-        new ColumnHeader("txndata.GAS_LIMIT", 32, length),
-        new ColumnHeader("txndata.GAS_PRICE", 32, length),
-        new ColumnHeader("txndata.INIT_CODE_SIZE", 8, length),
-        new ColumnHeader("txndata.INITIAL_BALANCE", 32, length),
+        new ColumnHeader("txndata.FROM_HI", 4, length),
+        new ColumnHeader("txndata.FROM_LO", 16, length),
+        new ColumnHeader("txndata.GAS_CUMULATIVE", 16, length),
+        new ColumnHeader("txndata.GAS_INITIALLY_AVAILABLE", 16, length),
+        new ColumnHeader("txndata.GAS_LEFTOVER", 16, length),
+        new ColumnHeader("txndata.GAS_LIMIT", 8, length),
+        new ColumnHeader("txndata.GAS_PRICE", 8, length),
+        new ColumnHeader("txndata.INIT_CODE_SIZE", 4, length),
+        new ColumnHeader("txndata.INITIAL_BALANCE", 16, length),
         new ColumnHeader("txndata.INST", 1, length),
         new ColumnHeader("txndata.IS_DEP", 1, length),
         new ColumnHeader("txndata.IS_LAST_TX_OF_BLOCK", 1, length),
-        new ColumnHeader("txndata.NONCE", 32, length),
-        new ColumnHeader("txndata.OUTGOING_HI", 32, length),
-        new ColumnHeader("txndata.OUTGOING_LO", 32, length),
-        new ColumnHeader("txndata.OUTGOING_RLP_TXNRCPT", 32, length),
+        new ColumnHeader("txndata.NONCE", 8, length),
+        new ColumnHeader("txndata.OUTGOING_HI", 8, length),
+        new ColumnHeader("txndata.OUTGOING_LO", 16, length),
+        new ColumnHeader("txndata.OUTGOING_RLP_TXNRCPT", 16, length),
         new ColumnHeader("txndata.PHASE_RLP_TXN", 1, length),
         new ColumnHeader("txndata.PHASE_RLP_TXNRCPT", 1, length),
-        new ColumnHeader("txndata.PRIORITY_FEE_PER_GAS", 32, length),
-        new ColumnHeader("txndata.REFUND_COUNTER", 32, length),
-        new ColumnHeader("txndata.REFUND_EFFECTIVE", 32, length),
-        new ColumnHeader("txndata.REL_BLOCK", 4, length),
-        new ColumnHeader("txndata.REL_TX_NUM", 4, length),
-        new ColumnHeader("txndata.REL_TX_NUM_MAX", 4, length),
+        new ColumnHeader("txndata.PRIORITY_FEE_PER_GAS", 16, length),
+        new ColumnHeader("txndata.REFUND_COUNTER", 16, length),
+        new ColumnHeader("txndata.REFUND_EFFECTIVE", 16, length),
+        new ColumnHeader("txndata.REL_BLOCK", 2, length),
+        new ColumnHeader("txndata.REL_TX_NUM", 2, length),
+        new ColumnHeader("txndata.REL_TX_NUM_MAX", 2, length),
         new ColumnHeader("txndata.REQUIRES_EVM_EXECUTION", 1, length),
-        new ColumnHeader("txndata.RES", 32, length),
+        new ColumnHeader("txndata.RES", 8, length),
         new ColumnHeader("txndata.STATUS_CODE", 1, length),
-        new ColumnHeader("txndata.TO_HI", 8, length),
-        new ColumnHeader("txndata.TO_LO", 32, length),
+        new ColumnHeader("txndata.TO_HI", 4, length),
+        new ColumnHeader("txndata.TO_LO", 16, length),
         new ColumnHeader("txndata.TYPE0", 1, length),
         new ColumnHeader("txndata.TYPE1", 1, length),
         new ColumnHeader("txndata.TYPE2", 1, length),
-        new ColumnHeader("txndata.VALUE", 32, length),
+        new ColumnHeader("txndata.VALUE", 16, length),
         new ColumnHeader("txndata.WCP_FLAG", 1, length));
   }
 
@@ -534,26 +531,32 @@ public class Trace {
     return this.currentLine;
   }
 
-  public Trace absTxNum(final int b) {
+  public Trace absTxNum(final long b) {
     if (filled.get(0)) {
       throw new IllegalStateException("txndata.ABS_TX_NUM already set");
     } else {
       filled.set(0);
     }
 
-    absTxNum.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("absTxNum has invalid value (" + b + ")"); }
+    absTxNum.put((byte) (b >> 8));
+    absTxNum.put((byte) b);
+
 
     return this;
   }
 
-  public Trace absTxNumMax(final int b) {
+  public Trace absTxNumMax(final long b) {
     if (filled.get(1)) {
       throw new IllegalStateException("txndata.ABS_TX_NUM_MAX already set");
     } else {
       filled.set(1);
     }
 
-    absTxNumMax.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("absTxNumMax has invalid value (" + b + ")"); }
+    absTxNumMax.put((byte) (b >> 8));
+    absTxNumMax.put((byte) b);
+
 
     return this;
   }
@@ -565,11 +568,14 @@ public class Trace {
       filled.set(2);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      argOneLo.put((byte) 0);
-    }
-    argOneLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argOneLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { argOneLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { argOneLo.put(bs.get(j)); }
 
     return this;
   }
@@ -581,11 +587,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      argTwoLo.put((byte) 0);
-    }
-    argTwoLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argTwoLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { argTwoLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { argTwoLo.put(bs.get(j)); }
 
     return this;
   }
@@ -597,11 +606,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      basefee.put((byte) 0);
-    }
-    basefee.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("basefee has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { basefee.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { basefee.put(bs.get(j)); }
 
     return this;
   }
@@ -613,11 +625,14 @@ public class Trace {
       filled.set(5);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      blockGasLimit.put((byte) 0);
-    }
-    blockGasLimit.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("blockGasLimit has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { blockGasLimit.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { blockGasLimit.put(bs.get(j)); }
 
     return this;
   }
@@ -629,7 +644,12 @@ public class Trace {
       filled.set(6);
     }
 
-    callDataSize.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("callDataSize has invalid value (" + b + ")"); }
+    callDataSize.put((byte) (b >> 24));
+    callDataSize.put((byte) (b >> 16));
+    callDataSize.put((byte) (b >> 8));
+    callDataSize.put((byte) b);
+
 
     return this;
   }
@@ -641,7 +661,12 @@ public class Trace {
       filled.set(7);
     }
 
-    codeFragmentIndex.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")"); }
+    codeFragmentIndex.put((byte) (b >> 24));
+    codeFragmentIndex.put((byte) (b >> 16));
+    codeFragmentIndex.put((byte) (b >> 8));
+    codeFragmentIndex.put((byte) b);
+
 
     return this;
   }
@@ -653,7 +678,12 @@ public class Trace {
       filled.set(8);
     }
 
-    coinbaseHi.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("coinbaseHi has invalid value (" + b + ")"); }
+    coinbaseHi.put((byte) (b >> 24));
+    coinbaseHi.put((byte) (b >> 16));
+    coinbaseHi.put((byte) (b >> 8));
+    coinbaseHi.put((byte) b);
+
 
     return this;
   }
@@ -665,11 +695,14 @@ public class Trace {
       filled.set(9);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      coinbaseLo.put((byte) 0);
-    }
-    coinbaseLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("coinbaseLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { coinbaseLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { coinbaseLo.put(bs.get(j)); }
 
     return this;
   }
@@ -717,7 +750,12 @@ public class Trace {
       filled.set(13);
     }
 
-    fromHi.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("fromHi has invalid value (" + b + ")"); }
+    fromHi.put((byte) (b >> 24));
+    fromHi.put((byte) (b >> 16));
+    fromHi.put((byte) (b >> 8));
+    fromHi.put((byte) b);
+
 
     return this;
   }
@@ -729,11 +767,14 @@ public class Trace {
       filled.set(14);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      fromLo.put((byte) 0);
-    }
-    fromLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("fromLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { fromLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { fromLo.put(bs.get(j)); }
 
     return this;
   }
@@ -745,11 +786,14 @@ public class Trace {
       filled.set(15);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gasCumulative.put((byte) 0);
-    }
-    gasCumulative.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("gasCumulative has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { gasCumulative.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gasCumulative.put(bs.get(j)); }
 
     return this;
   }
@@ -761,11 +805,14 @@ public class Trace {
       filled.set(16);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gasInitiallyAvailable.put((byte) 0);
-    }
-    gasInitiallyAvailable.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("gasInitiallyAvailable has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { gasInitiallyAvailable.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gasInitiallyAvailable.put(bs.get(j)); }
 
     return this;
   }
@@ -777,11 +824,14 @@ public class Trace {
       filled.set(17);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gasLeftover.put((byte) 0);
-    }
-    gasLeftover.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("gasLeftover has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { gasLeftover.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gasLeftover.put(bs.get(j)); }
 
     return this;
   }
@@ -793,11 +843,14 @@ public class Trace {
       filled.set(18);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gasLimit.put((byte) 0);
-    }
-    gasLimit.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("gasLimit has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { gasLimit.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gasLimit.put(bs.get(j)); }
 
     return this;
   }
@@ -809,11 +862,14 @@ public class Trace {
       filled.set(19);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      gasPrice.put((byte) 0);
-    }
-    gasPrice.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("gasPrice has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { gasPrice.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { gasPrice.put(bs.get(j)); }
 
     return this;
   }
@@ -825,7 +881,12 @@ public class Trace {
       filled.set(21);
     }
 
-    initCodeSize.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("initCodeSize has invalid value (" + b + ")"); }
+    initCodeSize.put((byte) (b >> 24));
+    initCodeSize.put((byte) (b >> 16));
+    initCodeSize.put((byte) (b >> 8));
+    initCodeSize.put((byte) b);
+
 
     return this;
   }
@@ -837,11 +898,14 @@ public class Trace {
       filled.set(20);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      initialBalance.put((byte) 0);
-    }
-    initialBalance.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("initialBalance has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { initialBalance.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { initialBalance.put(bs.get(j)); }
 
     return this;
   }
@@ -889,11 +953,14 @@ public class Trace {
       filled.set(25);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      nonce.put((byte) 0);
-    }
-    nonce.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("nonce has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { nonce.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { nonce.put(bs.get(j)); }
 
     return this;
   }
@@ -905,11 +972,14 @@ public class Trace {
       filled.set(26);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      outgoingHi.put((byte) 0);
-    }
-    outgoingHi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("outgoingHi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { outgoingHi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { outgoingHi.put(bs.get(j)); }
 
     return this;
   }
@@ -921,11 +991,14 @@ public class Trace {
       filled.set(27);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      outgoingLo.put((byte) 0);
-    }
-    outgoingLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("outgoingLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { outgoingLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { outgoingLo.put(bs.get(j)); }
 
     return this;
   }
@@ -937,11 +1010,14 @@ public class Trace {
       filled.set(28);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      outgoingRlpTxnrcpt.put((byte) 0);
-    }
-    outgoingRlpTxnrcpt.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("outgoingRlpTxnrcpt has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { outgoingRlpTxnrcpt.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { outgoingRlpTxnrcpt.put(bs.get(j)); }
 
     return this;
   }
@@ -977,11 +1053,14 @@ public class Trace {
       filled.set(31);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      priorityFeePerGas.put((byte) 0);
-    }
-    priorityFeePerGas.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("priorityFeePerGas has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { priorityFeePerGas.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { priorityFeePerGas.put(bs.get(j)); }
 
     return this;
   }
@@ -993,11 +1072,14 @@ public class Trace {
       filled.set(32);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      refundCounter.put((byte) 0);
-    }
-    refundCounter.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("refundCounter has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { refundCounter.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { refundCounter.put(bs.get(j)); }
 
     return this;
   }
@@ -1009,47 +1091,59 @@ public class Trace {
       filled.set(33);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      refundEffective.put((byte) 0);
-    }
-    refundEffective.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("refundEffective has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { refundEffective.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { refundEffective.put(bs.get(j)); }
 
     return this;
   }
 
-  public Trace relBlock(final int b) {
+  public Trace relBlock(final long b) {
     if (filled.get(34)) {
       throw new IllegalStateException("txndata.REL_BLOCK already set");
     } else {
       filled.set(34);
     }
 
-    relBlock.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("relBlock has invalid value (" + b + ")"); }
+    relBlock.put((byte) (b >> 8));
+    relBlock.put((byte) b);
+
 
     return this;
   }
 
-  public Trace relTxNum(final int b) {
+  public Trace relTxNum(final long b) {
     if (filled.get(35)) {
       throw new IllegalStateException("txndata.REL_TX_NUM already set");
     } else {
       filled.set(35);
     }
 
-    relTxNum.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("relTxNum has invalid value (" + b + ")"); }
+    relTxNum.put((byte) (b >> 8));
+    relTxNum.put((byte) b);
+
 
     return this;
   }
 
-  public Trace relTxNumMax(final int b) {
+  public Trace relTxNumMax(final long b) {
     if (filled.get(36)) {
       throw new IllegalStateException("txndata.REL_TX_NUM_MAX already set");
     } else {
       filled.set(36);
     }
 
-    relTxNumMax.putInt(b);
+    if(b >= 65536L) { throw new IllegalArgumentException("relTxNumMax has invalid value (" + b + ")"); }
+    relTxNumMax.put((byte) (b >> 8));
+    relTxNumMax.put((byte) b);
+
 
     return this;
   }
@@ -1073,11 +1167,14 @@ public class Trace {
       filled.set(38);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      res.put((byte) 0);
-    }
-    res.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 64) { throw new IllegalArgumentException("res has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<8; i++) { res.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { res.put(bs.get(j)); }
 
     return this;
   }
@@ -1101,7 +1198,12 @@ public class Trace {
       filled.set(40);
     }
 
-    toHi.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("toHi has invalid value (" + b + ")"); }
+    toHi.put((byte) (b >> 24));
+    toHi.put((byte) (b >> 16));
+    toHi.put((byte) (b >> 8));
+    toHi.put((byte) b);
+
 
     return this;
   }
@@ -1113,11 +1215,14 @@ public class Trace {
       filled.set(41);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      toLo.put((byte) 0);
-    }
-    toLo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("toLo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { toLo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { toLo.put(bs.get(j)); }
 
     return this;
   }
@@ -1165,11 +1270,14 @@ public class Trace {
       filled.set(45);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      value.put((byte) 0);
-    }
-    value.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("value has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { value.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { value.put(bs.get(j)); }
 
     return this;
   }
@@ -1383,43 +1491,43 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      absTxNum.position(absTxNum.position() + 4);
+      absTxNum.position(absTxNum.position() + 2);
     }
 
     if (!filled.get(1)) {
-      absTxNumMax.position(absTxNumMax.position() + 4);
+      absTxNumMax.position(absTxNumMax.position() + 2);
     }
 
     if (!filled.get(2)) {
-      argOneLo.position(argOneLo.position() + 32);
+      argOneLo.position(argOneLo.position() + 16);
     }
 
     if (!filled.get(3)) {
-      argTwoLo.position(argTwoLo.position() + 32);
+      argTwoLo.position(argTwoLo.position() + 16);
     }
 
     if (!filled.get(4)) {
-      basefee.position(basefee.position() + 32);
+      basefee.position(basefee.position() + 16);
     }
 
     if (!filled.get(5)) {
-      blockGasLimit.position(blockGasLimit.position() + 32);
+      blockGasLimit.position(blockGasLimit.position() + 8);
     }
 
     if (!filled.get(6)) {
-      callDataSize.position(callDataSize.position() + 8);
+      callDataSize.position(callDataSize.position() + 4);
     }
 
     if (!filled.get(7)) {
-      codeFragmentIndex.position(codeFragmentIndex.position() + 8);
+      codeFragmentIndex.position(codeFragmentIndex.position() + 4);
     }
 
     if (!filled.get(8)) {
-      coinbaseHi.position(coinbaseHi.position() + 8);
+      coinbaseHi.position(coinbaseHi.position() + 4);
     }
 
     if (!filled.get(9)) {
-      coinbaseLo.position(coinbaseLo.position() + 32);
+      coinbaseLo.position(coinbaseLo.position() + 16);
     }
 
     if (!filled.get(10)) {
@@ -1435,39 +1543,39 @@ public class Trace {
     }
 
     if (!filled.get(13)) {
-      fromHi.position(fromHi.position() + 8);
+      fromHi.position(fromHi.position() + 4);
     }
 
     if (!filled.get(14)) {
-      fromLo.position(fromLo.position() + 32);
+      fromLo.position(fromLo.position() + 16);
     }
 
     if (!filled.get(15)) {
-      gasCumulative.position(gasCumulative.position() + 32);
+      gasCumulative.position(gasCumulative.position() + 16);
     }
 
     if (!filled.get(16)) {
-      gasInitiallyAvailable.position(gasInitiallyAvailable.position() + 32);
+      gasInitiallyAvailable.position(gasInitiallyAvailable.position() + 16);
     }
 
     if (!filled.get(17)) {
-      gasLeftover.position(gasLeftover.position() + 32);
+      gasLeftover.position(gasLeftover.position() + 16);
     }
 
     if (!filled.get(18)) {
-      gasLimit.position(gasLimit.position() + 32);
+      gasLimit.position(gasLimit.position() + 8);
     }
 
     if (!filled.get(19)) {
-      gasPrice.position(gasPrice.position() + 32);
+      gasPrice.position(gasPrice.position() + 8);
     }
 
     if (!filled.get(21)) {
-      initCodeSize.position(initCodeSize.position() + 8);
+      initCodeSize.position(initCodeSize.position() + 4);
     }
 
     if (!filled.get(20)) {
-      initialBalance.position(initialBalance.position() + 32);
+      initialBalance.position(initialBalance.position() + 16);
     }
 
     if (!filled.get(22)) {
@@ -1483,19 +1591,19 @@ public class Trace {
     }
 
     if (!filled.get(25)) {
-      nonce.position(nonce.position() + 32);
+      nonce.position(nonce.position() + 8);
     }
 
     if (!filled.get(26)) {
-      outgoingHi.position(outgoingHi.position() + 32);
+      outgoingHi.position(outgoingHi.position() + 8);
     }
 
     if (!filled.get(27)) {
-      outgoingLo.position(outgoingLo.position() + 32);
+      outgoingLo.position(outgoingLo.position() + 16);
     }
 
     if (!filled.get(28)) {
-      outgoingRlpTxnrcpt.position(outgoingRlpTxnrcpt.position() + 32);
+      outgoingRlpTxnrcpt.position(outgoingRlpTxnrcpt.position() + 16);
     }
 
     if (!filled.get(29)) {
@@ -1507,27 +1615,27 @@ public class Trace {
     }
 
     if (!filled.get(31)) {
-      priorityFeePerGas.position(priorityFeePerGas.position() + 32);
+      priorityFeePerGas.position(priorityFeePerGas.position() + 16);
     }
 
     if (!filled.get(32)) {
-      refundCounter.position(refundCounter.position() + 32);
+      refundCounter.position(refundCounter.position() + 16);
     }
 
     if (!filled.get(33)) {
-      refundEffective.position(refundEffective.position() + 32);
+      refundEffective.position(refundEffective.position() + 16);
     }
 
     if (!filled.get(34)) {
-      relBlock.position(relBlock.position() + 4);
+      relBlock.position(relBlock.position() + 2);
     }
 
     if (!filled.get(35)) {
-      relTxNum.position(relTxNum.position() + 4);
+      relTxNum.position(relTxNum.position() + 2);
     }
 
     if (!filled.get(36)) {
-      relTxNumMax.position(relTxNumMax.position() + 4);
+      relTxNumMax.position(relTxNumMax.position() + 2);
     }
 
     if (!filled.get(37)) {
@@ -1535,7 +1643,7 @@ public class Trace {
     }
 
     if (!filled.get(38)) {
-      res.position(res.position() + 32);
+      res.position(res.position() + 8);
     }
 
     if (!filled.get(39)) {
@@ -1543,11 +1651,11 @@ public class Trace {
     }
 
     if (!filled.get(40)) {
-      toHi.position(toHi.position() + 8);
+      toHi.position(toHi.position() + 4);
     }
 
     if (!filled.get(41)) {
-      toLo.position(toLo.position() + 32);
+      toLo.position(toLo.position() + 16);
     }
 
     if (!filled.get(42)) {
@@ -1563,7 +1671,7 @@ public class Trace {
     }
 
     if (!filled.get(45)) {
-      value.position(value.position() + 32);
+      value.position(value.position() + 16);
     }
 
     if (!filled.get(46)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/Trace.java
@@ -40,12 +40,17 @@ public class Trace {
   public static final int COMMON_RLP_TXN_PHASE_NUMBER_5 = 0x7;
   public static final int CREATE2_SHIFT = 0xff;
   public static final int EIP_3541_MARKER = 0xef;
-  public static final BigInteger EMPTY_KECCAK_HI = new BigInteger("262949717399590921288928019264691438528");
-  public static final BigInteger EMPTY_KECCAK_LO = new BigInteger("304396909071904405792975023732328604784");
+  public static final BigInteger EMPTY_KECCAK_HI =
+      new BigInteger("262949717399590921288928019264691438528");
+  public static final BigInteger EMPTY_KECCAK_LO =
+      new BigInteger("304396909071904405792975023732328604784");
   public static final int EMPTY_RIPEMD_HI = 0x9c1185a5;
-  public static final BigInteger EMPTY_RIPEMD_LO = new BigInteger("263072838190121256777638892741499129137");
-  public static final BigInteger EMPTY_SHA2_HI = new BigInteger("302652579918965577886386472538583578916");
-  public static final BigInteger EMPTY_SHA2_LO = new BigInteger("52744687940778649747319168982913824853");
+  public static final BigInteger EMPTY_RIPEMD_LO =
+      new BigInteger("263072838190121256777638892741499129137");
+  public static final BigInteger EMPTY_SHA2_HI =
+      new BigInteger("302652579918965577886386472538583578916");
+  public static final BigInteger EMPTY_SHA2_LO =
+      new BigInteger("52744687940778649747319168982913824853");
   public static final int EVM_INST_ADD = 0x1;
   public static final int EVM_INST_ADDMOD = 0x8;
   public static final int EVM_INST_ADDRESS = 0x30;
@@ -538,10 +543,11 @@ public class Trace {
       filled.set(0);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("absTxNum has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("absTxNum has invalid value (" + b + ")");
+    }
     absTxNum.put((byte) (b >> 8));
     absTxNum.put((byte) b);
-
 
     return this;
   }
@@ -553,10 +559,11 @@ public class Trace {
       filled.set(1);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("absTxNumMax has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("absTxNumMax has invalid value (" + b + ")");
+    }
     absTxNumMax.put((byte) (b >> 8));
     absTxNumMax.put((byte) b);
-
 
     return this;
   }
@@ -571,11 +578,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argOneLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("argOneLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { argOneLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      argOneLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { argOneLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      argOneLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -590,11 +603,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argTwoLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("argTwoLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { argTwoLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      argTwoLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { argTwoLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      argTwoLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -609,11 +628,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("basefee has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("basefee has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { basefee.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      basefee.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { basefee.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      basefee.put(bs.get(j));
+    }
 
     return this;
   }
@@ -628,11 +653,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("blockGasLimit has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "blockGasLimit has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { blockGasLimit.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      blockGasLimit.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { blockGasLimit.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      blockGasLimit.put(bs.get(j));
+    }
 
     return this;
   }
@@ -644,12 +676,13 @@ public class Trace {
       filled.set(6);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("callDataSize has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("callDataSize has invalid value (" + b + ")");
+    }
     callDataSize.put((byte) (b >> 24));
     callDataSize.put((byte) (b >> 16));
     callDataSize.put((byte) (b >> 8));
     callDataSize.put((byte) b);
-
 
     return this;
   }
@@ -661,12 +694,13 @@ public class Trace {
       filled.set(7);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")");
+    }
     codeFragmentIndex.put((byte) (b >> 24));
     codeFragmentIndex.put((byte) (b >> 16));
     codeFragmentIndex.put((byte) (b >> 8));
     codeFragmentIndex.put((byte) b);
-
 
     return this;
   }
@@ -678,12 +712,13 @@ public class Trace {
       filled.set(8);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("coinbaseHi has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("coinbaseHi has invalid value (" + b + ")");
+    }
     coinbaseHi.put((byte) (b >> 24));
     coinbaseHi.put((byte) (b >> 16));
     coinbaseHi.put((byte) (b >> 8));
     coinbaseHi.put((byte) b);
-
 
     return this;
   }
@@ -698,11 +733,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("coinbaseLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "coinbaseLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { coinbaseLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      coinbaseLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { coinbaseLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      coinbaseLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -750,12 +792,13 @@ public class Trace {
       filled.set(13);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("fromHi has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("fromHi has invalid value (" + b + ")");
+    }
     fromHi.put((byte) (b >> 24));
     fromHi.put((byte) (b >> 16));
     fromHi.put((byte) (b >> 8));
     fromHi.put((byte) b);
-
 
     return this;
   }
@@ -770,11 +813,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("fromLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("fromLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { fromLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      fromLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { fromLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      fromLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -789,11 +838,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("gasCumulative has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "gasCumulative has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { gasCumulative.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      gasCumulative.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gasCumulative.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gasCumulative.put(bs.get(j));
+    }
 
     return this;
   }
@@ -808,11 +864,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("gasInitiallyAvailable has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "gasInitiallyAvailable has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { gasInitiallyAvailable.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      gasInitiallyAvailable.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gasInitiallyAvailable.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gasInitiallyAvailable.put(bs.get(j));
+    }
 
     return this;
   }
@@ -827,11 +890,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("gasLeftover has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "gasLeftover has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { gasLeftover.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      gasLeftover.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gasLeftover.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gasLeftover.put(bs.get(j));
+    }
 
     return this;
   }
@@ -846,11 +916,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("gasLimit has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("gasLimit has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { gasLimit.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      gasLimit.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gasLimit.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gasLimit.put(bs.get(j));
+    }
 
     return this;
   }
@@ -865,11 +941,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("gasPrice has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("gasPrice has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { gasPrice.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      gasPrice.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { gasPrice.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      gasPrice.put(bs.get(j));
+    }
 
     return this;
   }
@@ -881,12 +963,13 @@ public class Trace {
       filled.set(21);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("initCodeSize has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("initCodeSize has invalid value (" + b + ")");
+    }
     initCodeSize.put((byte) (b >> 24));
     initCodeSize.put((byte) (b >> 16));
     initCodeSize.put((byte) (b >> 8));
     initCodeSize.put((byte) b);
-
 
     return this;
   }
@@ -901,11 +984,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("initialBalance has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "initialBalance has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { initialBalance.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      initialBalance.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { initialBalance.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      initialBalance.put(bs.get(j));
+    }
 
     return this;
   }
@@ -956,11 +1046,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("nonce has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("nonce has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { nonce.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      nonce.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { nonce.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      nonce.put(bs.get(j));
+    }
 
     return this;
   }
@@ -975,11 +1071,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("outgoingHi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException(
+          "outgoingHi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { outgoingHi.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      outgoingHi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { outgoingHi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      outgoingHi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -994,11 +1097,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("outgoingLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "outgoingLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { outgoingLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      outgoingLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { outgoingLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      outgoingLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1013,11 +1123,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("outgoingRlpTxnrcpt has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "outgoingRlpTxnrcpt has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { outgoingRlpTxnrcpt.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      outgoingRlpTxnrcpt.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { outgoingRlpTxnrcpt.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      outgoingRlpTxnrcpt.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1056,11 +1173,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("priorityFeePerGas has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "priorityFeePerGas has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { priorityFeePerGas.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      priorityFeePerGas.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { priorityFeePerGas.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      priorityFeePerGas.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1075,11 +1199,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("refundCounter has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "refundCounter has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { refundCounter.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      refundCounter.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { refundCounter.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      refundCounter.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1094,11 +1225,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("refundEffective has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "refundEffective has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { refundEffective.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      refundEffective.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { refundEffective.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      refundEffective.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1110,10 +1248,11 @@ public class Trace {
       filled.set(34);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("relBlock has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("relBlock has invalid value (" + b + ")");
+    }
     relBlock.put((byte) (b >> 8));
     relBlock.put((byte) b);
-
 
     return this;
   }
@@ -1125,10 +1264,11 @@ public class Trace {
       filled.set(35);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("relTxNum has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("relTxNum has invalid value (" + b + ")");
+    }
     relTxNum.put((byte) (b >> 8));
     relTxNum.put((byte) b);
-
 
     return this;
   }
@@ -1140,10 +1280,11 @@ public class Trace {
       filled.set(36);
     }
 
-    if(b >= 65536L) { throw new IllegalArgumentException("relTxNumMax has invalid value (" + b + ")"); }
+    if (b >= 65536L) {
+      throw new IllegalArgumentException("relTxNumMax has invalid value (" + b + ")");
+    }
     relTxNumMax.put((byte) (b >> 8));
     relTxNumMax.put((byte) b);
-
 
     return this;
   }
@@ -1170,11 +1311,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 64) { throw new IllegalArgumentException("res has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 64) {
+      throw new IllegalArgumentException("res has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<8; i++) { res.put((byte) 0); }
+    for (int i = bs.size(); i < 8; i++) {
+      res.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { res.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      res.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1198,12 +1345,13 @@ public class Trace {
       filled.set(40);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("toHi has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("toHi has invalid value (" + b + ")");
+    }
     toHi.put((byte) (b >> 24));
     toHi.put((byte) (b >> 16));
     toHi.put((byte) (b >> 8));
     toHi.put((byte) b);
-
 
     return this;
   }
@@ -1218,11 +1366,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("toLo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("toLo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { toLo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      toLo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { toLo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      toLo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -1273,11 +1427,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("value has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("value has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { value.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      value.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { value.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      value.put(bs.get(j));
+    }
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Trace.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.wcp;
 
-import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -175,11 +174,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc1.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc1.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc1.put(bs.get(j));
+    }
 
     return this;
   }
@@ -194,11 +199,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc2.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc2.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc2.put(bs.get(j));
+    }
 
     return this;
   }
@@ -213,11 +224,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc3 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc3 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc3.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc3.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc3.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc3.put(bs.get(j));
+    }
 
     return this;
   }
@@ -232,11 +249,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc4 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc4 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc4.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc4.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc4.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc4.put(bs.get(j));
+    }
 
     return this;
   }
@@ -251,11 +274,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc5 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc5 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc5.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc5.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc5.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc5.put(bs.get(j));
+    }
 
     return this;
   }
@@ -270,11 +299,17 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc6 has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException("acc6 has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { acc6.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      acc6.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { acc6.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      acc6.put(bs.get(j));
+    }
 
     return this;
   }
@@ -289,11 +324,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument1Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "argument1Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { argument1Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      argument1Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { argument1Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      argument1Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -308,11 +350,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument1Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "argument1Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { argument1Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      argument1Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { argument1Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      argument1Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -327,11 +376,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument2Hi has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "argument2Hi has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { argument2Hi.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      argument2Hi.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { argument2Hi.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      argument2Hi.put(bs.get(j));
+    }
 
     return this;
   }
@@ -346,11 +402,18 @@ public class Trace {
     // Trim array to size
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
-    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument2Lo has invalid width (" + bs.size() + ")"); }
+    if (bs.bitLength() > 128) {
+      throw new IllegalArgumentException(
+          "argument2Lo has invalid width (" + bs.bitLength() + "bits)");
+    }
     // Write padding (if necessary)
-    for(int i=bs.size(); i<16; i++) { argument2Lo.put((byte) 0); }
+    for (int i = bs.size(); i < 16; i++) {
+      argument2Lo.put((byte) 0);
+    }
     // Write bytes
-    for(int j=0; j<bs.size(); j++) { argument2Lo.put(bs.get(j)); }
+    for (int j = 0; j < bs.size(); j++) {
+      argument2Lo.put(bs.get(j));
+    }
 
     return this;
   }
@@ -686,12 +749,13 @@ public class Trace {
       filled.set(37);
     }
 
-    if(b >= 4294967296L) { throw new IllegalArgumentException("wordComparisonStamp has invalid value (" + b + ")"); }
+    if (b >= 4294967296L) {
+      throw new IllegalArgumentException("wordComparisonStamp has invalid value (" + b + ")");
+    }
     wordComparisonStamp.put((byte) (b >> 24));
     wordComparisonStamp.put((byte) (b >> 16));
     wordComparisonStamp.put((byte) (b >> 8));
     wordComparisonStamp.put((byte) b);
-
 
     return this;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Trace.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.wcp;
 
+import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
 import java.util.BitSet;
 import java.util.List;
@@ -75,16 +76,16 @@ public class Trace {
 
   static List<ColumnHeader> headers(int length) {
     return List.of(
-        new ColumnHeader("wcp.ACC_1", 32, length),
-        new ColumnHeader("wcp.ACC_2", 32, length),
-        new ColumnHeader("wcp.ACC_3", 32, length),
-        new ColumnHeader("wcp.ACC_4", 32, length),
-        new ColumnHeader("wcp.ACC_5", 32, length),
-        new ColumnHeader("wcp.ACC_6", 32, length),
-        new ColumnHeader("wcp.ARGUMENT_1_HI", 32, length),
-        new ColumnHeader("wcp.ARGUMENT_1_LO", 32, length),
-        new ColumnHeader("wcp.ARGUMENT_2_HI", 32, length),
-        new ColumnHeader("wcp.ARGUMENT_2_LO", 32, length),
+        new ColumnHeader("wcp.ACC_1", 16, length),
+        new ColumnHeader("wcp.ACC_2", 16, length),
+        new ColumnHeader("wcp.ACC_3", 16, length),
+        new ColumnHeader("wcp.ACC_4", 16, length),
+        new ColumnHeader("wcp.ACC_5", 16, length),
+        new ColumnHeader("wcp.ACC_6", 16, length),
+        new ColumnHeader("wcp.ARGUMENT_1_HI", 16, length),
+        new ColumnHeader("wcp.ARGUMENT_1_LO", 16, length),
+        new ColumnHeader("wcp.ARGUMENT_2_HI", 16, length),
+        new ColumnHeader("wcp.ARGUMENT_2_LO", 16, length),
         new ColumnHeader("wcp.BIT_1", 1, length),
         new ColumnHeader("wcp.BIT_2", 1, length),
         new ColumnHeader("wcp.BIT_3", 1, length),
@@ -112,7 +113,7 @@ public class Trace {
         new ColumnHeader("wcp.ONE_LINE_INSTRUCTION", 1, length),
         new ColumnHeader("wcp.RESULT", 1, length),
         new ColumnHeader("wcp.VARIABLE_LENGTH_INSTRUCTION", 1, length),
-        new ColumnHeader("wcp.WORD_COMPARISON_STAMP", 8, length));
+        new ColumnHeader("wcp.WORD_COMPARISON_STAMP", 4, length));
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -171,11 +172,14 @@ public class Trace {
       filled.set(0);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc1.put((byte) 0);
-    }
-    acc1.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc1 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc1.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc1.put(bs.get(j)); }
 
     return this;
   }
@@ -187,11 +191,14 @@ public class Trace {
       filled.set(1);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc2.put((byte) 0);
-    }
-    acc2.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc2 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc2.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc2.put(bs.get(j)); }
 
     return this;
   }
@@ -203,11 +210,14 @@ public class Trace {
       filled.set(2);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc3.put((byte) 0);
-    }
-    acc3.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc3 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc3.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc3.put(bs.get(j)); }
 
     return this;
   }
@@ -219,11 +229,14 @@ public class Trace {
       filled.set(3);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc4.put((byte) 0);
-    }
-    acc4.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc4 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc4.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc4.put(bs.get(j)); }
 
     return this;
   }
@@ -235,11 +248,14 @@ public class Trace {
       filled.set(4);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc5.put((byte) 0);
-    }
-    acc5.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc5 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc5.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc5.put(bs.get(j)); }
 
     return this;
   }
@@ -251,11 +267,14 @@ public class Trace {
       filled.set(5);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      acc6.put((byte) 0);
-    }
-    acc6.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("acc6 has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { acc6.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { acc6.put(bs.get(j)); }
 
     return this;
   }
@@ -267,11 +286,14 @@ public class Trace {
       filled.set(6);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      argument1Hi.put((byte) 0);
-    }
-    argument1Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument1Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { argument1Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { argument1Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -283,11 +305,14 @@ public class Trace {
       filled.set(7);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      argument1Lo.put((byte) 0);
-    }
-    argument1Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument1Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { argument1Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { argument1Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -299,11 +324,14 @@ public class Trace {
       filled.set(8);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      argument2Hi.put((byte) 0);
-    }
-    argument2Hi.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument2Hi has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { argument2Hi.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { argument2Hi.put(bs.get(j)); }
 
     return this;
   }
@@ -315,11 +343,14 @@ public class Trace {
       filled.set(9);
     }
 
-    final byte[] bs = b.toArrayUnsafe();
-    for (int i = bs.length; i < 32; i++) {
-      argument2Lo.put((byte) 0);
-    }
-    argument2Lo.put(b.toArrayUnsafe());
+    // Trim array to size
+    Bytes bs = b.trimLeadingZeros();
+    // Sanity check against expected width
+    if(bs.bitLength() > 128) { throw new IllegalArgumentException("argument2Lo has invalid width (" + bs.size() + ")"); }
+    // Write padding (if necessary)
+    for(int i=bs.size(); i<16; i++) { argument2Lo.put((byte) 0); }
+    // Write bytes
+    for(int j=0; j<bs.size(); j++) { argument2Lo.put(bs.get(j)); }
 
     return this;
   }
@@ -655,7 +686,12 @@ public class Trace {
       filled.set(37);
     }
 
-    wordComparisonStamp.putLong(b);
+    if(b >= 4294967296L) { throw new IllegalArgumentException("wordComparisonStamp has invalid value (" + b + ")"); }
+    wordComparisonStamp.put((byte) (b >> 24));
+    wordComparisonStamp.put((byte) (b >> 16));
+    wordComparisonStamp.put((byte) (b >> 8));
+    wordComparisonStamp.put((byte) b);
+
 
     return this;
   }
@@ -821,43 +857,43 @@ public class Trace {
 
   public Trace fillAndValidateRow() {
     if (!filled.get(0)) {
-      acc1.position(acc1.position() + 32);
+      acc1.position(acc1.position() + 16);
     }
 
     if (!filled.get(1)) {
-      acc2.position(acc2.position() + 32);
+      acc2.position(acc2.position() + 16);
     }
 
     if (!filled.get(2)) {
-      acc3.position(acc3.position() + 32);
+      acc3.position(acc3.position() + 16);
     }
 
     if (!filled.get(3)) {
-      acc4.position(acc4.position() + 32);
+      acc4.position(acc4.position() + 16);
     }
 
     if (!filled.get(4)) {
-      acc5.position(acc5.position() + 32);
+      acc5.position(acc5.position() + 16);
     }
 
     if (!filled.get(5)) {
-      acc6.position(acc6.position() + 32);
+      acc6.position(acc6.position() + 16);
     }
 
     if (!filled.get(6)) {
-      argument1Hi.position(argument1Hi.position() + 32);
+      argument1Hi.position(argument1Hi.position() + 16);
     }
 
     if (!filled.get(7)) {
-      argument1Lo.position(argument1Lo.position() + 32);
+      argument1Lo.position(argument1Lo.position() + 16);
     }
 
     if (!filled.get(8)) {
-      argument2Hi.position(argument2Hi.position() + 32);
+      argument2Hi.position(argument2Hi.position() + 16);
     }
 
     if (!filled.get(9)) {
-      argument2Lo.position(argument2Lo.position() + 32);
+      argument2Lo.position(argument2Lo.position() + 16);
     }
 
     if (!filled.get(11)) {
@@ -969,7 +1005,7 @@ public class Trace {
     }
 
     if (!filled.get(37)) {
-      wordComparisonStamp.position(wordComparisonStamp.position() + 8);
+      wordComparisonStamp.position(wordComparisonStamp.position() + 4);
     }
 
     filled.clear();


### PR DESCRIPTION
This regenerates `Trace.java` files for all modules except the `hub` using the latest version of `corset`.  This optimises the generated `lt` trace files by ensuring the right widths are used for each column.  For example, a column with type `i8` previously used `2` bytes per element in the `lt` file (but now uses only `1`).  Likewise, a column with type `i64` was previously using `32` bytes per element in the `lt` file (but now uses `8` as expected).  

This has led to some modest space savings in the generated traces.  For the `531` tests in this repository, the total size of all `lt` files generates goes from `6.7G` to `5.1G`.  Furthermore, it seems likely that the `hub` will offer further (perhaps significant) improvements given that it accounts for the largest number of columns.