### PR TITLE
Separate shared and private CLI options

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/plugins/AbstractLineaPrivateOptionsPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/AbstractLineaPrivateOptionsPlugin.java
@@ -21,12 +21,14 @@ import net.consensys.linea.plugins.config.LineaL1L2BridgeConfiguration;
 import net.consensys.linea.plugins.config.LineaTracerCliOptions;
 import net.consensys.linea.plugins.config.LineaTracerConfiguration;
 import org.hyperledger.besu.plugin.BesuContext;
-import org.hyperledger.besu.plugin.BesuPlugin;
-import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 
-/** In this class we put CLI options that are shared with other plugins not defined here */
+/**
+ * In this class we put CLI options that are private to plugins in this repo.
+ *
+ * <p>For the moment is just a placeholder since there are no private options
+ */
 @Slf4j
-public abstract class AbstractLineaSharedOptionsPlugin implements BesuPlugin {
+public abstract class AbstractLineaPrivateOptionsPlugin extends AbstractLineaSharedOptionsPlugin {
   private static final String CLI_OPTIONS_PREFIX = "linea";
   private static boolean cliOptionsRegistered = false;
   private static boolean configured = false;
@@ -37,43 +39,35 @@ public abstract class AbstractLineaSharedOptionsPlugin implements BesuPlugin {
 
   @Override
   public synchronized void register(final BesuContext context) {
+    super.register(context);
     if (!cliOptionsRegistered) {
-      final PicoCLIOptions cmdlineOptions =
-          context
-              .getService(PicoCLIOptions.class)
-              .orElseThrow(
-                  () ->
-                      new IllegalStateException(
-                          "Failed to obtain PicoCLI options from the BesuContext"));
-      tracerCliOptions = LineaTracerCliOptions.create();
-      l1L2BridgeCliOptions = LineaL1L2BridgeCliOptions.create();
-
-      cmdlineOptions.addPicoCLIOptions(CLI_OPTIONS_PREFIX, tracerCliOptions);
-      cmdlineOptions.addPicoCLIOptions(CLI_OPTIONS_PREFIX, l1L2BridgeCliOptions);
+      //      final PicoCLIOptions cmdlineOptions =
+      //          context
+      //              .getService(PicoCLIOptions.class)
+      //              .orElseThrow(
+      //                  () ->
+      //                      new IllegalStateException(
+      //                          "Failed to obtain PicoCLI options from the BesuContext"));
       cliOptionsRegistered = true;
     }
   }
 
   @Override
   public void beforeExternalServices() {
+    super.beforeExternalServices();
     if (!configured) {
-      tracerConfiguration = tracerCliOptions.toDomainObject();
-      l1L2BridgeConfiguration = l1L2BridgeCliOptions.toDomainObject();
       configured = true;
     }
-
-    log.debug("Configured plugin {} with tracer configuration: {}", getName(), tracerConfiguration);
-    log.debug(
-        "Configured plugin {} with L1 L2 bridge configuration: {}",
-        getName(),
-        l1L2BridgeCliOptions);
   }
 
   @Override
-  public void start() {}
+  public void start() {
+    super.start();
+  }
 
   @Override
   public void stop() {
+    super.stop();
     cliOptionsRegistered = false;
     configured = false;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/AbstractLineaRequiredPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/AbstractLineaRequiredPlugin.java
@@ -20,7 +20,7 @@ import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
 
 @Slf4j
-public abstract class AbstractLineaRequiredPlugin extends AbstractLineaSharedOptionsPlugin {
+public abstract class AbstractLineaRequiredPlugin extends AbstractLineaPrivateOptionsPlugin {
 
   /**
    * Linea plugins extending this class will halt startup of Besu in case of exception during

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/counters/CountersEndpointServicePlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/counters/CountersEndpointServicePlugin.java
@@ -16,7 +16,7 @@
 package net.consensys.linea.plugins.rpc.counters;
 
 import com.google.auto.service.AutoService;
-import net.consensys.linea.plugins.AbstractLineaSharedOptionsPlugin;
+import net.consensys.linea.plugins.AbstractLineaPrivateOptionsPlugin;
 import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.services.RpcEndpointService;
@@ -29,7 +29,7 @@ import org.hyperledger.besu.plugin.services.RpcEndpointService;
  * returns trace counters based on the provided request parameters. See {@link GenerateCountersV2}
  */
 @AutoService(BesuPlugin.class)
-public class CountersEndpointServicePlugin extends AbstractLineaSharedOptionsPlugin {
+public class CountersEndpointServicePlugin extends AbstractLineaPrivateOptionsPlugin {
   private BesuContext besuContext;
   private RpcEndpointService rpcEndpointService;
 

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointServicePlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointServicePlugin.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 
 import com.google.auto.service.AutoService;
 import lombok.extern.slf4j.Slf4j;
-import net.consensys.linea.plugins.AbstractLineaSharedOptionsPlugin;
+import net.consensys.linea.plugins.AbstractLineaPrivateOptionsPlugin;
 import net.consensys.linea.plugins.config.LineaTracerCliOptions;
 import net.consensys.linea.plugins.exception.TraceOutputException;
 import org.hyperledger.besu.plugin.BesuContext;
@@ -38,7 +38,7 @@ import org.hyperledger.besu.plugin.services.RpcEndpointService;
  */
 @AutoService(BesuPlugin.class)
 @Slf4j
-public class TracesEndpointServicePlugin extends AbstractLineaSharedOptionsPlugin {
+public class TracesEndpointServicePlugin extends AbstractLineaPrivateOptionsPlugin {
   private BesuContext besuContext;
   private RpcEndpointService rpcEndpointService;
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ReplayTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ReplayTests.java
@@ -80,10 +80,10 @@ public class ReplayTests {
     replay("2492975-2492977.json.gz");
   }
 
-    @Test
-    void leoFailingRange() {
-        replay("5389571-5389577.json.gz");
-    }
+  @Test
+  void leoFailingRange() {
+    replay("5389571-5389577.json.gz");
+  }
 
   @Test
   void failingMmuModexp() {


### PR DESCRIPTION
`AbstractLineaSharedOptionsPlugin` is a super class that only has options that are shared with sequencer plugins, while `AbstractLineaPrivateOptionsPlugin`, that extends the former, contains options that are private to plugins in this repo, this way `linea-sequencer` can remove its own version of `AbstractLineaSharedOptionsPlugin` and implement its private option in a separate ``AbstractLineaPrivateOptionsPlugin` .

Fixes #855 