### PR TITLE
fix: make --plugin-linea-conflated-trace-generation-traces-output-path option required to avoid faulty registration of the trace generation RPC endpoint

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaTracerCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaTracerCliOptions.java
@@ -33,6 +33,7 @@ public class LineaTracerCliOptions {
   private String moduleLimitFilePath = DEFAULT_MODULE_LIMIT_FILE_PATH;
 
   @CommandLine.Option(
+      required = true,
       names = {CONFLATED_TRACE_GENERATION_TRACES_OUTPUT_PATH},
       hidden = true,
       paramLabel = "<PATH>",

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ReplayTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ReplayTests.java
@@ -80,10 +80,10 @@ public class ReplayTests {
     replay("2492975-2492977.json.gz");
   }
 
-    @Test
-    void leoFailingRange() {
-        replay("5389571-5389577.json.gz");
-    }
+  @Test
+  void leoFailingRange() {
+    replay("5389571-5389577.json.gz");
+  }
 
   @Test
   void failingMmuModexp() {


### PR DESCRIPTION
…h option required to avoid faulty registration of the trace generation RPC endpoint