### PR TITLE
feat: update Linea-Besu to 24.7-develop-c0029e6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 releaseVersion=0.3.0-rc1
-besuVersion=24.7-develop-f812936
+besuVersion=24.7-develop-c0029e6
 besuArtifactGroup=io.consensys.linea-besu
 distributionIdentifier=linea-arithmetization
 distributionBaseUrl=https://artifacts.consensys.net/public/linea-besu/raw/names/linea-besu.tar.gz/versions/

--- a/reference-tests/src/test/java/net/consensys/linea/GeneralStateReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/GeneralStateReferenceTestTools.java
@@ -139,7 +139,7 @@ public class GeneralStateReferenceTestTools {
   public static void executeTest(final GeneralStateTestCaseEipSpec spec) {
     final BlockHeader blockHeader = spec.getBlockHeader();
     final ReferenceTestWorldState initialWorldState = spec.getInitialWorldState();
-    final Transaction transaction = spec.getTransaction();
+    final Transaction transaction = spec.getTransaction(0);
     final BlockBody blockBody = new BlockBody(List.of(transaction), new ArrayList<>());
 
     // Sometimes the tests ask us assemble an invalid transaction.  If we have


### PR DESCRIPTION
@gauravahuja could you please double check that the update to [GeneralStateReferenceTestTools.java](https://github.com/Consensys/linea-tracer/pull/905/files#diff-349fdaa64d7e5cef65e1ba5dad726643f90d0699b897b47378dea5499ea66bad) is correct?

@powerslider after this is merged, please publish a new release

fixes https://github.com/Consensys/linea-tracer/pull/904