### PR TITLE
feat(corset): enable `go-corset` in `gradle` action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -105,3 +105,40 @@ jobs:
           java-version: 21
       - name: spotless
         run: ./gradlew --no-daemon --parallel clean spotlessCheck
+
+  go-corset-tests:
+    runs-on: ubuntu-latest-128
+    steps:
+      - uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.CONSTRAINTS_SSH_KEY }}
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: 21
+          distribution: temurin
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Install Corset
+        run: RUSTFLAGS=-Awarnings cargo install --git ssh://git@github.com/ConsenSys/corset --tag v9.7.13 --locked --force
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+
+      - name: Install Go Corset
+        run:
+          go install github.com/consensys/go-corset/cmd/go-corset@latest
+
+      - name: Run unit tests
+        run: ./gradlew :arithmetization:test
+        env:
+          JAVA_OPTS: -Dorg.gradle.daemon=false
+          CORSET_FLAGS: disable

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -108,6 +108,7 @@ jobs:
 
   go-corset-tests:
     runs-on: ubuntu-latest-128
+    continue-on-error: true    
     steps:
       - uses: webfactory/ssh-agent@v0.7.0
         with:


### PR DESCRIPTION
This enables `go-corset` in the `gradle` action workflow.  However, `go-corset` is only run as part of a job which runs separately from the main tests job.  As such, it will not prevent pull requests from being merged.  The goal here is really to enable testing of `go-corset` before (eventually) swapping out the existing Rust corset tool.