### PR TITLE
fix: swap ordering of r/s fields in tx snapshot

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/blockcapture/snapshots/TransactionSnapshot.java
+++ b/arithmetization/src/main/java/net/consensys/linea/blockcapture/snapshots/TransactionSnapshot.java
@@ -55,8 +55,8 @@ public record TransactionSnapshot(
 
   public static TransactionSnapshot of(Transaction tx) {
     return new TransactionSnapshot(
-        tx.getS().toString(16),
         tx.getR().toString(16),
+        tx.getS().toString(16),
         tx.getType() == TransactionType.FRONTIER
             ? tx.getV().toString(16)
             : tx.getYParity().toString(16),


### PR DESCRIPTION
The ordering of these two fields was incorrect, and should be swapped. This then means the TX hashes are computed correctly.  Since this happens on the capture side, changes will only be noticed once the fix is deployed and new blocks captured.  Existing captures contain the `r` and `s` fields in the wrong order, and need to be updated.