### PR TITLE
fix: Use correct CHAINID in EVM

### DIFF
--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironment.java
@@ -84,7 +84,7 @@ public class ToyExecutionEnvironment {
       Hash.fromHexStringLenient("0xdeadbeef123123666dead666dead666");
 
   private final ToyWorld toyWorld;
-  private final EVM evm = MainnetEVMs.london(EvmConfiguration.DEFAULT);
+
   @Builder.Default private BigInteger chainId = CHAIN_ID;
   @Singular private final List<Transaction> transactions;
 
@@ -217,7 +217,9 @@ public class ToyExecutionEnvironment {
   }
 
   private MainnetTransactionProcessor getMainnetTransactionProcessor() {
-
+    // Construct EVM for executing transactions.
+    final EVM evm = MainnetEVMs.london(this.chainId, EvmConfiguration.DEFAULT);
+    //
     PrecompileContractRegistry precompileContractRegistry = new PrecompileContractRegistry();
 
     MainnetPrecompiledContracts.populateForIstanbul(

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
@@ -63,7 +63,6 @@ public class ToyExecutionEnvironmentV2 {
   private static final long DEFAULT_TIME_STAMP = 1347310;
   private static final Hash DEFAULT_HASH =
       Hash.fromHexStringLenient("0xdeadbeef123123666dead666dead666");
-  private static final EVM evm = MainnetEVMs.london(EvmConfiguration.DEFAULT);
   private static final FeeMarket feeMarket = FeeMarket.london(-1);
 
   @Builder.Default private BigInteger chainId = CHAIN_ID;
@@ -71,11 +70,12 @@ public class ToyExecutionEnvironmentV2 {
   @Singular private final List<Transaction> transactions;
 
   public void run() {
+    final EVM evm = MainnetEVMs.london(this.chainId, EvmConfiguration.DEFAULT);
     GeneralStateReferenceTestTools.executeTest(
-        this.buildGeneralStateTestCaseSpec(), getMainnetTransactionProcessor(), feeMarket);
+        this.buildGeneralStateTestCaseSpec(evm), getMainnetTransactionProcessor(evm), feeMarket);
   }
 
-  public GeneralStateTestCaseEipSpec buildGeneralStateTestCaseSpec() {
+  public GeneralStateTestCaseEipSpec buildGeneralStateTestCaseSpec(EVM evm) {
     Map<String, ReferenceTestWorldState.AccountMock> accountMockMap =
         toyWorld.getAddressAccountMap().entrySet().stream()
             .collect(
@@ -113,8 +113,7 @@ public class ToyExecutionEnvironmentV2 {
         /*expectException*/ null);
   }
 
-  private MainnetTransactionProcessor getMainnetTransactionProcessor() {
-
+  private MainnetTransactionProcessor getMainnetTransactionProcessor(EVM evm) {
     PrecompileContractRegistry precompileContractRegistry = new PrecompileContractRegistry();
 
     MainnetPrecompiledContracts.populateForIstanbul(


### PR DESCRIPTION
This updates the `ToyExecutionEnvironment` to use the correct CHAINID when constructing the EVM.  Previously, this was not done correctly and meant that the `CHAINID` bytecode was returning an invalid value, which in turn mean that storage addresses were being computed incorrectly (i.e. because they incorporated the CHAINID into the hash).