### PR TITLE
fix: `ToyWorld.commit()` parent update

### DIFF
--- a/testing/src/main/java/net/consensys/linea/testing/ToyAccount.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyAccount.java
@@ -176,6 +176,23 @@ public class ToyAccount implements MutableAccount {
     mutable = false;
   }
 
+  /**
+   * Push changes into the parent account, if one exists
+   *
+   * @return true if a parent account was updated, false if not (this indicates the account should
+   *     be inserted into the parent contact).
+   */
+  public boolean updateParent() {
+    if (parent instanceof ToyAccount toyAccount) {
+      toyAccount.balance = balance;
+      toyAccount.nonce = nonce;
+      toyAccount.storage.putAll(storage);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   public ReferenceTestWorldState.AccountMock toAccountMock() {
     Map<String, String> accountMockStorage = new HashMap<>();
     for (Map.Entry<UInt256, UInt256> e : storage.entrySet()) {


### PR DESCRIPTION
This puts through a simple fix for `ToyWorld.commit()` and also tidies up `ToyWorld` a little by removing the `accounts` field which is not needed (as was incorrectly managed).