### PR TITLE
[934] Use ToyExecutionEnvironmentV2 for blockhash test

### DIFF
--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/blockhash/BlockhashTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/blockhash/BlockhashTest.java
@@ -21,7 +21,6 @@ import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.BytecodeRunner;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class BlockhashTest {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/blockhash/BlockhashTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/blockhash/BlockhashTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 
 public class BlockhashTest {
 
-  @Disabled("Not possible to test yet, ToyWorld issue, see #934")
   @Test
   void someBlockhash() {
     BytecodeRunner.of(
@@ -141,6 +140,7 @@ public class BlockhashTest {
                 // TODO: add test with different block in the conflated batch
 
                 .compile())
+        .useToyExecutionEnvironmentV2(true)
         .run();
   }
 }

--- a/testing/src/main/java/net/consensys/linea/testing/BytecodeRunner.java
+++ b/testing/src/main/java/net/consensys/linea/testing/BytecodeRunner.java
@@ -43,6 +43,9 @@ public final class BytecodeRunner {
   public static final long DEFAULT_GAS_LIMIT = 25_000_000L;
   private final Bytes byteCode;
   ToyExecutionEnvironment toyExecutionEnvironment;
+  ToyExecutionEnvironmentV2 toyExecutionEnvironmentV2;
+
+  @Setter private boolean useToyExecutionEnvironmentV2 = false;
 
   /**
    * @param byteCode the byte code to test
@@ -112,18 +115,35 @@ public final class BytecodeRunner {
 
     final ToyWorld toyWorld = ToyWorld.builder().accounts(accounts).build();
 
-    toyExecutionEnvironment =
-        ToyExecutionEnvironment.builder()
-            .testValidator(x -> {})
-            .toyWorld(toyWorld)
-            .zkTracerValidator(zkTracerValidator)
-            .transaction(tx)
-            .build();
+    if (useToyExecutionEnvironmentV2) {
+      toyExecutionEnvironmentV2 =
+              ToyExecutionEnvironmentV2.builder()
+                      .testValidator(x -> {
+                      })
+                      .toyWorld(toyWorld)
+                      .zkTracerValidator(zkTracerValidator)
+                      .transaction(tx)
+                      .build();
+      toyExecutionEnvironmentV2.run();
 
-    toyExecutionEnvironment.run();
+    } else {
+      toyExecutionEnvironment =
+              ToyExecutionEnvironment.builder()
+                      .testValidator(x -> {
+                      })
+                      .toyWorld(toyWorld)
+                      .zkTracerValidator(zkTracerValidator)
+                      .transaction(tx)
+                      .build();
+      toyExecutionEnvironment.run();
+    }
   }
 
   public Hub getHub() {
-    return toyExecutionEnvironment.getHub();
+    if (useToyExecutionEnvironmentV2) {
+      return toyExecutionEnvironmentV2.getHub();
+    } else {
+      return toyExecutionEnvironment.getHub();
+    }
   }
 }

--- a/testing/src/main/java/net/consensys/linea/testing/BytecodeRunner.java
+++ b/testing/src/main/java/net/consensys/linea/testing/BytecodeRunner.java
@@ -117,24 +117,22 @@ public final class BytecodeRunner {
 
     if (useToyExecutionEnvironmentV2) {
       toyExecutionEnvironmentV2 =
-              ToyExecutionEnvironmentV2.builder()
-                      .testValidator(x -> {
-                      })
-                      .toyWorld(toyWorld)
-                      .zkTracerValidator(zkTracerValidator)
-                      .transaction(tx)
-                      .build();
+          ToyExecutionEnvironmentV2.builder()
+              .testValidator(x -> {})
+              .toyWorld(toyWorld)
+              .zkTracerValidator(zkTracerValidator)
+              .transaction(tx)
+              .build();
       toyExecutionEnvironmentV2.run();
 
     } else {
       toyExecutionEnvironment =
-              ToyExecutionEnvironment.builder()
-                      .testValidator(x -> {
-                      })
-                      .toyWorld(toyWorld)
-                      .zkTracerValidator(zkTracerValidator)
-                      .transaction(tx)
-                      .build();
+          ToyExecutionEnvironment.builder()
+              .testValidator(x -> {})
+              .toyWorld(toyWorld)
+              .zkTracerValidator(zkTracerValidator)
+              .transaction(tx)
+              .build();
       toyExecutionEnvironment.run();
     }
   }

--- a/testing/src/main/java/net/consensys/linea/testing/GeneralStateReferenceTestTools.java
+++ b/testing/src/main/java/net/consensys/linea/testing/GeneralStateReferenceTestTools.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -60,8 +61,11 @@ public class GeneralStateReferenceTestTools {
   @SneakyThrows
   public static void executeTest(
       final GeneralStateTestCaseEipSpec spec,
+      final ZkTracer tracer,
       final MainnetTransactionProcessor processor,
-      final FeeMarket feeMarket) {
+      final FeeMarket feeMarket,
+      final Consumer<TransactionProcessingResult> transactionProcessingResultValidator,
+      final Consumer<ZkTracer> zkTracerValidator) {
     final BlockHeader blockHeader = spec.getBlockHeader();
     final ReferenceTestWorldState initialWorldState = spec.getInitialWorldState();
     final List<Transaction> transactions = new ArrayList<>();
@@ -89,7 +93,6 @@ public class GeneralStateReferenceTestTools {
     final Wei blobGasPrice =
         feeMarket.blobGasPricePerGas(blockHeader.getExcessBlobGas().orElse(BlobGas.ZERO));
 
-    final ZkTracer tracer = new ZkTracer();
 
     tracer.traceStartConflation(1);
     tracer.traceStartBlock(blockHeader, blockBody);
@@ -114,6 +117,9 @@ public class GeneralStateReferenceTestTools {
               false,
               TransactionValidationParams.processingBlock(),
               blobGasPrice);
+
+      transactionProcessingResultValidator.accept(result);
+      zkTracerValidator.accept(tracer);
 
       if (result.isInvalid()) {
         final TransactionProcessingResult finalResult = result;

--- a/testing/src/main/java/net/consensys/linea/testing/GeneralStateReferenceTestTools.java
+++ b/testing/src/main/java/net/consensys/linea/testing/GeneralStateReferenceTestTools.java
@@ -93,7 +93,6 @@ public class GeneralStateReferenceTestTools {
     final Wei blobGasPrice =
         feeMarket.blobGasPricePerGas(blockHeader.getExcessBlobGas().orElse(BlobGas.ZERO));
 
-
     tracer.traceStartConflation(1);
     tracer.traceStartBlock(blockHeader, blockBody);
     TransactionProcessingResult result = null;

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
@@ -22,6 +22,7 @@ import static net.consensys.linea.zktracer.runtime.stack.Stack.MAX_STACK_SIZE;
 
 import java.math.BigInteger;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -30,6 +31,7 @@ import lombok.Singular;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.zktracer.ZkTracer;
 import net.consensys.linea.zktracer.module.constants.GlobalConstants;
+import net.consensys.linea.zktracer.module.hub.Hub;
 import org.hyperledger.besu.datatypes.*;
 import org.hyperledger.besu.ethereum.core.*;
 import org.hyperledger.besu.ethereum.core.Transaction;
@@ -39,6 +41,7 @@ import org.hyperledger.besu.ethereum.mainnet.MainnetTransactionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.TransactionValidatorFactory;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.LondonFeeMarket;
+import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.referencetests.GeneralStateTestCaseEipSpec;
 import org.hyperledger.besu.ethereum.referencetests.ReferenceTestWorldState;
 import org.hyperledger.besu.evm.EVM;
@@ -66,13 +69,35 @@ public class ToyExecutionEnvironmentV2 {
   private static final FeeMarket feeMarket = FeeMarket.london(-1);
 
   @Builder.Default private BigInteger chainId = CHAIN_ID;
+
   private final ToyWorld toyWorld;
+
   @Singular private final List<Transaction> transactions;
+
+  /**
+   * A function applied to the {@link TransactionProcessingResult} of each transaction; by default,
+   * asserts that the transaction is successful.
+   */
+  @Builder.Default private final Consumer<TransactionProcessingResult> testValidator = x -> {};
+
+  @Builder.Default private final Consumer<ZkTracer> zkTracerValidator = x -> {};
+
+  private final ZkTracer tracer = new ZkTracer();
+
 
   public void run() {
     final EVM evm = MainnetEVMs.london(this.chainId, EvmConfiguration.DEFAULT);
     GeneralStateReferenceTestTools.executeTest(
-        this.buildGeneralStateTestCaseSpec(evm), getMainnetTransactionProcessor(evm), feeMarket);
+            this.buildGeneralStateTestCaseSpec(evm),
+            tracer,
+            getMainnetTransactionProcessor(evm),
+            feeMarket,
+            testValidator,
+            zkTracerValidator);
+  }
+
+  public Hub getHub() {
+    return tracer.getHub();
   }
 
   public GeneralStateTestCaseEipSpec buildGeneralStateTestCaseSpec(EVM evm) {

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
@@ -84,16 +84,15 @@ public class ToyExecutionEnvironmentV2 {
 
   private final ZkTracer tracer = new ZkTracer();
 
-
   public void run() {
     final EVM evm = MainnetEVMs.london(this.chainId, EvmConfiguration.DEFAULT);
     GeneralStateReferenceTestTools.executeTest(
-            this.buildGeneralStateTestCaseSpec(evm),
-            tracer,
-            getMainnetTransactionProcessor(evm),
-            feeMarket,
-            testValidator,
-            zkTracerValidator);
+        this.buildGeneralStateTestCaseSpec(evm),
+        tracer,
+        getMainnetTransactionProcessor(evm),
+        feeMarket,
+        testValidator,
+        zkTracerValidator);
   }
 
   public Hub getHub() {


### PR DESCRIPTION
In this PR:
- Introduce the option of running ByteCodeRunner tests with ToyExecutionEnvironmentV2. 
- Update BlockHashTest to run with ToyExecutionEnvironmentV2

implements issue(s): #934 