### PR TITLE
fix: initial contract nonce (#1054)

### DIFF
--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ReplayTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ReplayTests.java
@@ -91,7 +91,7 @@ public class ReplayTests {
 
   @Test
   void fatMxp() {
-    replay("2492975-2492977.json.gz", false);
+    replay("2492975-2492977.json.gz");
   }
 
   @Test
@@ -126,7 +126,7 @@ public class ReplayTests {
 
   @Test
   void issue1006() {
-    replay("6032696-6032699.json.gz", false);
+    replay("6032696-6032699.json.gz");
   }
 
   @Test
@@ -144,7 +144,7 @@ public class ReplayTests {
 
   @Test
   void failingCreate2() {
-    replay("2250197-2250197.json.gz", false);
+    replay("2250197-2250197.json.gz");
   }
 
   @Test

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironment.java
@@ -254,7 +254,7 @@ public class ToyExecutionEnvironment {
         new MessageCallProcessor(evm, precompileContractRegistry);
 
     final ContractCreationProcessor contractCreationProcessor =
-        new ContractCreationProcessor(evm, false, List.of(), 0);
+        new ContractCreationProcessor(evm, false, List.of(), 1);
 
     return new MainnetTransactionProcessor(
         gasCalculator,


### PR DESCRIPTION
The initial contract nonce was incorrectly set as `0` when it should be `1`.  This also enables tx result checking for a small number of tests which now pass as a result of this fix.  The remaining replays fail because of an incorrect balance.