### PR TITLE
[997] Migrate most of the tests to ToyExecutionEnviromentV2

### DIFF
--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/blockhash/BlockhashTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/blockhash/BlockhashTest.java
@@ -139,7 +139,6 @@ public class BlockhashTest {
                 // TODO: add test with different block in the conflated batch
 
                 .compile())
-        .useToyExecutionEnvironmentV2(true)
         .run();
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/CallEmptyNoStopTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/CallEmptyNoStopTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.ToyAccount;
-import net.consensys.linea.testing.ToyExecutionEnvironment;
+import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.ToyTransaction;
 import net.consensys.linea.testing.ToyWorld;
 import net.consensys.linea.zktracer.opcode.OpCode;
@@ -78,7 +78,7 @@ public class CallEmptyNoStopTest {
             .accounts(List.of(senderAccount, receiverAccount, emptyCodeAccount))
             .build();
 
-    ToyExecutionEnvironment.builder()
+    ToyExecutionEnvironmentV2.builder()
         .toyWorld(toyWorld)
         .transaction(tx)
         .zkTracerValidator(

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/SimpleStorageConsistency.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/SimpleStorageConsistency.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.ToyAccount;
-import net.consensys.linea.testing.ToyExecutionEnvironment;
+import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.ToyTransaction;
 import net.consensys.linea.testing.ToyWorld;
 import net.consensys.linea.zktracer.opcode.OpCode;
@@ -143,7 +143,7 @@ public class SimpleStorageConsistency {
             .accounts(List.of(receiverAccount, senderAccount1, senderAccount2, senderAccount3))
             .build();
 
-    ToyExecutionEnvironment.builder()
+    ToyExecutionEnvironmentV2.builder()
         .toyWorld(toyWorld)
         .transactions(txs)
         .zkTracerValidator(zkTracer -> {})

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobCallTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobCallTest.java
@@ -93,7 +93,9 @@ public class OobCallTest {
   @Test
   void TestRecursiveCallsWithBytecode() {
     final BytecodeRunner bytecodeRunner =
-        BytecodeRunner.of(Bytes.fromHexString("60006000600060006000305af1"));
+        BytecodeRunner.of(Bytes.fromHexString("60006000600060006000305af1"))
+            .useToyExecutionEnvironmentV2(false);
+
     bytecodeRunner.run(Wei.fromEth(400), 0xFFFFFFFFL);
 
     final Hub hub = bytecodeRunner.getHub();

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlpaddr/TestRlpAddress.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlpaddr/TestRlpAddress.java
@@ -21,7 +21,6 @@ import java.util.Random;
 
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.ToyAccount;
-import net.consensys.linea.testing.ToyExecutionEnvironment;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.ToyTransaction;
 import net.consensys.linea.testing.ToyWorld;
@@ -134,7 +133,7 @@ public class TestRlpAddress {
             .payload(initCodeReturnContractCode)
             .build();
 
-    ToyExecutionEnvironment.builder()
+    ToyExecutionEnvironmentV2.builder()
         .toyWorld(world.build())
         .transaction(tx)
         .testValidator(x -> {})

--- a/testing/src/main/java/net/consensys/linea/testing/BytecodeRunner.java
+++ b/testing/src/main/java/net/consensys/linea/testing/BytecodeRunner.java
@@ -45,7 +45,7 @@ public final class BytecodeRunner {
   ToyExecutionEnvironment toyExecutionEnvironment;
   ToyExecutionEnvironmentV2 toyExecutionEnvironmentV2;
 
-  @Setter private boolean useToyExecutionEnvironmentV2 = false;
+  @Setter private boolean useToyExecutionEnvironmentV2 = true;
 
   /**
    * @param byteCode the byte code to test

--- a/testing/src/main/java/net/consensys/linea/testing/ExampleTxTest.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ExampleTxTest.java
@@ -55,6 +55,6 @@ class ExampleTxTest {
     ToyWorld toyWorld =
         ToyWorld.builder().accounts(List.of(senderAccount, receiverAccount)).build();
 
-    ToyExecutionEnvironment.builder().toyWorld(toyWorld).transaction(tx).build().run();
+    ToyExecutionEnvironmentV2.builder().toyWorld(toyWorld).transaction(tx).build().run();
   }
 }


### PR DESCRIPTION
#997 

Migrate most of the unit tests to use ToyExecutionEnviromentV2. The following tests fail with V2 so have not been migrated:

1. TxSkip
2. OobCallTest
3. StpTest
