### PR TITLE
fix CountOnlyModule

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/CountingOnlyModule.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/CountingOnlyModule.java
@@ -24,26 +24,26 @@ import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 
 /** A {@link CountingOnlyModule} is a {@link Module} that only counts certain outcomes. */
 public interface CountingOnlyModule extends Module {
-  CountOnlyOperation counts = new CountOnlyOperation();
+  CountOnlyOperation counts();
 
   @Override
   default void enterTransaction() {
-    counts.enter();
+    counts().enter();
   }
 
   @Override
   default void popTransaction() {
-    counts.pop();
+    counts().pop();
   }
 
   @Override
   default int lineCount() {
-    return counts.lineCount();
+    return counts().lineCount();
   }
 
   default void addPrecompileLimit(final int count) {
     Preconditions.checkArgument(count >= 0, "Must be positive");
-    counts.add(count);
+    counts().add(count);
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/stacked/CountOnlyOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/stacked/CountOnlyOperation.java
@@ -17,9 +17,11 @@ package net.consensys.linea.zktracer.container.stacked;
 
 import com.google.common.base.Preconditions;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
 
 @Accessors(fluent = true)
+@RequiredArgsConstructor
 public class CountOnlyOperation {
 
   private int countCommitedToTheConflation = 0;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
@@ -18,14 +18,20 @@ package net.consensys.linea.zktracer.module.limits;
 import java.util.List;
 
 import com.google.common.base.Preconditions;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
+import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 import net.consensys.linea.zktracer.module.limits.precompiles.EcRecoverEffectiveCall;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 
 @RequiredArgsConstructor
+@Getter
+@Accessors(fluent = true)
 public class Keccak implements CountingOnlyModule {
+  private final CountOnlyOperation counts = new CountOnlyOperation();
   private static final int ADDRESS_BYTES = Address.SIZE;
   private static final int HASH_BYTES = Hash.SIZE;
   private static final int L1_MSG_INDICES_BYTES = 8;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeEffectiveCall.java
@@ -17,9 +17,14 @@ package net.consensys.linea.zktracer.module.limits.precompiles;
 
 import static com.google.common.base.Preconditions.*;
 
+import lombok.Getter;
+import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
-
+import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
+@Getter
+@Accessors(fluent = true)
 public final class BlakeEffectiveCall implements CountingOnlyModule {
+  private final CountOnlyOperation counts = new CountOnlyOperation();
 
   @Override
   public String moduleKey() {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeEffectiveCall.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
+
 @Getter
 @Accessors(fluent = true)
 public final class BlakeEffectiveCall implements CountingOnlyModule {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeRounds.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeRounds.java
@@ -24,6 +24,7 @@ import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 @Accessors(fluent = true)
 public final class BlakeRounds implements CountingOnlyModule {
   private final CountOnlyOperation counts = new CountOnlyOperation();
+
   @Override
   public String moduleKey() {
     return "PRECOMPILE_BLAKE_ROUNDS";

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeRounds.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeRounds.java
@@ -15,10 +15,15 @@
 
 package net.consensys.linea.zktracer.module.limits.precompiles;
 
+import lombok.Getter;
+import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
+import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 
+@Getter
+@Accessors(fluent = true)
 public final class BlakeRounds implements CountingOnlyModule {
-
+  private final CountOnlyOperation counts = new CountOnlyOperation();
   @Override
   public String moduleKey() {
     return "PRECOMPILE_BLAKE_ROUNDS";

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcAddEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcAddEffectiveCall.java
@@ -21,10 +21,12 @@ import lombok.Getter;
 import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
+
 @Getter
 @Accessors(fluent = true)
 public final class EcAddEffectiveCall implements CountingOnlyModule {
   private final CountOnlyOperation counts = new CountOnlyOperation();
+
   @Override
   public String moduleKey() {
     return "PRECOMPILE_ECADD_EFFECTIVE_CALLS";

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcAddEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcAddEffectiveCall.java
@@ -17,10 +17,14 @@ package net.consensys.linea.zktracer.module.limits.precompiles;
 
 import static com.google.common.base.Preconditions.*;
 
+import lombok.Getter;
+import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
-
+import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
+@Getter
+@Accessors(fluent = true)
 public final class EcAddEffectiveCall implements CountingOnlyModule {
-
+  private final CountOnlyOperation counts = new CountOnlyOperation();
   @Override
   public String moduleKey() {
     return "PRECOMPILE_ECADD_EFFECTIVE_CALLS";

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcMulEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcMulEffectiveCall.java
@@ -17,12 +17,16 @@ package net.consensys.linea.zktracer.module.limits.precompiles;
 
 import static com.google.common.base.Preconditions.*;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
-
+import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
+@Getter
+@Accessors(fluent = true)
 @RequiredArgsConstructor
 public final class EcMulEffectiveCall implements CountingOnlyModule {
-
+  private final CountOnlyOperation counts = new CountOnlyOperation();
   @Override
   public String moduleKey() {
     return "PRECOMPILE_ECMUL_EFFECTIVE_CALLS";

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcMulEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcMulEffectiveCall.java
@@ -22,11 +22,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
+
 @Getter
 @Accessors(fluent = true)
 @RequiredArgsConstructor
 public final class EcMulEffectiveCall implements CountingOnlyModule {
   private final CountOnlyOperation counts = new CountOnlyOperation();
+
   @Override
   public String moduleKey() {
     return "PRECOMPILE_ECMUL_EFFECTIVE_CALLS";

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingFinalExponentiations.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingFinalExponentiations.java
@@ -18,16 +18,19 @@ package net.consensys.linea.zktracer.module.limits.precompiles;
 import static net.consensys.linea.zktracer.CurveOperations.*;
 
 import com.google.common.base.Preconditions;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
+import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 
 @Slf4j
 @RequiredArgsConstructor
 @Accessors(fluent = true)
+@Getter
 public final class EcPairingFinalExponentiations implements CountingOnlyModule {
-
+  private final CountOnlyOperation counts = new CountOnlyOperation();
   private static final int PRECOMPILE_BASE_GAS_FEE = 45_000; // cf EIP-1108
   private static final int PRECOMPILE_MILLER_LOOP_GAS_FEE = 34_000; // cf EIP-1108
   private static final int ECPAIRING_NB_BYTES_PER_MILLER_LOOP = 192;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingG2MembershipCalls.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingG2MembershipCalls.java
@@ -23,6 +23,7 @@ import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 @Accessors(fluent = true)
 public class EcPairingG2MembershipCalls implements CountingOnlyModule {
   private final CountOnlyOperation counts = new CountOnlyOperation();
+
   @Override
   public String moduleKey() {
     return "PRECOMPILE_ECPAIRING_G2_MEMBERSHIP_CALLS";

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingG2MembershipCalls.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingG2MembershipCalls.java
@@ -14,10 +14,15 @@
  */
 package net.consensys.linea.zktracer.module.limits.precompiles;
 
+import lombok.Getter;
+import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
+import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 
+@Getter
+@Accessors(fluent = true)
 public class EcPairingG2MembershipCalls implements CountingOnlyModule {
-
+  private final CountOnlyOperation counts = new CountOnlyOperation();
   @Override
   public String moduleKey() {
     return "PRECOMPILE_ECPAIRING_G2_MEMBERSHIP_CALLS";

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingMillerLoops.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingMillerLoops.java
@@ -23,7 +23,8 @@ import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 @Getter
 @Accessors(fluent = true)
 public final class EcPairingMillerLoops implements CountingOnlyModule {
-  private final  CountOnlyOperation counts = new CountOnlyOperation();
+  private final CountOnlyOperation counts = new CountOnlyOperation();
+
   @Override
   public String moduleKey() {
     return "PRECOMPILE_ECPAIRING_MILLER_LOOPS";

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingMillerLoops.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingMillerLoops.java
@@ -15,10 +15,15 @@
 
 package net.consensys.linea.zktracer.module.limits.precompiles;
 
+import lombok.Getter;
+import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
+import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 
+@Getter
+@Accessors(fluent = true)
 public final class EcPairingMillerLoops implements CountingOnlyModule {
-
+  private final  CountOnlyOperation counts = new CountOnlyOperation();
   @Override
   public String moduleKey() {
     return "PRECOMPILE_ECPAIRING_MILLER_LOOPS";

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcRecoverEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcRecoverEffectiveCall.java
@@ -28,6 +28,7 @@ import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 @Accessors(fluent = true)
 public final class EcRecoverEffectiveCall implements CountingOnlyModule {
   private final CountOnlyOperation counts = new CountOnlyOperation();
+
   @Override
   public String moduleKey() {
     return "PRECOMPILE_ECRECOVER_EFFECTIVE_CALLS";

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcRecoverEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcRecoverEffectiveCall.java
@@ -17,12 +17,17 @@ package net.consensys.linea.zktracer.module.limits.precompiles;
 
 import static com.google.common.base.Preconditions.*;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
+import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 
 @RequiredArgsConstructor
+@Getter
+@Accessors(fluent = true)
 public final class EcRecoverEffectiveCall implements CountingOnlyModule {
-
+  private final CountOnlyOperation counts = new CountOnlyOperation();
   @Override
   public String moduleKey() {
     return "PRECOMPILE_ECRECOVER_EFFECTIVE_CALLS";

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/ModexpEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/ModexpEffectiveCall.java
@@ -16,16 +16,19 @@
 package net.consensys.linea.zktracer.module.limits.precompiles;
 
 import com.google.common.base.Preconditions;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
+import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 
+@Getter
 @Slf4j
 @RequiredArgsConstructor
 @Accessors(fluent = true)
 public class ModexpEffectiveCall implements CountingOnlyModule {
-
+  private final CountOnlyOperation counts = new CountOnlyOperation();
   public static final int PROVER_MAX_INPUT_BYTE_SIZE = 4096 / 8;
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/RipemdBlocks.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/RipemdBlocks.java
@@ -15,11 +15,17 @@
 
 package net.consensys.linea.zktracer.module.limits.precompiles;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
+import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 
 @RequiredArgsConstructor
+@Getter
+@Accessors(fluent = true)
 public final class RipemdBlocks implements CountingOnlyModule {
+  private final CountOnlyOperation counts = new CountOnlyOperation();
   private static final int PRECOMPILE_BASE_GAS_FEE = 600;
   private static final int PRECOMPILE_GAS_FEE_PER_EWORD = 120;
   private static final int RIPEMD160_BLOCKSIZE = 64 * 8;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/Sha256Blocks.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/Sha256Blocks.java
@@ -19,10 +19,11 @@ import lombok.Getter;
 import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
+
 @Getter
 @Accessors(fluent = true)
 public final class Sha256Blocks implements CountingOnlyModule {
-  private final  CountOnlyOperation counts = new CountOnlyOperation();
+  private final CountOnlyOperation counts = new CountOnlyOperation();
   private static final int PRECOMPILE_BASE_GAS_FEE = 60;
   private static final int PRECOMPILE_GAS_FEE_PER_EWORD = 12;
   private static final int SHA256_BLOCKSIZE = 64 * 8;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/Sha256Blocks.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/Sha256Blocks.java
@@ -15,10 +15,14 @@
 
 package net.consensys.linea.zktracer.module.limits.precompiles;
 
+import lombok.Getter;
+import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
-
+import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
+@Getter
+@Accessors(fluent = true)
 public final class Sha256Blocks implements CountingOnlyModule {
-
+  private final  CountOnlyOperation counts = new CountOnlyOperation();
   private static final int PRECOMPILE_BASE_GAS_FEE = 60;
   private static final int PRECOMPILE_GAS_FEE_PER_EWORD = 12;
   private static final int SHA256_BLOCKSIZE = 64 * 8;

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/containers/CountOnlyModuleTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/containers/CountOnlyModuleTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright ConsenSys Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.zktracer.containers;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import net.consensys.linea.zktracer.ZkTracer;
+import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
+import net.consensys.linea.zktracer.module.limits.precompiles.EcAddEffectiveCall;
+import net.consensys.linea.zktracer.module.limits.precompiles.ModexpEffectiveCall;
+import org.junit.jupiter.api.Test;
+
+public class CountOnlyModuleTest {
+  @Test
+  void test(){
+    ZkTracer state = new ZkTracer();
+    final ModexpEffectiveCall countingOnlyModule = state.getHub().modexpEffectiveCall();
+
+    countingOnlyModule.enterTransaction();
+    countingOnlyModule.addPrecompileLimit(1);
+    assertThat(countingOnlyModule.lineCount()).isEqualTo(1);
+
+    countingOnlyModule.enterTransaction();
+    countingOnlyModule.addPrecompileLimit(1);
+    assertThat(countingOnlyModule.lineCount()).isEqualTo(2);
+
+    countingOnlyModule.popTransaction();
+    assertThat(countingOnlyModule.lineCount()).isEqualTo(1);
+
+    state = new ZkTracer();
+    assertThat(state.getHub().modexpEffectiveCall().lineCount()).isEqualTo(0);
+  }
+}

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/containers/CountOnlyModuleTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/containers/CountOnlyModuleTest.java
@@ -18,14 +18,12 @@ package net.consensys.linea.zktracer.containers;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import net.consensys.linea.zktracer.ZkTracer;
-import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
-import net.consensys.linea.zktracer.module.limits.precompiles.EcAddEffectiveCall;
 import net.consensys.linea.zktracer.module.limits.precompiles.ModexpEffectiveCall;
 import org.junit.jupiter.api.Test;
 
 public class CountOnlyModuleTest {
   @Test
-  void test(){
+  void test() {
     ZkTracer state = new ZkTracer();
     final ModexpEffectiveCall countingOnlyModule = state.getHub().modexpEffectiveCall();
 


### PR DESCRIPTION
Counters for precompiles wheren't reboot when creating a new ZkTracer, pointing to the same `CountOnlyModule`