### PR TITLE
Increase Threads available to `corset` for Github Runner

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/corset/RustCorsetValidator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/corset/RustCorsetValidator.java
@@ -231,6 +231,7 @@ public class RustCorsetValidator extends AbstractExecutable {
    * @return
    */
   private String determineNumberOfThreads() {
-    return Optional.ofNullable(System.getenv("CORSET_THREADS")).orElse("2");
+    int ncpus = Runtime.getRuntime().availableProcessors();
+    return Optional.ofNullable(System.getenv("CORSET_THREADS")).orElse(Integer.toString(ncpus));
   }
 }


### PR DESCRIPTION
This changes the default number of threads to be used when running `RustCorsetValidator` from `2` to the number of available cores.  The ability to override this using `CORSET_THREADS` remains.