### PR TITLE
feat: enable reporting in `go-corset`

### DIFF
--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -101,4 +101,4 @@ jobs:
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
-          GOCORSET_FLAGS: -wd -b1024 --air
+          GOCORSET_FLAGS: -wd --ansi-escapes=false --report --air

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -168,11 +168,11 @@ jobs:
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
-          GOCORSET_FLAGS: -wd -b1024 --air
+          GOCORSET_FLAGS: -wd --ansi-escapes=false --report --air
 
       - name: Run replay tests
         run: GOMEMLIMIT=196GiB ./gradlew :arithmetization:replayTests
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
-          GOCORSET_FLAGS: -wd -b1024 --air
+          GOCORSET_FLAGS: -wd --ansi-escapes=false --report --air


### PR DESCRIPTION
This enables reporting in `go-corset` so we can get more debug information about failing constraints.