### PR TITLE
build: build a separate zkevm.bin for reference tests

### DIFF
--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -52,15 +52,16 @@ jobs:
       - name: Generate block chain reference tests
         run:  ./gradlew :reference-tests:generateBlockchainReferenceTests -Dorg.gradle.parallel=true -Dorg.gradle.caching=true
         env:
-          JAVA_OPTS: -Dorg.gradle.daemon=false -DZKEVM_BIN_ORIGINAL_PATH="linea-constraints/zkevm.bin"
+          JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: fields,expand,expand,expand
 
       - name: generate zkevm.bin
-        run: cd ./linea-constraints; make zkevm.bin -B; cd ..
+        run: cd ./linea-constraints; make zkevm_for_reference_tests.bin -B; cd ..
 
       - name: Run general reference tests
         run: ./gradlew referenceGeneralStateTests
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
+          ZKEVM_BIN: zkevm_for_reference_tests.bin
           CORSET_FLAGS: fields,expand,expand,expand
 

--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -1,8 +1,8 @@
 name: reference tests
 
-on: [push, pull_request]
-#  schedule:
-#    - cron: "0 23 * * *"
+on:
+  schedule:
+    - cron: "0 23 * * *"
 
 env:
   CARGO_NET_GIT_FETCH_WITH_CLI: true

--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -1,8 +1,8 @@
 name: reference tests
 
-on:
-  schedule:
-    - cron: "0 23 * * *"
+on: [push, pull_request]
+#  schedule:
+#    - cron: "0 23 * * *"
 
 env:
   CARGO_NET_GIT_FETCH_WITH_CLI: true

--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -59,7 +59,7 @@ jobs:
         run: cd ./linea-constraints; make zkevm_for_reference_tests.bin -B; cd ..
 
       - name: Run general reference tests
-        run: ./gradlew referenceGeneralStateTests
+        run: ./gradlew referenceGeneralStateTests -x spotlessCheck
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           ZKEVM_BIN: zkevm_for_reference_tests.bin

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -85,7 +85,7 @@ jobs:
         run: cd ./linea-constraints; make zkevm_for_reference_tests.bin -B; cd ..
 
       - name: Run reference blockchain tests
-        run: ./gradlew referenceBlockchainTests
+        run: ./gradlew referenceBlockchainTests -x spotlessCheck
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           ZKEVM_BIN: zkevm_for_reference_tests.bin

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -78,16 +78,17 @@ jobs:
       - name: Generate block chain reference tests
         run:  ./gradlew :reference-tests:generateBlockchainReferenceTests -Dorg.gradle.parallel=true -Dorg.gradle.caching=true
         env:
-          JAVA_OPTS: -Dorg.gradle.daemon=false -DZKEVM_BIN_ORIGINAL_PATH="linea-constraints/zkevm.bin"
+          JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: fields,expand,expand,expand
 
       - name: generate zkevm.bin
-        run: cd ./linea-constraints; make zkevm.bin -B; cd ..
+        run: cd ./linea-constraints; make zkevm_for_reference_tests.bin -B; cd ..
 
       - name: Run reference blockchain tests
         run: ./gradlew referenceBlockchainTests
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
+          ZKEVM_BIN: zkevm_for_reference_tests.bin
           CORSET_FLAGS: fields,expand,expand,expand
           FAILED_TESTS_FILE_NAME: ${{ inputs.failed_tests_file_name || '' }}
           FAILED_TEST_JSON_DIRECTORY: ${{ ../tmp/${{ inputs.branch-name }}/ || '' }}

--- a/arithmetization/src/main/java/net/consensys/linea/corset/CorsetValidator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/corset/CorsetValidator.java
@@ -44,7 +44,9 @@ public class CorsetValidator {
   public record Result(boolean isValid, File traceFile, String corsetOutput) {}
 
   /** */
-  private static final String ZK_EVM_RELATIVE_PATH = "/linea-constraints/zkevm.bin";
+  private static final String ZK_EVM_RELATIVE_PATH = "/linea-constraints/";
+
+  private static final String ZK_EVM_BIN = "zkevm.bin";
 
   /** Specifies the default zkEVM.bin file to use (including its path). */
   private String defaultZkEvm = null;
@@ -120,18 +122,22 @@ public class CorsetValidator {
       throw new RuntimeException(e);
     }
 
-    final String zkEvmBinInCurrentDir = currentDir + ZK_EVM_RELATIVE_PATH;
+    final String zkEvmBinInCurrentDir = currentDir + ZK_EVM_RELATIVE_PATH + binName();
     if (new File(zkEvmBinInCurrentDir).exists()) {
       defaultZkEvm = zkEvmBinInCurrentDir;
       return;
     }
 
-    final String zkEvmBinInDirAbove = currentDir + "/.." + ZK_EVM_RELATIVE_PATH;
+    final String zkEvmBinInDirAbove = currentDir + "/.." + ZK_EVM_RELATIVE_PATH + binName();
     if (new File(zkEvmBinInDirAbove).exists()) {
       defaultZkEvm = zkEvmBinInDirAbove;
       return;
     }
 
-    log.warn("Could not find default path for zkevm.bin");
+    log.warn("Could not find default path for {}", binName());
+  }
+
+  private String binName() {
+    return System.getenv("ZKEVM_BIN") != null ? System.getenv("ZKEVM_BIN") : ZK_EVM_BIN;
   }
 }

--- a/reference-tests/build.gradle
+++ b/reference-tests/build.gradle
@@ -72,7 +72,7 @@ tasks.register('referenceGeneralStateTests', Test) {
   systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
   systemProperties["junit.jupiter.execution.parallel.mode.classes.default"] = "concurrent"
   maxParallelForks = Runtime.getRuntime().availableProcessors()
-  
+
   boolean isCiServer = System.getenv().containsKey("CI")
   minHeapSize = "4g"
   maxHeapSize = isCiServer ? "32g" : "8g"

--- a/reference-tests/build.gradle
+++ b/reference-tests/build.gradle
@@ -67,6 +67,12 @@ tasks.register('referenceGeneralStateTests', Test) {
 
   dependsOn generateGeneralStateReferenceTests
 
+  systemProperties["junit.jupiter.execution.timeout.default"] = "5 m" // 5 minutes
+  systemProperties["junit.jupiter.execution.parallel.enabled"] = true
+  systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
+  systemProperties["junit.jupiter.execution.parallel.mode.classes.default"] = "concurrent"
+  maxParallelForks = Runtime.getRuntime().availableProcessors()
+  
   boolean isCiServer = System.getenv().containsKey("CI")
   minHeapSize = "4g"
   maxHeapSize = isCiServer ? "32g" : "8g"


### PR DESCRIPTION
use zkevm for reference test suite that deactivate DATA module to bypass the hardcoded constraints:

BLOCK_GAS_LIMIT   <-    LINEA_BLOCK_GAS_LIMIT
CHAINID           <-    LINEA_CHAIN_ID         (not active atm)
DIFFICULTY        <-    LINEA_DIFFICULTY
BASEFEE           <-    LINEA_BASE_FEE
 