### PR TITLE
Fix multi block tests

### DIFF
--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleMultiBlockTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleMultiBlockTest.java
@@ -13,10 +13,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.testing;
+package net.consensys.linea.zktracer;
 
 import java.util.List;
 
+import net.consensys.linea.testing.BytecodeCompiler;
+import net.consensys.linea.testing.MultiBlockExecutionEnvironment;
+import net.consensys.linea.testing.ToyAccount;
+import net.consensys.linea.testing.ToyTransaction;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.crypto.KeyPair;

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleTxTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleTxTest.java
@@ -13,10 +13,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.testing;
+package net.consensys.linea.zktracer;
 
 import java.util.List;
 
+import net.consensys.linea.testing.BytecodeCompiler;
+import net.consensys.linea.testing.ToyAccount;
+import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
+import net.consensys.linea.testing.ToyTransaction;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.hyperledger.besu.crypto.KeyPair;
 import org.hyperledger.besu.crypto.SECP256K1;

--- a/testing/src/main/java/net/consensys/linea/testing/MultiBlockExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/MultiBlockExecutionEnvironment.java
@@ -54,6 +54,7 @@ public class MultiBlockExecutionEnvironment {
 
   public void run() {
     ReplayExecutionEnvironment.builder()
+        .useCoinbaseAddressFromBlockHeader(true)
         .build()
         .replay(ToyExecutionEnvironmentV2.CHAIN_ID, this.buildConflationSnapshot());
   }


### PR DESCRIPTION
After this commit _[use CliqueProtocolSchedule instead of MainnetProtocolSchedule to extract the correct coinbase value](https://github.com/Consensys/linea-tracer/pull/1222)_ the multi block test fail because unlike Replay tests, they don't have the actual block header with clique information.

This change should fix this exception
```
Invalid Bytes supplied - too short to produce a valid Clique Extra Data object.
java.lang.IllegalArgumentException: Invalid Bytes supplied - too short to produce a valid Clique Extra Data object.
	at org.hyperledger.besu.consensus.clique.CliqueExtraData.decodeRaw(CliqueExtraData.java:115)
	at org.hyperledger.besu.consensus.clique.CliqueBlockHeaderFunctions.
```