### PR TITLE
feat: configure `corset` for full expansion

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -87,13 +87,14 @@ jobs:
         run: ./gradlew :arithmetization:test --stacktrace
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
-          CORSET_FLAGS: fields,expand,expand,expand
+          CORSET_FLAGS: fields,expand,expand,expand,expand,auto
+          REPLAY_TESTS_PARALLELISM: 2
 
       - name: Run Replay tests
         run: ./gradlew :arithmetization:fastReplayTests --stacktrace
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
-          CORSET_FLAGS: fields,expand,expand,expand
+          CORSET_FLAGS: fields,expand,expand,expand,expand,auto
           REPLAY_TESTS_PARALLELISM: 2
 
       - name: Upload test report


### PR DESCRIPTION
This sets `corset` to fully expand constraints (and traces) during checking on the CI pipeline.