### PR TITLE
Improve StackItem memory footprint

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
@@ -81,8 +81,8 @@ public class CommonFragmentValues {
     // this.contextNumberNew = hub.contextNumberNew(callFrame);
     this.pc = hubProcessingPhase == TX_EXEC ? hub.currentFrame().pc() : 0;
     this.pcNew = computePcNew(hub, pc, noStackException, hub.state.getProcessingPhase() == TX_EXEC);
-    this.height = (short) callFrame.stack().getHeight();
-    this.heightNew = (short) callFrame.stack().getHeightNew();
+    this.height = callFrame.stack().getHeight();
+    this.heightNew = callFrame.stack().getHeightNew();
 
     // TODO: partial solution, will not work in general
     this.gasExpected = hub.expectedGas();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/TraceSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/TraceSection.java
@@ -37,6 +37,7 @@ import net.consensys.linea.zktracer.module.hub.fragment.TraceFragment;
 import net.consensys.linea.zktracer.module.hub.fragment.common.CommonFragment;
 import net.consensys.linea.zktracer.module.hub.fragment.common.CommonFragmentValues;
 import net.consensys.linea.zktracer.runtime.callstack.CallFrame;
+import net.consensys.linea.zktracer.runtime.stack.Stack;
 import net.consensys.linea.zktracer.runtime.stack.StackLine;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.internal.Words;
@@ -158,12 +159,13 @@ public class TraceSection {
 
   private List<TraceFragment> makeStackFragments(final Hub hub, CallFrame f) {
     final List<TraceFragment> r = new ArrayList<>(2);
+    Stack snapshot = f.stack().snapshot();
     if (f.pending().lines().isEmpty()) {
       for (int i = 0; i < (f.opCodeData().stackSettings().twoLineInstruction() ? 2 : 1); i++) {
         r.add(
             StackFragment.prepare(
                 hub,
-                f.stack().snapshot(),
+                snapshot,
                 new StackLine().asStackItems(),
                 hub.pch().exceptions(),
                 hub.pch().abortingConditions().snapshot(),
@@ -177,7 +179,7 @@ public class TraceSection {
         r.add(
             StackFragment.prepare(
                 hub,
-                f.stack().snapshot(),
+                snapshot,
                 line.asStackItems(),
                 hub.pch().exceptions(),
                 hub.pch().abortingConditions().snapshot(),

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/stack/Stack.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/stack/Stack.java
@@ -78,7 +78,8 @@ public class Stack {
 
   private void zeroOne(MessageFrame ignoredFrame, StackContext pending) {
     pending.addArmingLine(
-        new IndexedStackOperation(4, StackItem.push((short) (height + 1), stackStampWithOffset(0))));
+        new IndexedStackOperation(
+            4, StackItem.push((short) (height + 1), stackStampWithOffset(0))));
   }
 
   private void oneOne(MessageFrame frame, StackContext pending) {
@@ -95,8 +96,10 @@ public class Stack {
 
     pending.addArmingLine(
         new IndexedStackOperation(1, StackItem.pop(height, val1, stackStampWithOffset(0))),
-        new IndexedStackOperation(2, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))),
-        new IndexedStackOperation(4, StackItem.push((short) (height - 1), stackStampWithOffset(2))));
+        new IndexedStackOperation(
+            2, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))),
+        new IndexedStackOperation(
+            4, StackItem.push((short) (height - 1), stackStampWithOffset(2))));
   }
 
   private void threeOne(MessageFrame frame, StackContext pending) {
@@ -106,9 +109,12 @@ public class Stack {
 
     pending.addArmingLine(
         new IndexedStackOperation(1, StackItem.pop(height, val1, stackStampWithOffset(0))),
-        new IndexedStackOperation(2, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))),
-        new IndexedStackOperation(3, StackItem.pop((short) (height - 2), val3, stackStampWithOffset(2))),
-        new IndexedStackOperation(4, StackItem.push((short) (height - 2), stackStampWithOffset(3))));
+        new IndexedStackOperation(
+            2, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))),
+        new IndexedStackOperation(
+            3, StackItem.pop((short) (height - 2), val3, stackStampWithOffset(2))),
+        new IndexedStackOperation(
+            4, StackItem.push((short) (height - 2), stackStampWithOffset(3))));
   }
 
   private void loadStore(MessageFrame frame, StackContext pending) {
@@ -118,7 +124,8 @@ public class Stack {
 
       pending.addLine(
           new IndexedStackOperation(1, StackItem.pop(height, val1, stackStampWithOffset(0))),
-          new IndexedStackOperation(4, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))));
+          new IndexedStackOperation(
+              4, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))));
     } else {
       Bytes val = getStack(frame, 0);
 
@@ -133,7 +140,8 @@ public class Stack {
     Bytes val = getStack(frame, depth);
 
     pending.addLine(
-        new IndexedStackOperation(1, StackItem.pop((short) (height - depth), val, stackStampWithOffset(0))),
+        new IndexedStackOperation(
+            1, StackItem.pop((short) (height - depth), val, stackStampWithOffset(0))),
         new IndexedStackOperation(
             2, StackItem.pushImmediate((short) (height - depth), val, stackStampWithOffset(1))),
         new IndexedStackOperation(
@@ -146,7 +154,8 @@ public class Stack {
     Bytes val2 = getStack(frame, depth);
 
     pending.addLine(
-        new IndexedStackOperation(1, StackItem.pop((short) (height - depth), val1, stackStampWithOffset(0))),
+        new IndexedStackOperation(
+            1, StackItem.pop((short) (height - depth), val1, stackStampWithOffset(0))),
         new IndexedStackOperation(2, StackItem.pop(height, val2, stackStampWithOffset(1))),
         new IndexedStackOperation(
             3, StackItem.pushImmediate((short) (height - depth), val2, stackStampWithOffset(2))),
@@ -161,7 +170,8 @@ public class Stack {
     // Stack line 1
     pending.addLine(
         new IndexedStackOperation(1, StackItem.pop(height, offset, stackStampWithOffset(0))),
-        new IndexedStackOperation(2, StackItem.pop((short) (height - 1), size, stackStampWithOffset(1))));
+        new IndexedStackOperation(
+            2, StackItem.pop((short) (height - 1), size, stackStampWithOffset(1))));
 
     // Stack line 2
     IndexedStackOperation[] line2 = new IndexedStackOperation[] {};
@@ -234,9 +244,12 @@ public class Stack {
       Bytes val3 = getStack(frame, 3);
 
       pending.addLine(
-          new IndexedStackOperation(1, StackItem.pop((short) (height - 1), val1, stackStampWithOffset(1))),
-          new IndexedStackOperation(2, StackItem.pop((short) (height - 3), val3, stackStampWithOffset(2))),
-          new IndexedStackOperation(3, StackItem.pop((short) (height - 2), val2, stackStampWithOffset(3))),
+          new IndexedStackOperation(
+              1, StackItem.pop((short) (height - 1), val1, stackStampWithOffset(1))),
+          new IndexedStackOperation(
+              2, StackItem.pop((short) (height - 3), val3, stackStampWithOffset(2))),
+          new IndexedStackOperation(
+              3, StackItem.pop((short) (height - 2), val2, stackStampWithOffset(3))),
           new IndexedStackOperation(4, StackItem.pop(height, val0, stamp)));
     } else {
       Bytes val1 = getStack(frame, 0);
@@ -245,8 +258,10 @@ public class Stack {
 
       pending.addLine(
           new IndexedStackOperation(1, StackItem.pop(height, val1, stackStampWithOffset(1))),
-          new IndexedStackOperation(2, StackItem.pop((short) (height - 2), val2, stackStampWithOffset(2))),
-          new IndexedStackOperation(3, StackItem.pop((short) (height - 1), val3, stackStampWithOffset(3))));
+          new IndexedStackOperation(
+              2, StackItem.pop((short) (height - 2), val2, stackStampWithOffset(2))),
+          new IndexedStackOperation(
+              3, StackItem.pop((short) (height - 1), val3, stackStampWithOffset(3))));
     }
   }
 
@@ -264,27 +279,40 @@ public class Stack {
       Bytes val7 = getStack(frame, 6);
 
       pending.addLine(
-          new IndexedStackOperation(1, StackItem.pop((short) (height - 3), val4, stackStampWithOffset(3))),
-          new IndexedStackOperation(2, StackItem.pop((short) (height - 4), val5, stackStampWithOffset(4))),
-          new IndexedStackOperation(3, StackItem.pop((short) (height - 5), val6, stackStampWithOffset(5))),
-          new IndexedStackOperation(4, StackItem.pop((short) (height - 6), val7, stackStampWithOffset(6))));
+          new IndexedStackOperation(
+              1, StackItem.pop((short) (height - 3), val4, stackStampWithOffset(3))),
+          new IndexedStackOperation(
+              2, StackItem.pop((short) (height - 4), val5, stackStampWithOffset(4))),
+          new IndexedStackOperation(
+              3, StackItem.pop((short) (height - 5), val6, stackStampWithOffset(5))),
+          new IndexedStackOperation(
+              4, StackItem.pop((short) (height - 6), val7, stackStampWithOffset(6))));
       pending.addArmingLine(
           new IndexedStackOperation(1, StackItem.pop(height, val1, stackStampWithOffset(0))),
-          new IndexedStackOperation(2, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))),
-          new IndexedStackOperation(3, StackItem.pop((short) (height - 2), val3, stackStampWithOffset(2))),
-          new IndexedStackOperation(4, StackItem.push((short) (height - 6), stackStampWithOffset(7))));
+          new IndexedStackOperation(
+              2, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))),
+          new IndexedStackOperation(
+              3, StackItem.pop((short) (height - 2), val3, stackStampWithOffset(2))),
+          new IndexedStackOperation(
+              4, StackItem.push((short) (height - 6), stackStampWithOffset(7))));
     } else {
 
       pending.addLine(
-          new IndexedStackOperation(1, StackItem.pop((short) (height - 2), val3, stackStampWithOffset(3))),
-          new IndexedStackOperation(2, StackItem.pop((short) (height - 3), val4, stackStampWithOffset(4))),
-          new IndexedStackOperation(3, StackItem.pop((short) (height - 4), val5, stackStampWithOffset(5))),
-          new IndexedStackOperation(4, StackItem.pop((short) (height - 5), val6, stackStampWithOffset(6))));
+          new IndexedStackOperation(
+              1, StackItem.pop((short) (height - 2), val3, stackStampWithOffset(3))),
+          new IndexedStackOperation(
+              2, StackItem.pop((short) (height - 3), val4, stackStampWithOffset(4))),
+          new IndexedStackOperation(
+              3, StackItem.pop((short) (height - 4), val5, stackStampWithOffset(5))),
+          new IndexedStackOperation(
+              4, StackItem.pop((short) (height - 5), val6, stackStampWithOffset(6))));
 
       pending.addArmingLine(
           new IndexedStackOperation(1, StackItem.pop(height, val1, stackStampWithOffset(0))),
-          new IndexedStackOperation(2, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))),
-          new IndexedStackOperation(4, StackItem.push((short) (height - 5), stackStampWithOffset(7))));
+          new IndexedStackOperation(
+              2, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))),
+          new IndexedStackOperation(
+              4, StackItem.push((short) (height - 5), stackStampWithOffset(7))));
     }
   }
 
@@ -293,17 +321,21 @@ public class Stack {
     final Bytes val2 = getStack(frame, 2);
 
     pending.addLine(
-        new IndexedStackOperation(1, StackItem.pop((short) (height - 1), val1, stackStampWithOffset(1))),
-        new IndexedStackOperation(2, StackItem.pop((short) (height - 2), val2, stackStampWithOffset(2))));
+        new IndexedStackOperation(
+            1, StackItem.pop((short) (height - 1), val1, stackStampWithOffset(1))),
+        new IndexedStackOperation(
+            2, StackItem.pop((short) (height - 2), val2, stackStampWithOffset(2))));
     // case CREATE2
     if (currentOpcodeData.stackSettings().flag2()) {
       final Bytes val3 = getStack(frame, 3);
       final Bytes val4 = getStack(frame, 0);
 
       pending.addArmingLine(
-          new IndexedStackOperation(2, StackItem.pop((short) (height - 3), val3, stackStampWithOffset(3))),
+          new IndexedStackOperation(
+              2, StackItem.pop((short) (height - 3), val3, stackStampWithOffset(3))),
           new IndexedStackOperation(3, StackItem.pop(height, val4, stackStampWithOffset(0))),
-          new IndexedStackOperation(4, StackItem.push((short) (height - 3), stackStampWithOffset(4))));
+          new IndexedStackOperation(
+              4, StackItem.push((short) (height - 3), stackStampWithOffset(4))));
     } else
     // case CREATE
     {
@@ -311,7 +343,8 @@ public class Stack {
 
       pending.addArmingLine(
           new IndexedStackOperation(3, StackItem.pop(height, val4, stackStampWithOffset(0))),
-          new IndexedStackOperation(4, StackItem.push((short) (height - 2), stackStampWithOffset(4))));
+          new IndexedStackOperation(
+              4, StackItem.push((short) (height - 2), stackStampWithOffset(4))));
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/stack/Stack.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/stack/Stack.java
@@ -31,8 +31,8 @@ public class Stack {
   public static final byte PUSH = 1;
   public static final byte POP = 2;
 
-  @Getter int height;
-  @Getter int heightNew;
+  @Getter short height;
+  @Getter short heightNew;
   @Getter OpCodeData currentOpcodeData;
   Status status;
   int stamp;
@@ -78,7 +78,7 @@ public class Stack {
 
   private void zeroOne(MessageFrame ignoredFrame, StackContext pending) {
     pending.addArmingLine(
-        new IndexedStackOperation(4, StackItem.push(height + 1, stackStampWithOffset(0))));
+        new IndexedStackOperation(4, StackItem.push((short) (height + 1), stackStampWithOffset(0))));
   }
 
   private void oneOne(MessageFrame frame, StackContext pending) {
@@ -95,8 +95,8 @@ public class Stack {
 
     pending.addArmingLine(
         new IndexedStackOperation(1, StackItem.pop(height, val1, stackStampWithOffset(0))),
-        new IndexedStackOperation(2, StackItem.pop(height - 1, val2, stackStampWithOffset(1))),
-        new IndexedStackOperation(4, StackItem.push(height - 1, stackStampWithOffset(2))));
+        new IndexedStackOperation(2, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))),
+        new IndexedStackOperation(4, StackItem.push((short) (height - 1), stackStampWithOffset(2))));
   }
 
   private void threeOne(MessageFrame frame, StackContext pending) {
@@ -106,9 +106,9 @@ public class Stack {
 
     pending.addArmingLine(
         new IndexedStackOperation(1, StackItem.pop(height, val1, stackStampWithOffset(0))),
-        new IndexedStackOperation(2, StackItem.pop(height - 1, val2, stackStampWithOffset(1))),
-        new IndexedStackOperation(3, StackItem.pop(height - 2, val3, stackStampWithOffset(2))),
-        new IndexedStackOperation(4, StackItem.push(height - 2, stackStampWithOffset(3))));
+        new IndexedStackOperation(2, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))),
+        new IndexedStackOperation(3, StackItem.pop((short) (height - 2), val3, stackStampWithOffset(2))),
+        new IndexedStackOperation(4, StackItem.push((short) (height - 2), stackStampWithOffset(3))));
   }
 
   private void loadStore(MessageFrame frame, StackContext pending) {
@@ -118,7 +118,7 @@ public class Stack {
 
       pending.addLine(
           new IndexedStackOperation(1, StackItem.pop(height, val1, stackStampWithOffset(0))),
-          new IndexedStackOperation(4, StackItem.pop(height - 1, val2, stackStampWithOffset(1))));
+          new IndexedStackOperation(4, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))));
     } else {
       Bytes val = getStack(frame, 0);
 
@@ -133,11 +133,11 @@ public class Stack {
     Bytes val = getStack(frame, depth);
 
     pending.addLine(
-        new IndexedStackOperation(1, StackItem.pop(height - depth, val, stackStampWithOffset(0))),
+        new IndexedStackOperation(1, StackItem.pop((short) (height - depth), val, stackStampWithOffset(0))),
         new IndexedStackOperation(
-            2, StackItem.pushImmediate(height - depth, val, stackStampWithOffset(1))),
+            2, StackItem.pushImmediate((short) (height - depth), val, stackStampWithOffset(1))),
         new IndexedStackOperation(
-            4, StackItem.pushImmediate(height + 1, val, stackStampWithOffset(2))));
+            4, StackItem.pushImmediate((short) (height + 1), val, stackStampWithOffset(2))));
   }
 
   private void swap(MessageFrame frame, StackContext pending) {
@@ -146,10 +146,10 @@ public class Stack {
     Bytes val2 = getStack(frame, depth);
 
     pending.addLine(
-        new IndexedStackOperation(1, StackItem.pop(height - depth, val1, stackStampWithOffset(0))),
+        new IndexedStackOperation(1, StackItem.pop((short) (height - depth), val1, stackStampWithOffset(0))),
         new IndexedStackOperation(2, StackItem.pop(height, val2, stackStampWithOffset(1))),
         new IndexedStackOperation(
-            3, StackItem.pushImmediate(height - depth, val2, stackStampWithOffset(2))),
+            3, StackItem.pushImmediate((short) (height - depth), val2, stackStampWithOffset(2))),
         new IndexedStackOperation(
             4, StackItem.pushImmediate(height, val1, stackStampWithOffset(3))));
   }
@@ -161,7 +161,7 @@ public class Stack {
     // Stack line 1
     pending.addLine(
         new IndexedStackOperation(1, StackItem.pop(height, offset, stackStampWithOffset(0))),
-        new IndexedStackOperation(2, StackItem.pop(height - 1, size, stackStampWithOffset(1))));
+        new IndexedStackOperation(2, StackItem.pop((short) (height - 1), size, stackStampWithOffset(1))));
 
     // Stack line 2
     IndexedStackOperation[] line2 = new IndexedStackOperation[] {};
@@ -173,7 +173,7 @@ public class Stack {
         line2 =
             new IndexedStackOperation[] {
               new IndexedStackOperation(
-                  1, StackItem.pop(height - 2, topic1, stackStampWithOffset(0))),
+                  1, StackItem.pop((short) (height - 2), topic1, stackStampWithOffset(0))),
             };
       }
       case LOG2 -> {
@@ -183,9 +183,9 @@ public class Stack {
         line2 =
             new IndexedStackOperation[] {
               new IndexedStackOperation(
-                  1, StackItem.pop(height - 2, topic1, stackStampWithOffset(2))),
+                  1, StackItem.pop((short) (height - 2), topic1, stackStampWithOffset(2))),
               new IndexedStackOperation(
-                  2, StackItem.pop(height - 3, topic2, stackStampWithOffset(3))),
+                  2, StackItem.pop((short) (height - 3), topic2, stackStampWithOffset(3))),
             };
       }
       case LOG3 -> {
@@ -196,11 +196,11 @@ public class Stack {
         line2 =
             new IndexedStackOperation[] {
               new IndexedStackOperation(
-                  1, StackItem.pop(height - 2, topic1, stackStampWithOffset(2))),
+                  1, StackItem.pop((short) (height - 2), topic1, stackStampWithOffset(2))),
               new IndexedStackOperation(
-                  2, StackItem.pop(height - 3, topic2, stackStampWithOffset(3))),
+                  2, StackItem.pop((short) (height - 3), topic2, stackStampWithOffset(3))),
               new IndexedStackOperation(
-                  3, StackItem.pop(height - 4, topic3, stackStampWithOffset(4))),
+                  3, StackItem.pop((short) (height - 4), topic3, stackStampWithOffset(4))),
             };
       }
       case LOG4 -> {
@@ -212,13 +212,13 @@ public class Stack {
         line2 =
             new IndexedStackOperation[] {
               new IndexedStackOperation(
-                  1, StackItem.pop(height - 2, topic1, stackStampWithOffset(2))),
+                  1, StackItem.pop((short) (height - 2), topic1, stackStampWithOffset(2))),
               new IndexedStackOperation(
-                  2, StackItem.pop(height - 3, topic2, stackStampWithOffset(3))),
+                  2, StackItem.pop((short) (height - 3), topic2, stackStampWithOffset(3))),
               new IndexedStackOperation(
-                  3, StackItem.pop(height - 4, topic3, stackStampWithOffset(4))),
+                  3, StackItem.pop((short) (height - 4), topic3, stackStampWithOffset(4))),
               new IndexedStackOperation(
-                  4, StackItem.pop(height - 5, topic4, stackStampWithOffset(5))),
+                  4, StackItem.pop((short) (height - 5), topic4, stackStampWithOffset(5))),
             };
       }
       default -> throw new RuntimeException("not a LOGx");
@@ -234,9 +234,9 @@ public class Stack {
       Bytes val3 = getStack(frame, 3);
 
       pending.addLine(
-          new IndexedStackOperation(1, StackItem.pop(height - 1, val1, stackStampWithOffset(1))),
-          new IndexedStackOperation(2, StackItem.pop(height - 3, val3, stackStampWithOffset(2))),
-          new IndexedStackOperation(3, StackItem.pop(height - 2, val2, stackStampWithOffset(3))),
+          new IndexedStackOperation(1, StackItem.pop((short) (height - 1), val1, stackStampWithOffset(1))),
+          new IndexedStackOperation(2, StackItem.pop((short) (height - 3), val3, stackStampWithOffset(2))),
+          new IndexedStackOperation(3, StackItem.pop((short) (height - 2), val2, stackStampWithOffset(3))),
           new IndexedStackOperation(4, StackItem.pop(height, val0, stamp)));
     } else {
       Bytes val1 = getStack(frame, 0);
@@ -245,8 +245,8 @@ public class Stack {
 
       pending.addLine(
           new IndexedStackOperation(1, StackItem.pop(height, val1, stackStampWithOffset(1))),
-          new IndexedStackOperation(2, StackItem.pop(height - 2, val2, stackStampWithOffset(2))),
-          new IndexedStackOperation(3, StackItem.pop(height - 1, val3, stackStampWithOffset(3))));
+          new IndexedStackOperation(2, StackItem.pop((short) (height - 2), val2, stackStampWithOffset(2))),
+          new IndexedStackOperation(3, StackItem.pop((short) (height - 1), val3, stackStampWithOffset(3))));
     }
   }
 
@@ -264,27 +264,27 @@ public class Stack {
       Bytes val7 = getStack(frame, 6);
 
       pending.addLine(
-          new IndexedStackOperation(1, StackItem.pop(height - 3, val4, stackStampWithOffset(3))),
-          new IndexedStackOperation(2, StackItem.pop(height - 4, val5, stackStampWithOffset(4))),
-          new IndexedStackOperation(3, StackItem.pop(height - 5, val6, stackStampWithOffset(5))),
-          new IndexedStackOperation(4, StackItem.pop(height - 6, val7, stackStampWithOffset(6))));
+          new IndexedStackOperation(1, StackItem.pop((short) (height - 3), val4, stackStampWithOffset(3))),
+          new IndexedStackOperation(2, StackItem.pop((short) (height - 4), val5, stackStampWithOffset(4))),
+          new IndexedStackOperation(3, StackItem.pop((short) (height - 5), val6, stackStampWithOffset(5))),
+          new IndexedStackOperation(4, StackItem.pop((short) (height - 6), val7, stackStampWithOffset(6))));
       pending.addArmingLine(
           new IndexedStackOperation(1, StackItem.pop(height, val1, stackStampWithOffset(0))),
-          new IndexedStackOperation(2, StackItem.pop(height - 1, val2, stackStampWithOffset(1))),
-          new IndexedStackOperation(3, StackItem.pop(height - 2, val3, stackStampWithOffset(2))),
-          new IndexedStackOperation(4, StackItem.push(height - 6, stackStampWithOffset(7))));
+          new IndexedStackOperation(2, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))),
+          new IndexedStackOperation(3, StackItem.pop((short) (height - 2), val3, stackStampWithOffset(2))),
+          new IndexedStackOperation(4, StackItem.push((short) (height - 6), stackStampWithOffset(7))));
     } else {
 
       pending.addLine(
-          new IndexedStackOperation(1, StackItem.pop(height - 2, val3, stackStampWithOffset(3))),
-          new IndexedStackOperation(2, StackItem.pop(height - 3, val4, stackStampWithOffset(4))),
-          new IndexedStackOperation(3, StackItem.pop(height - 4, val5, stackStampWithOffset(5))),
-          new IndexedStackOperation(4, StackItem.pop(height - 5, val6, stackStampWithOffset(6))));
+          new IndexedStackOperation(1, StackItem.pop((short) (height - 2), val3, stackStampWithOffset(3))),
+          new IndexedStackOperation(2, StackItem.pop((short) (height - 3), val4, stackStampWithOffset(4))),
+          new IndexedStackOperation(3, StackItem.pop((short) (height - 4), val5, stackStampWithOffset(5))),
+          new IndexedStackOperation(4, StackItem.pop((short) (height - 5), val6, stackStampWithOffset(6))));
 
       pending.addArmingLine(
           new IndexedStackOperation(1, StackItem.pop(height, val1, stackStampWithOffset(0))),
-          new IndexedStackOperation(2, StackItem.pop(height - 1, val2, stackStampWithOffset(1))),
-          new IndexedStackOperation(4, StackItem.push(height - 5, stackStampWithOffset(7))));
+          new IndexedStackOperation(2, StackItem.pop((short) (height - 1), val2, stackStampWithOffset(1))),
+          new IndexedStackOperation(4, StackItem.push((short) (height - 5), stackStampWithOffset(7))));
     }
   }
 
@@ -293,17 +293,17 @@ public class Stack {
     final Bytes val2 = getStack(frame, 2);
 
     pending.addLine(
-        new IndexedStackOperation(1, StackItem.pop(height - 1, val1, stackStampWithOffset(1))),
-        new IndexedStackOperation(2, StackItem.pop(height - 2, val2, stackStampWithOffset(2))));
+        new IndexedStackOperation(1, StackItem.pop((short) (height - 1), val1, stackStampWithOffset(1))),
+        new IndexedStackOperation(2, StackItem.pop((short) (height - 2), val2, stackStampWithOffset(2))));
     // case CREATE2
     if (currentOpcodeData.stackSettings().flag2()) {
       final Bytes val3 = getStack(frame, 3);
       final Bytes val4 = getStack(frame, 0);
 
       pending.addArmingLine(
-          new IndexedStackOperation(2, StackItem.pop(height - 3, val3, stackStampWithOffset(3))),
+          new IndexedStackOperation(2, StackItem.pop((short) (height - 3), val3, stackStampWithOffset(3))),
           new IndexedStackOperation(3, StackItem.pop(height, val4, stackStampWithOffset(0))),
-          new IndexedStackOperation(4, StackItem.push(height - 3, stackStampWithOffset(4))));
+          new IndexedStackOperation(4, StackItem.push((short) (height - 3), stackStampWithOffset(4))));
     } else
     // case CREATE
     {
@@ -311,7 +311,7 @@ public class Stack {
 
       pending.addArmingLine(
           new IndexedStackOperation(3, StackItem.pop(height, val4, stackStampWithOffset(0))),
-          new IndexedStackOperation(4, StackItem.push(height - 2, stackStampWithOffset(4))));
+          new IndexedStackOperation(4, StackItem.push((short) (height - 2), stackStampWithOffset(4))));
     }
   }
 
@@ -346,7 +346,7 @@ public class Stack {
     final int delta = currentOpcodeData.stackSettings().delta();
 
     Preconditions.checkArgument(heightNew == frame.stackSize());
-    height = frame.stackSize();
+    height = (short) frame.stackSize();
     heightNew += currentOpcodeData.stackSettings().nbAdded();
     heightNew -= currentOpcodeData.stackSettings().nbRemoved();
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/stack/StackItem.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/stack/StackItem.java
@@ -36,7 +36,7 @@ public final class StackItem {
    * The relative height of the element with regard to the stack height just before executing the
    * linked EVM instruction.
    */
-  @Getter private final int height;
+  @Getter private final short height;
 
   /** The value having been popped from/pushed on the stack. */
   @Getter @Setter private Bytes value;
@@ -65,23 +65,23 @@ public final class StackItem {
     this.stackStamp = 0;
   }
 
-  StackItem(int height, Bytes value, byte action, int stackStamp) {
+  StackItem(short height, Bytes value, byte action, int stackStamp) {
     this.height = height;
     this.value = value;
     this.action = action;
     this.stackStamp = stackStamp;
   }
 
-  public static StackItem pop(int height, Bytes value, int stackStamp) {
+  public static StackItem pop(short height, Bytes value, int stackStamp) {
     return new StackItem(height, value, Stack.POP, stackStamp);
   }
 
-  public static StackItem push(int height, int stackStamp) {
+  public static StackItem push(short height, int stackStamp) {
     return new StackItem(
         height, MARKER /* marker value, erased on unlatching */, Stack.PUSH, stackStamp);
   }
 
-  public static StackItem pushImmediate(int height, Bytes val, int stackStamp) {
+  public static StackItem pushImmediate(short height, Bytes val, int stackStamp) {
     return new StackItem(height, val.copy(), Stack.PUSH, stackStamp);
   }
 }


### PR DESCRIPTION
Improve StackItem memory footprint by changing height field from int to short.
By analyzing https://github.com/Consensys/linea-tracer/pull/1376 in details, we found that because of the padding mechanism to have multiples of 8, the whole memory gain is actually only 24 * 3 bytes = 72 bytes :sweat_smile:

This is because using a reference to Action or having a primitive byte make StackItem use in both cases 32 bytes. If we change the height from int to short (4 bytes to 2 bytes) this will reduce the shallow size from 32 to 24 bytes.
StackOperation with action as a Action (enum)
```
**Memory layout of StackItem:**
lineatracer.StackItem object internals:
OFF  SZ                            TYPE DESCRIPTION                 VALUE
  0   8                                 (object header: mark)       0x0000000000000005 (biasable; age: 0)
  8   4                                 (object header: class)      0x000e6da0
 12   4                             int StackOperation.height       0
 16   4                             int StackOperation.stackStamp   0
 20   4   org.apache.tuweni.bytes.Bytes StackOperation.value        (object)
 24   4              lineatracer.Action StackOperation.action       (object)
 28   4                                 (object alignment gap)      
Instance size: 32 bytes
Space losses: 0 bytes internal + 4 bytes external = 4 bytes total
```

**StackOperation with action as a primitive byte**
```
Memory layout of StackOperation:
lineatracer.StackItem object internals:
OFF  SZ                            TYPE DESCRIPTION                 VALUE
  0   8                                 (object header: mark)       0x0000000000000005 (biasable; age: 0)
  8   4                                 (object header: class)      0x000e6da0
 12   4                             int StackOperation.height       0
 16   4                             int StackOperation.stackStamp   0
 20   1                            byte StackOperation.action       0
 21   3                                 (alignment/padding gap)     
 24   4   org.apache.tuweni.bytes.Bytes StackOperation.value        (object)
 28   4                                 (object alignment gap)      
Instance size: 32 bytes
Space losses: 3 bytes internal + 4 bytes external = 7 bytes total
```
If we make height a short, so basically going from -32,768 to 32,767, StackItem will consume 24 bytes shallow size instead of 32.
```
lineatracer.StackItem object internals:
OFF  SZ                            TYPE DESCRIPTION                 VALUE
  0   8                                 (object header: mark)       0x0000000000000005 (biasable; age: 0)
  8   4                                 (object header: class)      0x000e6da0
 12   4                             int StackOperation.stackStamp   0
 16   2                           short StackOperation.height       0
 18   1                            byte StackOperation.action       0
 19   1                                 (alignment/padding gap)     
 20   4   org.apache.tuweni.bytes.Bytes StackOperation.value        (object)
Instance size: 24 bytes
Space losses: 1 bytes internal + 0 bytes external = 1 bytes total
```