### PR TITLE
Debug blockchain reference test 455

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -267,12 +267,15 @@ public class ZkTracer implements ConflationAwareOperationTracer {
       }
     }
   }
+  static int counter = 0;
 
   @Override
   public void traceContextEnter(MessageFrame frame) {
     // We only want to trigger on creation of new contexts, not on re-entry in
     // existing contexts
+    counter += 1;
     if (frame.getState() == MessageFrame.State.NOT_STARTED) {
+      log.info("Message frame not started, invoking hub.traceContextEnter, {}", counter);
       try {
         this.hub.traceContextEnter(frame);
         this.debugMode.ifPresent(x -> x.traceContextEnter(frame));

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -48,6 +48,13 @@ tasks.withType(Test).configureEach {
 
   jvmArgs = [
     '-XX:-UseGCOverheadLimit',
+//    '-XX:InitiatingHeapOccupancyPercent=70',
+    '-XX:+PrintGC',
+//    '-XX:+PrintGCDetails',
+//    '-XX:+UnlockExperimentalVMOptions',
+//    '-XX:+UseZGC',
+//    '-XX:+HeapDumpOnOutOfMemoryError',
+//    '-Dfile.encoding=UTF-8',
     // Mockito and jackson-databind do some strange reflection during tests.
     // This suppresses an illegal access warning.
     '--add-opens',

--- a/reference-tests/build.gradle
+++ b/reference-tests/build.gradle
@@ -56,11 +56,11 @@ tasks.register("generateGeneralStateReferenceTests", RefTestGenerationTask) {
 
 tasks.register('referenceBlockchainTests', Test) {
   description = 'Runs ETH reference blockchain tests.'
-  dependsOn generateBlockchainReferenceTests
+//  dependsOn generateBlockchainReferenceTests
 
   boolean isCiServer = System.getenv().containsKey("CI")
   minHeapSize = isCiServer ? "8g" :"4g"
-  maxHeapSize = isCiServer ? "50g" : "8g"
+  maxHeapSize = isCiServer ? "50g" : "16g"
 
   useJUnitPlatform {
     includeTags("BlockchainReferenceTest")
@@ -88,7 +88,8 @@ tasks.register('referenceGeneralStateTests', Test) {
     dependsOn buildReferenceTestsZkevmBin
     environment.put("ZKEVM_BIN", "zkevm_for_reference_tests.bin")
 
-    systemProperty("junit.jupiter.execution.timeout.default", "5 m")  // 5 minutes
+    systemProperty("junit.jupiter.execution.timeout.default", "45 m")  // 5 minutes
+//    systemProperty("junit.jupiter.execution.timeout.thread.mode.default", "separate_thread")
     systemProperty("junit.jupiter.execution.parallel.enabled", "true")
     systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
     systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")

--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -221,7 +221,7 @@ public class BlockchainReferenceTestTools {
 
     zkTracer.traceEndConflation(worldState);
 
-    ExecutionEnvironment.checkTracer(zkTracer, CORSET_VALIDATOR, Optional.of(log));
+//    ExecutionEnvironment.checkTracer(zkTracer, CORSET_VALIDATOR, Optional.of(log));
 
     assertThat(blockchain.getChainHeadHash()).isEqualTo(spec.getLastBlockHash());
   }

--- a/reference-tests/src/test/resources/templates/BlockchainReferenceTest.java.template
+++ b/reference-tests/src/test/resources/templates/BlockchainReferenceTest.java.template
@@ -18,16 +18,13 @@ package net.consensys.linea.generated.blockchain;
 import static net.consensys.linea.BlockchainReferenceTestTools.executeTest;
 import static net.consensys.linea.BlockchainReferenceTestTools.generateTestParametersForConfig;
 
+import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
-import net.consensys.linea.ReferenceTestWatcher;
 import org.hyperledger.besu.ethereum.referencetests.BlockchainReferenceTestCaseSpec;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -35,13 +32,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /** The blockchain test operation testing framework entry point. */
-@ExtendWith(ReferenceTestWatcher.class)
 @Tag("BlockchainReferenceTest")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Execution(ExecutionMode.CONCURRENT)
 public class %%TESTS_NAME%% {
-
-  public ReferenceTestWatcher testWatcher = new ReferenceTestWatcher();
 
   private static final String FAILED_MODULE = "%%FAILED_MODULE%%";
   private static final String FAILED_CONSTRAINT = "%%FAILED_CONSTRAINT%%";
@@ -49,15 +42,14 @@ public class %%TESTS_NAME%% {
 
   public static Stream<Arguments> getTestParametersForConfig()
         throws ExecutionException, InterruptedException {
-    if (FAILED_MODULE.isEmpty()) {
-    return generateTestParametersForConfig(TEST_CONFIG_FILE_DIR_PATH).stream().map(params ->
-        Arguments.of(params[0], params[1], params[2])
-        );
-    } else {
-      return generateTestParametersForConfig(TEST_CONFIG_FILE_DIR_PATH, FAILED_MODULE, FAILED_CONSTRAINT).stream().map(params ->
-          Arguments.of(params[0], params[1], params[2])
-      );
+    Collection<Object[]> testParameters = FAILED_MODULE.isEmpty()
+        ? generateTestParametersForConfig(TEST_CONFIG_FILE_DIR_PATH)
+        : generateTestParametersForConfig(TEST_CONFIG_FILE_DIR_PATH, FAILED_MODULE, FAILED_CONSTRAINT);
+    Collection<Object[]> filteredTestParameters = testParameters.stream().filter(params -> (Boolean) params[2]).toList();
+    if (filteredTestParameters.isEmpty()) {
+      return Stream.of(Arguments.of("%%TESTS_NAME%%", null, false));
     }
+    return filteredTestParameters.stream().map(params -> Arguments.of(params[0], params[1], params[2]));
   }
 
   @ParameterizedTest(name = "Name: {0}")

--- a/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
@@ -62,8 +62,9 @@ public class ExecutionEnvironment {
     Path traceFilePath = null;
     try {
       traceFilePath = Files.createTempFile(null, ".lt");
-      zkTracer.writeToFile(traceFilePath);
       final Path finalTraceFilePath = traceFilePath;
+      logger.ifPresent(log -> log.debug("writing trace to {}", finalTraceFilePath));
+      zkTracer.writeToFile(traceFilePath);
       logger.ifPresent(log -> log.debug("trace written to {}", finalTraceFilePath));
       CorsetValidator.Result corsetValidationResult = corsetValidator.validate(traceFilePath);
       assertThat(corsetValidationResult.isValid())


### PR DESCRIPTION
Steps to reproduce the OOM error:
1. Checkout this branch
2. `./gradlew generateBlockchainReferenceTests`
3. In `BlockchainReferenceTest_455.java` set `private static final String[] TEST_CONFIG_FILE_DIR_PATH = { "BlockchainTests/GeneralStateTests/stTimeConsuming/static_Call50000_sha256.json" };`
4. Run BlockchainReferenceTest_455 in the IDE or in terminal `./gradlew reference-tests:referenceBlockchainTests --tests "BlockchainReferenceTest_455"` 

The test case `static_Call50000_sha256_*` in `BlockchainReferenceTest_455` causes the JVM to run out of heap space. Increasing the heap to 24G worked for me.

In this test `ZkTracer.traceContextEnter` is invoked 50000 times (Don't know why), and inside this method  `this.hub.traceContextEnter(frame)` consumes up all the heap.

