### PR TITLE
Fixing `underflowException` in `KeccakSection` and same fix for `blockhash` module

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Blockhash.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Blockhash.java
@@ -31,7 +31,6 @@ import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.defer.PostOpcodeDefer;
-import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Blockhash.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Blockhash.java
@@ -107,10 +107,6 @@ public class Blockhash implements OperationSetModule<BlockhashOperation>, PostOp
   public void resolvePostExecution(
       Hub hub, MessageFrame frame, Operation.OperationResult operationResult) {
 
-    if (Exceptions.any(hub.pch().exceptions())) {
-      return;
-    }
-
     final OpCode opCode = OpCode.of(frame.getCurrentOperation().getOpcode());
     if (opCode == OpCode.BLOCKHASH) {
       final Bytes32 result = Bytes32.leftPad(frame.getStackItem(0));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Blockhash.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Blockhash.java
@@ -31,6 +31,7 @@ import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.defer.PostOpcodeDefer;
+import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
@@ -105,6 +106,11 @@ public class Blockhash implements OperationSetModule<BlockhashOperation>, PostOp
   @Override
   public void resolvePostExecution(
       Hub hub, MessageFrame frame, Operation.OperationResult operationResult) {
+
+    if (Exceptions.any(hub.pch().exceptions())) {
+      return;
+    }
+
     final OpCode opCode = OpCode.of(frame.getCurrentOperation().getOpcode());
     if (opCode == OpCode.BLOCKHASH) {
       final Bytes32 result = Bytes32.leftPad(frame.getStackItem(0));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/KeccakSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/KeccakSection.java
@@ -60,6 +60,11 @@ public class KeccakSection extends TraceSection implements PostOpcodeDefer {
   @Override
   public void resolvePostExecution(
       Hub hub, MessageFrame frame, Operation.OperationResult operationResult) {
+
+    if (Exceptions.any(hub.pch().exceptions())) {
+      return;
+    }
+
     final Bytes32 hashResult = Bytes32.leftPad(frame.getStackItem(0));
 
     // retroactively set HASH_INFO_FLAG and HASH_INFO_KECCAK_HI, HASH_INFO_KECCAK_LO


### PR DESCRIPTION
We also address the `BLOCKHASH` case. Maybe that's undesirable. This "fix" could be
- incorrect given the BLOCKHASH module implementation
- unnecessary or too late: the `BLOCKHASH` module should only be triggered if the underlying instruction is
unexceptional (no `SOX` and no `OOGX`)