### PR TITLE
fix: support regeneration of `GlobalConstants.java` (#952)

### DIFF
--- a/buildSrc/src/main/groovy/TraceFilesTask.groovy
+++ b/buildSrc/src/main/groovy/TraceFilesTask.groovy
@@ -7,6 +7,10 @@ import org.gradle.api.tasks.Optional
 abstract class TraceFilesTask extends Exec {
 
   @Input
+  @Optional
+  abstract Property<String> getClassName()
+
+  @Input
   abstract Property<String> getModule()
 
   @Input
@@ -22,6 +26,10 @@ abstract class TraceFilesTask extends Exec {
                      "-P", module.get(),
                      "-o", "${project.projectDir}/src/main/java/net/consensys/linea/zktracer/module/${moduleDir.getOrElse(module.get())}"
     ]
+    if(className) {
+      arguments.add("-c")
+      arguments.add("${className.get()}")
+    }
     arguments.addAll(files.get().collect({"linea-constraints/${it}"}))
 
     workingDir project.rootDir

--- a/gradle/trace-files.gradle
+++ b/gradle/trace-files.gradle
@@ -113,6 +113,7 @@ tasks.register('binreftable', TraceFilesTask) {
         group "Trace files generation"
         dependsOn corsetExists
 
+	className = "GlobalConstants"
         module = moduleName
         files = [ "${moduleName}/constants.lisp"]
     }


### PR DESCRIPTION
This enables regeneration of the `GlobalConstants.java` via the command `gradle constants`.  This requires Corset `v9.7.15` (which at this time has not yet been released).  The solution is to allow for an override to the class name being produced in Corset.  So, it doesn't always have to generate a file `Trace.java`.  Rather you can specify the class name to generate (in this case, `GlobalConstants`).  The relevant gradle option for the `constants` command is updated to do this.