### PR TITLE
Add nonce to ToyTransactionBuilder and Txn result validator for multi block tests

### DIFF
--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleSolidityTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleSolidityTest.java
@@ -22,12 +22,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
 import net.consensys.linea.testing.SmartContractUtils;
 import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.ToyTransaction;
+import net.consensys.linea.testing.TransactionProcessingResultValidator;
 import net.consensys.linea.testing.Web3jUtils;
 import net.consensys.linea.testing.generated.FrameworkEntrypoint;
 import net.consensys.linea.testing.generated.TestSnippet_Events;
@@ -107,8 +107,8 @@ public class ExampleSolidityTest {
             .keyPair(keyPair)
             .build();
 
-    Consumer<TransactionProcessingResult> resultValidator =
-        (TransactionProcessingResult result) -> {
+    TransactionProcessingResultValidator resultValidator =
+        (Transaction transaction, TransactionProcessingResult result) -> {
           // One event from the snippet
           // One event from the framework entrypoint about contract call
           assertEquals(result.getLogs().size(), 2);
@@ -133,7 +133,7 @@ public class ExampleSolidityTest {
     ToyExecutionEnvironmentV2.builder()
         .accounts(List.of(senderAccount, frameworkEntrypointAccount, snippetAccount))
         .transaction(tx)
-        .testValidator(resultValidator)
+        .transactionProcessingResultValidator(resultValidator)
         .build()
         .run();
   }
@@ -170,8 +170,8 @@ public class ExampleSolidityTest {
             .keyPair(keyPair)
             .build();
 
-    Consumer<TransactionProcessingResult> resultValidator =
-        (TransactionProcessingResult result) -> {
+    TransactionProcessingResultValidator resultValidator =
+        (Transaction transaction, TransactionProcessingResult result) -> {
           assertEquals(result.getLogs().size(), 1);
           TestSnippet_Events.DataNoIndexesEventResponse response =
               TestSnippet_Events.getDataNoIndexesEventFromLog(
@@ -182,7 +182,7 @@ public class ExampleSolidityTest {
     ToyExecutionEnvironmentV2.builder()
         .accounts(List.of(senderAccount, contractAccount))
         .transaction(tx)
-        .testValidator(resultValidator)
+        .transactionProcessingResultValidator(resultValidator)
         .build()
         .run();
   }
@@ -273,8 +273,8 @@ public class ExampleSolidityTest {
     Bytes txPayload =
         Bytes.fromHexStringLenient(FunctionEncoder.encode(frameworkEntryPointFunction));
 
-    Consumer<TransactionProcessingResult> resultValidator =
-        (TransactionProcessingResult result) -> {
+    TransactionProcessingResultValidator resultValidator =
+        (Transaction transaction, TransactionProcessingResult result) -> {
           assertEquals(result.getLogs().size(), 1);
           for (Log log : result.getLogs()) {
             String logTopic = log.getTopics().getFirst().toHexString();
@@ -301,7 +301,7 @@ public class ExampleSolidityTest {
     ToyExecutionEnvironmentV2.builder()
         .accounts(List.of(senderAccount, yulAccount, frameworkEntrypointAccount))
         .transaction(tx)
-        .testValidator(resultValidator)
+        .transactionProcessingResultValidator(resultValidator)
         .build()
         .run();
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mxp/MxpTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mxp/MxpTest.java
@@ -28,6 +28,7 @@ import net.consensys.linea.testing.BytecodeRunner;
 import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.ToyTransaction;
+import net.consensys.linea.testing.TransactionProcessingResultValidator;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.opcode.gas.MxpType;
 import net.consensys.linea.zktracer.types.EWord;
@@ -292,7 +293,12 @@ public class MxpTest {
             contractMO1Account,
             contractMO2Account);
 
-    ToyExecutionEnvironmentV2.builder().accounts(accounts).transaction(tx).build().run();
+    ToyExecutionEnvironmentV2.builder()
+        .accounts(accounts)
+        .transaction(tx)
+        .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
+        .build()
+        .run();
   }
 
   // Support methods

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobCallTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobCallTest.java
@@ -25,6 +25,7 @@ import net.consensys.linea.testing.BytecodeRunner;
 import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.ToyTransaction;
+import net.consensys.linea.testing.TransactionProcessingResultValidator;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.types.EWord;
@@ -199,7 +200,8 @@ public class OobCallTest {
         ToyExecutionEnvironmentV2.builder()
             .accounts(List.of(userAccount, contractCallerAccount, contractCalleeAccount))
             .transaction(tx)
-            .testValidator(x -> {})
+            .transactionProcessingResultValidator(
+                TransactionProcessingResultValidator.EMPTY_VALIDATOR)
             .build();
 
     toyExecutionEnvironmentV2.run();
@@ -251,7 +253,8 @@ public class OobCallTest {
         ToyExecutionEnvironmentV2.builder()
             .accounts(List.of(userAccount, contractCallerAccount))
             .transaction(tx)
-            .testValidator(x -> {})
+            .transactionProcessingResultValidator(
+                TransactionProcessingResultValidator.EMPTY_VALIDATOR)
             .build();
 
     toyExecutionEnvironmentV2.run();

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlpaddr/TestRlpAddress.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlpaddr/TestRlpAddress.java
@@ -24,6 +24,7 @@ import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.ToyTransaction;
+import net.consensys.linea.testing.TransactionProcessingResultValidator;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.crypto.KeyPair;
@@ -137,7 +138,7 @@ public class TestRlpAddress {
     ToyExecutionEnvironmentV2.builder()
         .accounts(List.of(senderAccount, contractAccount))
         .transaction(tx)
-        .testValidator(x -> {})
+        .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
         .build()
         .run();
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlptxn/TestRandomTxns.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlptxn/TestRandomTxns.java
@@ -40,7 +40,8 @@ class TestRandomTxns {
   //    ToyExecutionEnvironment.builder()
   //        .toyWorld(world.build())
   //        .transactions(txList)
-  //        .testValidator(x -> {})
+  //
+  // .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
   //        .build()
   //        .run();
   //  }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/stp/StpTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/stp/StpTest.java
@@ -27,6 +27,7 @@ import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.ToyTransaction;
+import net.consensys.linea.testing.TransactionProcessingResultValidator;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.crypto.KeyPair;
@@ -66,7 +67,7 @@ public class StpTest {
     ToyExecutionEnvironmentV2.builder()
         .accounts(world)
         .transactions(txList)
-        .testValidator(x -> {})
+        .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
         .build()
         .run();
   }
@@ -89,7 +90,7 @@ public class StpTest {
     ToyExecutionEnvironmentV2.builder()
         .accounts(world)
         .transactions(txList)
-        .testValidator(x -> {})
+        .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
         .build()
         .run();
   }

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -133,7 +133,7 @@ tasks.register("fastReplayTests", Test) {
     systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
     systemProperty("junit.jupiter.execution.parallel.config.strategy", "fixed")
     systemProperty("junit.jupiter.execution.parallel.config.fixed.parallelism",
-      System.getenv().get("REPLAY_TESTS_PARALLELISM").toInteger())
+      System.getenv().getOrDefault("REPLAY_TESTS_PARALLELISM", "1").toInteger())
   }
   useJUnitPlatform {
     includeTags("replay")
@@ -152,7 +152,7 @@ tasks.register("nightlyReplayTests", Test) {
     systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
     systemProperty("junit.jupiter.execution.parallel.config.strategy", "fixed")
     systemProperty("junit.jupiter.execution.parallel.config.fixed.parallelism",
-      System.getenv().get("REPLAY_TESTS_PARALLELISM").toInteger())
+      System.getenv().getOrDefault("REPLAY_TESTS_PARALLELISM", "1").toInteger())
   }
 
   useJUnitPlatform {

--- a/testing/src/main/java/net/consensys/linea/testing/BytecodeRunner.java
+++ b/testing/src/main/java/net/consensys/linea/testing/BytecodeRunner.java
@@ -113,7 +113,8 @@ public final class BytecodeRunner {
 
     toyExecutionEnvironmentV2 =
         ToyExecutionEnvironmentV2.builder()
-            .testValidator(x -> {})
+            .transactionProcessingResultValidator(
+                TransactionProcessingResultValidator.EMPTY_VALIDATOR)
             .accounts(accounts)
             .zkTracerValidator(zkTracerValidator)
             .transaction(tx)

--- a/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
@@ -92,6 +92,7 @@ public class ExecutionEnvironment {
                 .number(parentBlockHeader.get().getNumber() + 1)
                 .timestamp(parentBlockHeader.get().getTimestamp() + 100)
                 .parentHash(parentBlockHeader.get().getHash())
+                .nonce(parentBlockHeader.get().getNonce() + 1)
                 .blockHeaderFunctions(new CliqueBlockHeaderFunctions())
             : BlockHeaderBuilder.createDefault();
 

--- a/testing/src/main/java/net/consensys/linea/testing/GeneralStateReferenceTestTools.java
+++ b/testing/src/main/java/net/consensys/linea/testing/GeneralStateReferenceTestTools.java
@@ -60,7 +60,7 @@ public class GeneralStateReferenceTestTools {
       final GeneralStateTestCaseEipSpec spec,
       final ProtocolSpec protocolSpec,
       final ZkTracer tracer,
-      final Consumer<TransactionProcessingResult> transactionProcessingResultValidator,
+      final TransactionProcessingResultValidator transactionProcessingResultValidator,
       final Consumer<ZkTracer> zkTracerValidator) {
     final BlockHeader blockHeader = spec.getBlockHeader();
     final ReferenceTestWorldState initialWorldState = spec.getInitialWorldState();
@@ -116,9 +116,6 @@ public class GeneralStateReferenceTestTools {
               TransactionValidationParams.processingBlock(),
               blobGasPrice);
 
-      transactionProcessingResultValidator.accept(result);
-      zkTracerValidator.accept(tracer);
-
       if (result.isInvalid()) {
         final TransactionProcessingResult finalResult = result;
         assertThat(spec.getExpectException())
@@ -126,6 +123,9 @@ public class GeneralStateReferenceTestTools {
             .isNotNull();
         return;
       }
+
+      transactionProcessingResultValidator.accept(transaction, result);
+      zkTracerValidator.accept(tracer);
     }
 
     tracer.traceEndBlock(blockHeader, blockBody);

--- a/testing/src/main/java/net/consensys/linea/testing/MultiBlockExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/MultiBlockExecutionEnvironment.java
@@ -34,6 +34,14 @@ public class MultiBlockExecutionEnvironment {
 
   private final List<BlockSnapshot> blocks;
 
+  /**
+   * A transaction validator of each transaction; by default, it asserts that the transaction was
+   * successfully processed.
+   */
+  @Builder.Default
+  private final TransactionProcessingResultValidator transactionProcessingResultValidator =
+      TransactionProcessingResultValidator.DEFAULT_VALIDATOR;
+
   public static class MultiBlockExecutionEnvironmentBuilder {
 
     private List<BlockSnapshot> blocks = new ArrayList<>();
@@ -55,6 +63,7 @@ public class MultiBlockExecutionEnvironment {
   public void run() {
     ReplayExecutionEnvironment.builder()
         .useCoinbaseAddressFromBlockHeader(true)
+        .transactionProcessingResultValidator(this.transactionProcessingResultValidator)
         .build()
         .replay(ToyExecutionEnvironmentV2.CHAIN_ID, this.buildConflationSnapshot());
   }

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
@@ -30,7 +30,6 @@ import org.hyperledger.besu.datatypes.*;
 import org.hyperledger.besu.ethereum.core.*;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
-import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.referencetests.GeneralStateTestCaseEipSpec;
 import org.hyperledger.besu.ethereum.referencetests.ReferenceTestWorldState;
 
@@ -51,10 +50,12 @@ public class ToyExecutionEnvironmentV2 {
   @Singular private final List<Transaction> transactions;
 
   /**
-   * A function applied to the {@link TransactionProcessingResult} of each transaction; by default,
-   * asserts that the transaction is successful.
+   * A transaction validator of each transaction; by default, it asserts that the transaction was
+   * successfully processed.
    */
-  @Builder.Default private final Consumer<TransactionProcessingResult> testValidator = x -> {};
+  @Builder.Default
+  private final TransactionProcessingResultValidator transactionProcessingResultValidator =
+      TransactionProcessingResultValidator.DEFAULT_VALIDATOR;
 
   @Builder.Default private final Consumer<ZkTracer> zkTracerValidator = x -> {};
 
@@ -66,7 +67,11 @@ public class ToyExecutionEnvironmentV2 {
         this.buildGeneralStateTestCaseSpec(protocolSpec);
 
     GeneralStateReferenceTestTools.executeTest(
-        generalStateTestCaseEipSpec, protocolSpec, tracer, testValidator, zkTracerValidator);
+        generalStateTestCaseEipSpec,
+        protocolSpec,
+        tracer,
+        transactionProcessingResultValidator,
+        zkTracerValidator);
   }
 
   public Hub getHub() {

--- a/testing/src/main/java/net/consensys/linea/testing/ToyTransaction.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyTransaction.java
@@ -59,6 +59,7 @@ public class ToyTransaction {
   private final List<AccessListEntry> accessList;
   private final Wei maxPriorityFeePerGas;
   private final Wei maxFeePerGas;
+  private final Long nonce;
 
   /** Customizations applied to the Lombok generated builder. */
   public static class ToyTransactionBuilder {
@@ -72,7 +73,7 @@ public class ToyTransaction {
       final Transaction.Builder builder =
           Transaction.builder()
               .to(to != null ? to.getAddress() : null)
-              .nonce(sender.getNonce())
+              .nonce(nonce != null ? nonce : sender.getNonce())
               .accessList(accessList)
               .type(Optional.ofNullable(transactionType).orElse(DEFAULT_TX_TYPE))
               .gasPrice(Optional.ofNullable(gasPrice).orElse(DEFAULT_GAS_PRICE))

--- a/testing/src/main/java/net/consensys/linea/testing/TransactionProcessingResultValidator.java
+++ b/testing/src/main/java/net/consensys/linea/testing/TransactionProcessingResultValidator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.testing;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
+
+@FunctionalInterface
+public interface TransactionProcessingResultValidator {
+
+  void accept(Transaction transaction, TransactionProcessingResult transactionProcessingResult);
+
+  TransactionProcessingResultValidator DEFAULT_VALIDATOR =
+      (t, r) -> {
+        assertTrue(
+            r.isSuccessful(),
+            () ->
+                "Transaction: %s not successful. %s"
+                    .formatted(t.getHash().toString(), r.toString()));
+      };
+
+  TransactionProcessingResultValidator EMPTY_VALIDATOR = (t, r) -> {};
+}


### PR DESCRIPTION
This PR:

- Fixes the cases where tests using `ToyExecutionEnvironmentV2` or `MultiBlockExecutionEnvironment` with multiple transactions from the same sender account would fail. These tests fail because because the sender account nonce is updated after each transaction in test framework but the nonce of the following transactions from the same sender are not, which would result in an error like `transaction nonce 5 below sender account nonce 6`.
- Adds ability to use a `TransactionProcessingResultValidator` for `MultiBlockExecutionEnvironment` and `ReplayExecutionEnvironment`.
  - By default the `ReplayExecutionEnvironment` uses an empty `TransactionProcessingResultValidator` that does no validation.
  - By default  `MultiBlockExecutionEnvironment` and `ToyExecutionEnvironmentV2` uses a default `TransactionProcessingResultValidator` that validates if the transaction processing was successful.
  - The TransactionProcessingResultValidator can be overridden as is the case in some tests.