### PR TITLE
feat: support Variable Report Width for Corset

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -84,13 +84,13 @@ jobs:
         run: ./gradlew :arithmetization:test --stacktrace
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
-          CORSET_FLAGS: fields,expand,expand,expand
+          CORSET_FLAGS: trace-span=3,fields,expand,expand,expand
 
       - name: Run Replay tests
         run: ./gradlew :arithmetization:fastReplayTests --stacktrace
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
-          CORSET_FLAGS: fields,expand,expand,expand
+          CORSET_FLAGS: trace-span=3,fields,expand,expand,expand
           REPLAY_TESTS_PARALLELISM: 2
 
       - name: Upload test report

--- a/arithmetization/src/main/java/net/consensys/linea/corset/RustCorsetValidator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/corset/RustCorsetValidator.java
@@ -69,6 +69,13 @@ public class RustCorsetValidator extends AbstractExecutable {
    */
   @Getter @Setter private boolean autoConstraints = false;
 
+  /**
+   * Specifies the number of rows to show either side for a failing constraint. This can faciliate
+   * debugging, since the greater the width the more information can be seen. At the same time,
+   * however, too much information can make the report very hard to read.
+   */
+  @Getter @Setter private int reportWidth = 8;
+
   /** Indicates whether or not this validator is active (i.e. we located the corset binary). */
   @Getter private boolean active = false;
 
@@ -170,8 +177,12 @@ public class RustCorsetValidator extends AbstractExecutable {
               this.autoConstraints = true;
               break;
             default:
-              // Error
-              throw new RuntimeException("Unknown Corset configuration flag: %s".formatted(flag));
+              if (flag.startsWith("trace-span=")) {
+                this.reportWidth = Integer.parseInt(flag.substring(11));
+              } else {
+                // Error
+                throw new RuntimeException("Unknown Corset configuration flag: %s".formatted(flag));
+              }
           }
         }
       }
@@ -215,6 +226,9 @@ public class RustCorsetValidator extends AbstractExecutable {
       options.add("--auto-constraints");
       options.add("nhood,sorts");
     }
+    // Specify span width to use
+    options.add("--trace-span");
+    options.add(Integer.toString(this.reportWidth));
     // Specify number of threads to use.
     options.add("-t");
     options.add(determineNumberOfThreads());


### PR DESCRIPTION
This updates the `CorsetValidator` to support changing the number of trace rows reported for a failing constraint.  The default is firstly changed to `8` (compared with `2` previously).  Secondly, its possible to override the default via the `CORSET_FLAGS` environment variable. This means we can set a small width for the CI pipeline, where horizontal real estate is more limited.