### PR TITLE
Typo Update get-started.md

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -31,7 +31,7 @@ cargo install --git ssh://git@github.com/ConsenSys/corset --locked --force
 git submodule update --init --recursive
 ```
 
-Note: Windows user may have to run 'git config core.protectNTFS false' command within the linea-constraints folder to bypass CON.* file names being reserved.
+Note: Windows users may have to run 'git config core.protectNTFS false' command within the linea-constraints folder to bypass CON.* file names being reserved.
 
 #### Step 6: Install [pre-commit](https://pre-commit.com/)
 


### PR DESCRIPTION
#### Description:
This pull request addresses a small grammatical error in the documentation. The phrase **"Windows user"** has been corrected to **"Windows users"**, as it refers to the general group of users who are using Windows, rather than a single individual.

#### Importance:
The original wording was incorrect because it used the singular form "user" when referring to all Windows users. The correction ensures the language is grammatically accurate and reflects the intended meaning, which is to address users of Windows in general. This kind of detail is important for clarity and professionalism in the documentation.

#### Changes:
- Replaced **"Windows user"** with **"Windows users"** in the relevant section of the documentation.
