### PR TITLE
Remove `CONSTRAINTS_SSH_KEY` from Github Actions

### DIFF
--- a/.github/actions/setup-rust-corset/action.yml
+++ b/.github/actions/setup-rust-corset/action.yml
@@ -9,4 +9,4 @@ runs:
 
     - name: Install Corset
       shell: bash
-      run: RUSTFLAGS=-Awarnings cargo install --git ssh://git@github.com/ConsenSys/corset --tag v9.7.17 --locked --force
+      run: RUSTFLAGS=-Awarnings cargo install --git https://github.com/Consensys/corset.git --tag v9.7.17 --locked --force

--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -12,11 +12,6 @@ jobs:
   ethereum-tests:
     runs-on: ubuntu-latest-128
     steps:
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CONSTRAINTS_SSH_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -60,11 +55,6 @@ jobs:
   ethereum-tests-go-corset:
     runs-on: ubuntu-latest-128
     steps:
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CONSTRAINTS_SSH_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -12,10 +12,6 @@ jobs:
   nightly-tests:
     runs-on: ubuntu-latest-128
     steps:
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CONSTRAINTS_SSH_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/gradle-weekly-tests.yml
+++ b/.github/workflows/gradle-weekly-tests.yml
@@ -12,11 +12,6 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CONSTRAINTS_SSH_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -49,10 +44,6 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CONSTRAINTS_SSH_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -58,11 +58,6 @@ jobs:
         if: ${{ inputs.tests-with-ssh }}
         uses: lhotari/action-upterm@v1
 
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CONSTRAINTS_SSH_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -108,11 +103,6 @@ jobs:
       - name: Setup upterm session
         if: ${{ inputs.tests-with-ssh }}
         uses: lhotari/action-upterm@v1
-
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CONSTRAINTS_SSH_KEY }}
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -22,10 +22,6 @@ jobs:
   blockchain-reference-tests:
     runs-on: [ubuntu-latest-128]
     steps:
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.CONSTRAINTS_SSH_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This removes the need for the `CONSTRAINTS_SSH_KEY` from the Github actions.  This is no longer required since all relevant repositories are now public.