### PR TITLE
fix: Disable Tx Outcome Checks

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/MxpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/MxpOperation.java
@@ -292,7 +292,6 @@ public class MxpOperation extends ModuleOperation {
       maxOffset = max(maxOffset1, maxOffset2);
       mxpCall.setMxpx(maxOffset.compareTo(TWO_POW_32) >= 0);
     }
-    System.out.println("");
   }
 
   public void setExpands() {

--- a/arithmetization/src/test/java/net/consensys/linea/replaytests/ReplayTestTools.java
+++ b/arithmetization/src/test/java/net/consensys/linea/replaytests/ReplayTestTools.java
@@ -96,7 +96,7 @@ public class ReplayTestTools {
    * @param filename Name of replay file
    */
   public static void replay(BigInteger chainId, String filename) {
-    replay(chainId, filename, true);
+    replay(chainId, filename, false);
   }
 
   /**


### PR DESCRIPTION
Currently, the tx outcome checks are failing because of a fix in BESU which affects reported balances in some cases.  The issue is that this fix now invalidates some of the recorded tx outcome data.  Therefore, this data needs to be rerecorded, which will take some time.  As a temporary stop-gap measure, therefore, we can disable the outcome checks to allow PRs to continue as normal.