### PR TITLE
fix: incorrect generation of `Trace.java` files

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/Trace.java
@@ -108,7 +108,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "add.ACC_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -133,7 +134,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "add.ACC_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -158,7 +160,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "add.ARG_1_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -183,7 +186,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "add.ARG_1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -208,7 +212,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "add.ARG_2_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -233,7 +238,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "add.ARG_2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -330,7 +336,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "add.RES_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -355,7 +362,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "add.RES_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -377,7 +385,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("add.STAMP has invalid value (" + b + ")");
     }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/bin/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/bin/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.bin;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -73,44 +74,45 @@ public class Trace {
   private final MappedByteBuffer xxxByteLo;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("bin.ACC_1", 16, length),
-        new ColumnHeader("bin.ACC_2", 16, length),
-        new ColumnHeader("bin.ACC_3", 16, length),
-        new ColumnHeader("bin.ACC_4", 16, length),
-        new ColumnHeader("bin.ACC_5", 16, length),
-        new ColumnHeader("bin.ACC_6", 16, length),
-        new ColumnHeader("bin.ARGUMENT_1_HI", 16, length),
-        new ColumnHeader("bin.ARGUMENT_1_LO", 16, length),
-        new ColumnHeader("bin.ARGUMENT_2_HI", 16, length),
-        new ColumnHeader("bin.ARGUMENT_2_LO", 16, length),
-        new ColumnHeader("bin.BIT_1", 1, length),
-        new ColumnHeader("bin.BIT_B_4", 1, length),
-        new ColumnHeader("bin.BITS", 1, length),
-        new ColumnHeader("bin.BYTE_1", 1, length),
-        new ColumnHeader("bin.BYTE_2", 1, length),
-        new ColumnHeader("bin.BYTE_3", 1, length),
-        new ColumnHeader("bin.BYTE_4", 1, length),
-        new ColumnHeader("bin.BYTE_5", 1, length),
-        new ColumnHeader("bin.BYTE_6", 1, length),
-        new ColumnHeader("bin.COUNTER", 1, length),
-        new ColumnHeader("bin.CT_MAX", 1, length),
-        new ColumnHeader("bin.INST", 1, length),
-        new ColumnHeader("bin.IS_AND", 1, length),
-        new ColumnHeader("bin.IS_BYTE", 1, length),
-        new ColumnHeader("bin.IS_NOT", 1, length),
-        new ColumnHeader("bin.IS_OR", 1, length),
-        new ColumnHeader("bin.IS_SIGNEXTEND", 1, length),
-        new ColumnHeader("bin.IS_XOR", 1, length),
-        new ColumnHeader("bin.LOW_4", 1, length),
-        new ColumnHeader("bin.NEG", 1, length),
-        new ColumnHeader("bin.PIVOT", 1, length),
-        new ColumnHeader("bin.RESULT_HI", 16, length),
-        new ColumnHeader("bin.RESULT_LO", 16, length),
-        new ColumnHeader("bin.SMALL", 1, length),
-        new ColumnHeader("bin.STAMP", 4, length),
-        new ColumnHeader("bin.XXX_BYTE_HI", 1, length),
-        new ColumnHeader("bin.XXX_BYTE_LO", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("bin.ACC_1", 16, length));
+    headers.add(new ColumnHeader("bin.ACC_2", 16, length));
+    headers.add(new ColumnHeader("bin.ACC_3", 16, length));
+    headers.add(new ColumnHeader("bin.ACC_4", 16, length));
+    headers.add(new ColumnHeader("bin.ACC_5", 16, length));
+    headers.add(new ColumnHeader("bin.ACC_6", 16, length));
+    headers.add(new ColumnHeader("bin.ARGUMENT_1_HI", 16, length));
+    headers.add(new ColumnHeader("bin.ARGUMENT_1_LO", 16, length));
+    headers.add(new ColumnHeader("bin.ARGUMENT_2_HI", 16, length));
+    headers.add(new ColumnHeader("bin.ARGUMENT_2_LO", 16, length));
+    headers.add(new ColumnHeader("bin.BIT_1", 1, length));
+    headers.add(new ColumnHeader("bin.BIT_B_4", 1, length));
+    headers.add(new ColumnHeader("bin.BITS", 1, length));
+    headers.add(new ColumnHeader("bin.BYTE_1", 1, length));
+    headers.add(new ColumnHeader("bin.BYTE_2", 1, length));
+    headers.add(new ColumnHeader("bin.BYTE_3", 1, length));
+    headers.add(new ColumnHeader("bin.BYTE_4", 1, length));
+    headers.add(new ColumnHeader("bin.BYTE_5", 1, length));
+    headers.add(new ColumnHeader("bin.BYTE_6", 1, length));
+    headers.add(new ColumnHeader("bin.COUNTER", 1, length));
+    headers.add(new ColumnHeader("bin.CT_MAX", 1, length));
+    headers.add(new ColumnHeader("bin.INST", 1, length));
+    headers.add(new ColumnHeader("bin.IS_AND", 1, length));
+    headers.add(new ColumnHeader("bin.IS_BYTE", 1, length));
+    headers.add(new ColumnHeader("bin.IS_NOT", 1, length));
+    headers.add(new ColumnHeader("bin.IS_OR", 1, length));
+    headers.add(new ColumnHeader("bin.IS_SIGNEXTEND", 1, length));
+    headers.add(new ColumnHeader("bin.IS_XOR", 1, length));
+    headers.add(new ColumnHeader("bin.LOW_4", 1, length));
+    headers.add(new ColumnHeader("bin.NEG", 1, length));
+    headers.add(new ColumnHeader("bin.PIVOT", 1, length));
+    headers.add(new ColumnHeader("bin.RESULT_HI", 16, length));
+    headers.add(new ColumnHeader("bin.RESULT_LO", 16, length));
+    headers.add(new ColumnHeader("bin.SMALL", 1, length));
+    headers.add(new ColumnHeader("bin.STAMP", 4, length));
+    headers.add(new ColumnHeader("bin.XXX_BYTE_HI", 1, length));
+    headers.add(new ColumnHeader("bin.XXX_BYTE_LO", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -172,7 +174,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "bin.ACC_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -197,7 +200,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "bin.ACC_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -222,7 +226,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "bin.ACC_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -247,7 +252,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "bin.ACC_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -272,7 +278,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc5 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "bin.ACC_5 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -297,7 +304,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc6 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "bin.ACC_6 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -323,7 +331,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "argument1Hi has invalid width (" + bs.bitLength() + "bits)");
+          "bin.ARGUMENT_1_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -349,7 +357,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "argument1Lo has invalid width (" + bs.bitLength() + "bits)");
+          "bin.ARGUMENT_1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -375,7 +383,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "argument2Hi has invalid width (" + bs.bitLength() + "bits)");
+          "bin.ARGUMENT_2_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -401,7 +409,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "argument2Lo has invalid width (" + bs.bitLength() + "bits)");
+          "bin.ARGUMENT_2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -678,7 +686,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resultHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "bin.RESULT_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -703,7 +712,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resultLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "bin.RESULT_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -737,7 +747,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("bin.STAMP has invalid value (" + b + ")");
     }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.blake2fmodexpdata;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -57,20 +58,21 @@ public class Trace {
   private final MappedByteBuffer stamp;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("blake2fmodexpdata.ID", 4, length),
-        new ColumnHeader("blake2fmodexpdata.INDEX", 1, length),
-        new ColumnHeader("blake2fmodexpdata.INDEX_MAX", 1, length),
-        new ColumnHeader("blake2fmodexpdata.IS_BLAKE_DATA", 1, length),
-        new ColumnHeader("blake2fmodexpdata.IS_BLAKE_PARAMS", 1, length),
-        new ColumnHeader("blake2fmodexpdata.IS_BLAKE_RESULT", 1, length),
-        new ColumnHeader("blake2fmodexpdata.IS_MODEXP_BASE", 1, length),
-        new ColumnHeader("blake2fmodexpdata.IS_MODEXP_EXPONENT", 1, length),
-        new ColumnHeader("blake2fmodexpdata.IS_MODEXP_MODULUS", 1, length),
-        new ColumnHeader("blake2fmodexpdata.IS_MODEXP_RESULT", 1, length),
-        new ColumnHeader("blake2fmodexpdata.LIMB", 16, length),
-        new ColumnHeader("blake2fmodexpdata.PHASE", 1, length),
-        new ColumnHeader("blake2fmodexpdata.STAMP", 2, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("blake2fmodexpdata.ID", 4, length));
+    headers.add(new ColumnHeader("blake2fmodexpdata.INDEX", 1, length));
+    headers.add(new ColumnHeader("blake2fmodexpdata.INDEX_MAX", 1, length));
+    headers.add(new ColumnHeader("blake2fmodexpdata.IS_BLAKE_DATA", 1, length));
+    headers.add(new ColumnHeader("blake2fmodexpdata.IS_BLAKE_PARAMS", 1, length));
+    headers.add(new ColumnHeader("blake2fmodexpdata.IS_BLAKE_RESULT", 1, length));
+    headers.add(new ColumnHeader("blake2fmodexpdata.IS_MODEXP_BASE", 1, length));
+    headers.add(new ColumnHeader("blake2fmodexpdata.IS_MODEXP_EXPONENT", 1, length));
+    headers.add(new ColumnHeader("blake2fmodexpdata.IS_MODEXP_MODULUS", 1, length));
+    headers.add(new ColumnHeader("blake2fmodexpdata.IS_MODEXP_RESULT", 1, length));
+    headers.add(new ColumnHeader("blake2fmodexpdata.LIMB", 16, length));
+    headers.add(new ColumnHeader("blake2fmodexpdata.PHASE", 1, length));
+    headers.add(new ColumnHeader("blake2fmodexpdata.STAMP", 2, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -105,7 +107,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("id has invalid value (" + b + ")");
+      throw new IllegalArgumentException("blake2fmodexpdata.ID has invalid value (" + b + ")");
     }
     id.put((byte) (b >> 24));
     id.put((byte) (b >> 16));
@@ -234,7 +236,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "blake2fmodexpdata.LIMB has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -268,7 +271,7 @@ public class Trace {
     }
 
     if (b >= 1024L) {
-      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("blake2fmodexpdata.STAMP has invalid value (" + b + ")");
     }
     stamp.put((byte) (b >> 8));
     stamp.put((byte) b);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.blockdata;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -88,51 +89,52 @@ public class Trace {
   private final MappedByteBuffer wcpFlag;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("blockdata.BASEFEE", 6, length),
-        new ColumnHeader("blockdata.BLOCK_GAS_LIMIT", 6, length),
-        new ColumnHeader("blockdata.BYTE_HI_0", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_1", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_10", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_11", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_12", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_13", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_14", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_15", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_2", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_3", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_4", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_5", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_6", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_7", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_8", 1, length),
-        new ColumnHeader("blockdata.BYTE_HI_9", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_0", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_1", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_10", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_11", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_12", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_13", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_14", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_15", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_2", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_3", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_4", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_5", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_6", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_7", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_8", 1, length),
-        new ColumnHeader("blockdata.BYTE_LO_9", 1, length),
-        new ColumnHeader("blockdata.COINBASE_HI", 4, length),
-        new ColumnHeader("blockdata.COINBASE_LO", 16, length),
-        new ColumnHeader("blockdata.CT", 1, length),
-        new ColumnHeader("blockdata.DATA_HI", 16, length),
-        new ColumnHeader("blockdata.DATA_LO", 16, length),
-        new ColumnHeader("blockdata.FIRST_BLOCK_NUMBER", 6, length),
-        new ColumnHeader("blockdata.INST", 1, length),
-        new ColumnHeader("blockdata.REL_BLOCK", 2, length),
-        new ColumnHeader("blockdata.REL_TX_NUM_MAX", 2, length),
-        new ColumnHeader("blockdata.WCP_FLAG", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("blockdata.BASEFEE", 6, length));
+    headers.add(new ColumnHeader("blockdata.BLOCK_GAS_LIMIT", 6, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_0", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_1", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_10", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_11", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_12", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_13", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_14", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_15", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_2", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_3", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_4", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_5", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_6", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_7", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_8", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_HI_9", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_0", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_1", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_10", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_11", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_12", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_13", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_14", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_15", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_2", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_3", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_4", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_5", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_6", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_7", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_8", 1, length));
+    headers.add(new ColumnHeader("blockdata.BYTE_LO_9", 1, length));
+    headers.add(new ColumnHeader("blockdata.COINBASE_HI", 4, length));
+    headers.add(new ColumnHeader("blockdata.COINBASE_LO", 16, length));
+    headers.add(new ColumnHeader("blockdata.CT", 1, length));
+    headers.add(new ColumnHeader("blockdata.DATA_HI", 16, length));
+    headers.add(new ColumnHeader("blockdata.DATA_LO", 16, length));
+    headers.add(new ColumnHeader("blockdata.FIRST_BLOCK_NUMBER", 6, length));
+    headers.add(new ColumnHeader("blockdata.INST", 1, length));
+    headers.add(new ColumnHeader("blockdata.REL_BLOCK", 2, length));
+    headers.add(new ColumnHeader("blockdata.REL_TX_NUM_MAX", 2, length));
+    headers.add(new ColumnHeader("blockdata.WCP_FLAG", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -198,7 +200,7 @@ public class Trace {
     }
 
     if (b >= 281474976710656L) {
-      throw new IllegalArgumentException("basefee has invalid value (" + b + ")");
+      throw new IllegalArgumentException("blockdata.BASEFEE has invalid value (" + b + ")");
     }
     basefee.put((byte) (b >> 40));
     basefee.put((byte) (b >> 32));
@@ -218,7 +220,7 @@ public class Trace {
     }
 
     if (b >= 281474976710656L) {
-      throw new IllegalArgumentException("blockGasLimit has invalid value (" + b + ")");
+      throw new IllegalArgumentException("blockdata.BLOCK_GAS_LIMIT has invalid value (" + b + ")");
     }
     blockGasLimit.put((byte) (b >> 40));
     blockGasLimit.put((byte) (b >> 32));
@@ -622,7 +624,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("coinbaseHi has invalid value (" + b + ")");
+      throw new IllegalArgumentException("blockdata.COINBASE_HI has invalid value (" + b + ")");
     }
     coinbaseHi.put((byte) (b >> 24));
     coinbaseHi.put((byte) (b >> 16));
@@ -644,7 +646,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "coinbaseLo has invalid width (" + bs.bitLength() + "bits)");
+          "blockdata.COINBASE_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -666,7 +668,7 @@ public class Trace {
     }
 
     if (b >= 16L) {
-      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+      throw new IllegalArgumentException("blockdata.CT has invalid value (" + b + ")");
     }
     ct.put((byte) b);
 
@@ -684,7 +686,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("dataHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "blockdata.DATA_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -709,7 +712,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("dataLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "blockdata.DATA_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -731,7 +735,8 @@ public class Trace {
     }
 
     if (b >= 281474976710656L) {
-      throw new IllegalArgumentException("firstBlockNumber has invalid value (" + b + ")");
+      throw new IllegalArgumentException(
+          "blockdata.FIRST_BLOCK_NUMBER has invalid value (" + b + ")");
     }
     firstBlockNumber.put((byte) (b >> 40));
     firstBlockNumber.put((byte) (b >> 32));
@@ -763,7 +768,7 @@ public class Trace {
     }
 
     if (b >= 1024L) {
-      throw new IllegalArgumentException("relBlock has invalid value (" + b + ")");
+      throw new IllegalArgumentException("blockdata.REL_BLOCK has invalid value (" + b + ")");
     }
     relBlock.put((byte) (b >> 8));
     relBlock.put((byte) b);
@@ -779,7 +784,7 @@ public class Trace {
     }
 
     if (b >= 1024L) {
-      throw new IllegalArgumentException("relTxNumMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("blockdata.REL_TX_NUM_MAX has invalid value (" + b + ")");
     }
     relTxNumMax.put((byte) (b >> 8));
     relTxNumMax.put((byte) b);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.blockhash;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -80,51 +81,52 @@ public class Trace {
   private final MappedByteBuffer upperBoundCheck;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("blockhash.ABS_BLOCK", 6, length),
-        new ColumnHeader("blockhash.BLOCK_HASH_HI", 16, length),
-        new ColumnHeader("blockhash.BLOCK_HASH_LO", 16, length),
-        new ColumnHeader("blockhash.BLOCK_NUMBER_HI", 16, length),
-        new ColumnHeader("blockhash.BLOCK_NUMBER_LO", 16, length),
-        new ColumnHeader("blockhash.BYTE_HI_0", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_1", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_10", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_11", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_12", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_13", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_14", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_15", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_2", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_3", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_4", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_5", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_6", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_7", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_8", 1, length),
-        new ColumnHeader("blockhash.BYTE_HI_9", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_0", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_1", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_10", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_11", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_12", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_13", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_14", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_15", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_2", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_3", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_4", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_5", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_6", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_7", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_8", 1, length),
-        new ColumnHeader("blockhash.BYTE_LO_9", 1, length),
-        new ColumnHeader("blockhash.IN_RANGE", 1, length),
-        new ColumnHeader("blockhash.IOMF", 1, length),
-        new ColumnHeader("blockhash.LOWER_BOUND_CHECK", 1, length),
-        new ColumnHeader("blockhash.REL_BLOCK", 1, length),
-        new ColumnHeader("blockhash.RES_HI", 16, length),
-        new ColumnHeader("blockhash.RES_LO", 16, length),
-        new ColumnHeader("blockhash.UPPER_BOUND_CHECK", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("blockhash.ABS_BLOCK", 6, length));
+    headers.add(new ColumnHeader("blockhash.BLOCK_HASH_HI", 16, length));
+    headers.add(new ColumnHeader("blockhash.BLOCK_HASH_LO", 16, length));
+    headers.add(new ColumnHeader("blockhash.BLOCK_NUMBER_HI", 16, length));
+    headers.add(new ColumnHeader("blockhash.BLOCK_NUMBER_LO", 16, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_0", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_1", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_10", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_11", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_12", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_13", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_14", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_15", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_2", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_3", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_4", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_5", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_6", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_7", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_8", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_HI_9", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_0", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_1", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_10", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_11", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_12", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_13", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_14", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_15", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_2", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_3", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_4", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_5", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_6", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_7", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_8", 1, length));
+    headers.add(new ColumnHeader("blockhash.BYTE_LO_9", 1, length));
+    headers.add(new ColumnHeader("blockhash.IN_RANGE", 1, length));
+    headers.add(new ColumnHeader("blockhash.IOMF", 1, length));
+    headers.add(new ColumnHeader("blockhash.LOWER_BOUND_CHECK", 1, length));
+    headers.add(new ColumnHeader("blockhash.REL_BLOCK", 1, length));
+    headers.add(new ColumnHeader("blockhash.RES_HI", 16, length));
+    headers.add(new ColumnHeader("blockhash.RES_LO", 16, length));
+    headers.add(new ColumnHeader("blockhash.UPPER_BOUND_CHECK", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -190,7 +192,7 @@ public class Trace {
     }
 
     if (b >= 281474976710656L) {
-      throw new IllegalArgumentException("absBlock has invalid value (" + b + ")");
+      throw new IllegalArgumentException("blockhash.ABS_BLOCK has invalid value (" + b + ")");
     }
     absBlock.put((byte) (b >> 40));
     absBlock.put((byte) (b >> 32));
@@ -214,7 +216,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "blockHashHi has invalid width (" + bs.bitLength() + "bits)");
+          "blockhash.BLOCK_HASH_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -240,7 +242,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "blockHashLo has invalid width (" + bs.bitLength() + "bits)");
+          "blockhash.BLOCK_HASH_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -266,7 +268,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "blockNumberHi has invalid width (" + bs.bitLength() + "bits)");
+          "blockhash.BLOCK_NUMBER_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -292,7 +294,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "blockNumberLo has invalid width (" + bs.bitLength() + "bits)");
+          "blockhash.BLOCK_NUMBER_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -734,7 +736,7 @@ public class Trace {
     }
 
     if (b >= 256L) {
-      throw new IllegalArgumentException("relBlock has invalid value (" + b + ")");
+      throw new IllegalArgumentException("blockhash.REL_BLOCK has invalid value (" + b + ")");
     }
     relBlock.put((byte) b);
 
@@ -752,7 +754,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "blockhash.RES_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -777,7 +780,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "blockhash.RES_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/Trace.java
@@ -17,6 +17,7 @@ package net.consensys.linea.zktracer.module.ecdata;
 
 import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -122,61 +123,63 @@ public class Trace {
   private final MappedByteBuffer wcpRes;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("ecdata.ACC_PAIRINGS", 2, length),
-        new ColumnHeader("ecdata.ACCEPTABLE_PAIR_OF_POINTS_FOR_PAIRING_CIRCUIT", 1, length),
-        new ColumnHeader("ecdata.BYTE_DELTA", 1, length),
-        new ColumnHeader("ecdata.CIRCUIT_SELECTOR_ECADD", 1, length),
-        new ColumnHeader("ecdata.CIRCUIT_SELECTOR_ECMUL", 1, length),
-        new ColumnHeader("ecdata.CIRCUIT_SELECTOR_ECPAIRING", 1, length),
-        new ColumnHeader("ecdata.CIRCUIT_SELECTOR_ECRECOVER", 1, length),
-        new ColumnHeader("ecdata.CIRCUIT_SELECTOR_G2_MEMBERSHIP", 1, length),
-        new ColumnHeader("ecdata.CT", 1, length),
-        new ColumnHeader("ecdata.CT_MAX", 1, length),
-        new ColumnHeader("ecdata.EXT_ARG1_HI", 16, length),
-        new ColumnHeader("ecdata.EXT_ARG1_LO", 16, length),
-        new ColumnHeader("ecdata.EXT_ARG2_HI", 16, length),
-        new ColumnHeader("ecdata.EXT_ARG2_LO", 16, length),
-        new ColumnHeader("ecdata.EXT_ARG3_HI", 16, length),
-        new ColumnHeader("ecdata.EXT_ARG3_LO", 16, length),
-        new ColumnHeader("ecdata.EXT_FLAG", 1, length),
-        new ColumnHeader("ecdata.EXT_INST", 1, length),
-        new ColumnHeader("ecdata.EXT_RES_HI", 16, length),
-        new ColumnHeader("ecdata.EXT_RES_LO", 16, length),
-        new ColumnHeader("ecdata.G2_MEMBERSHIP_TEST_REQUIRED", 1, length),
-        new ColumnHeader("ecdata.HURDLE", 1, length),
-        new ColumnHeader("ecdata.ID", 4, length),
-        new ColumnHeader("ecdata.INDEX", 2, length),
-        new ColumnHeader("ecdata.INDEX_MAX", 2, length),
-        new ColumnHeader("ecdata.INTERNAL_CHECKS_PASSED", 1, length),
-        new ColumnHeader("ecdata.IS_ECADD_DATA", 1, length),
-        new ColumnHeader("ecdata.IS_ECADD_RESULT", 1, length),
-        new ColumnHeader("ecdata.IS_ECMUL_DATA", 1, length),
-        new ColumnHeader("ecdata.IS_ECMUL_RESULT", 1, length),
-        new ColumnHeader("ecdata.IS_ECPAIRING_DATA", 1, length),
-        new ColumnHeader("ecdata.IS_ECPAIRING_RESULT", 1, length),
-        new ColumnHeader("ecdata.IS_ECRECOVER_DATA", 1, length),
-        new ColumnHeader("ecdata.IS_ECRECOVER_RESULT", 1, length),
-        new ColumnHeader("ecdata.IS_INFINITY", 1, length),
-        new ColumnHeader("ecdata.IS_LARGE_POINT", 1, length),
-        new ColumnHeader("ecdata.IS_SMALL_POINT", 1, length),
-        new ColumnHeader("ecdata.LIMB", 16, length),
-        new ColumnHeader("ecdata.NOT_ON_G2", 1, length),
-        new ColumnHeader("ecdata.NOT_ON_G2_ACC", 1, length),
-        new ColumnHeader("ecdata.NOT_ON_G2_ACC_MAX", 1, length),
-        new ColumnHeader("ecdata.OVERALL_TRIVIAL_PAIRING", 1, length),
-        new ColumnHeader("ecdata.PHASE", 2, length),
-        new ColumnHeader("ecdata.STAMP", 4, length),
-        new ColumnHeader("ecdata.SUCCESS_BIT", 1, length),
-        new ColumnHeader("ecdata.TOTAL_PAIRINGS", 2, length),
-        new ColumnHeader("ecdata.TOTAL_SIZE", 2, length),
-        new ColumnHeader("ecdata.WCP_ARG1_HI", 16, length),
-        new ColumnHeader("ecdata.WCP_ARG1_LO", 16, length),
-        new ColumnHeader("ecdata.WCP_ARG2_HI", 16, length),
-        new ColumnHeader("ecdata.WCP_ARG2_LO", 16, length),
-        new ColumnHeader("ecdata.WCP_FLAG", 1, length),
-        new ColumnHeader("ecdata.WCP_INST", 1, length),
-        new ColumnHeader("ecdata.WCP_RES", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("ecdata.ACC_PAIRINGS", 2, length));
+    headers.add(
+        new ColumnHeader("ecdata.ACCEPTABLE_PAIR_OF_POINTS_FOR_PAIRING_CIRCUIT", 1, length));
+    headers.add(new ColumnHeader("ecdata.BYTE_DELTA", 1, length));
+    headers.add(new ColumnHeader("ecdata.CIRCUIT_SELECTOR_ECADD", 1, length));
+    headers.add(new ColumnHeader("ecdata.CIRCUIT_SELECTOR_ECMUL", 1, length));
+    headers.add(new ColumnHeader("ecdata.CIRCUIT_SELECTOR_ECPAIRING", 1, length));
+    headers.add(new ColumnHeader("ecdata.CIRCUIT_SELECTOR_ECRECOVER", 1, length));
+    headers.add(new ColumnHeader("ecdata.CIRCUIT_SELECTOR_G2_MEMBERSHIP", 1, length));
+    headers.add(new ColumnHeader("ecdata.CT", 1, length));
+    headers.add(new ColumnHeader("ecdata.CT_MAX", 1, length));
+    headers.add(new ColumnHeader("ecdata.EXT_ARG1_HI", 16, length));
+    headers.add(new ColumnHeader("ecdata.EXT_ARG1_LO", 16, length));
+    headers.add(new ColumnHeader("ecdata.EXT_ARG2_HI", 16, length));
+    headers.add(new ColumnHeader("ecdata.EXT_ARG2_LO", 16, length));
+    headers.add(new ColumnHeader("ecdata.EXT_ARG3_HI", 16, length));
+    headers.add(new ColumnHeader("ecdata.EXT_ARG3_LO", 16, length));
+    headers.add(new ColumnHeader("ecdata.EXT_FLAG", 1, length));
+    headers.add(new ColumnHeader("ecdata.EXT_INST", 1, length));
+    headers.add(new ColumnHeader("ecdata.EXT_RES_HI", 16, length));
+    headers.add(new ColumnHeader("ecdata.EXT_RES_LO", 16, length));
+    headers.add(new ColumnHeader("ecdata.G2_MEMBERSHIP_TEST_REQUIRED", 1, length));
+    headers.add(new ColumnHeader("ecdata.HURDLE", 1, length));
+    headers.add(new ColumnHeader("ecdata.ID", 4, length));
+    headers.add(new ColumnHeader("ecdata.INDEX", 2, length));
+    headers.add(new ColumnHeader("ecdata.INDEX_MAX", 2, length));
+    headers.add(new ColumnHeader("ecdata.INTERNAL_CHECKS_PASSED", 1, length));
+    headers.add(new ColumnHeader("ecdata.IS_ECADD_DATA", 1, length));
+    headers.add(new ColumnHeader("ecdata.IS_ECADD_RESULT", 1, length));
+    headers.add(new ColumnHeader("ecdata.IS_ECMUL_DATA", 1, length));
+    headers.add(new ColumnHeader("ecdata.IS_ECMUL_RESULT", 1, length));
+    headers.add(new ColumnHeader("ecdata.IS_ECPAIRING_DATA", 1, length));
+    headers.add(new ColumnHeader("ecdata.IS_ECPAIRING_RESULT", 1, length));
+    headers.add(new ColumnHeader("ecdata.IS_ECRECOVER_DATA", 1, length));
+    headers.add(new ColumnHeader("ecdata.IS_ECRECOVER_RESULT", 1, length));
+    headers.add(new ColumnHeader("ecdata.IS_INFINITY", 1, length));
+    headers.add(new ColumnHeader("ecdata.IS_LARGE_POINT", 1, length));
+    headers.add(new ColumnHeader("ecdata.IS_SMALL_POINT", 1, length));
+    headers.add(new ColumnHeader("ecdata.LIMB", 16, length));
+    headers.add(new ColumnHeader("ecdata.NOT_ON_G2", 1, length));
+    headers.add(new ColumnHeader("ecdata.NOT_ON_G2_ACC", 1, length));
+    headers.add(new ColumnHeader("ecdata.NOT_ON_G2_ACC_MAX", 1, length));
+    headers.add(new ColumnHeader("ecdata.OVERALL_TRIVIAL_PAIRING", 1, length));
+    headers.add(new ColumnHeader("ecdata.PHASE", 2, length));
+    headers.add(new ColumnHeader("ecdata.STAMP", 4, length));
+    headers.add(new ColumnHeader("ecdata.SUCCESS_BIT", 1, length));
+    headers.add(new ColumnHeader("ecdata.TOTAL_PAIRINGS", 2, length));
+    headers.add(new ColumnHeader("ecdata.TOTAL_SIZE", 2, length));
+    headers.add(new ColumnHeader("ecdata.WCP_ARG1_HI", 16, length));
+    headers.add(new ColumnHeader("ecdata.WCP_ARG1_LO", 16, length));
+    headers.add(new ColumnHeader("ecdata.WCP_ARG2_HI", 16, length));
+    headers.add(new ColumnHeader("ecdata.WCP_ARG2_LO", 16, length));
+    headers.add(new ColumnHeader("ecdata.WCP_FLAG", 1, length));
+    headers.add(new ColumnHeader("ecdata.WCP_INST", 1, length));
+    headers.add(new ColumnHeader("ecdata.WCP_RES", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -252,7 +255,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("accPairings has invalid value (" + b + ")");
+      throw new IllegalArgumentException("ecdata.ACC_PAIRINGS has invalid value (" + b + ")");
     }
     accPairings.put((byte) (b >> 8));
     accPairings.put((byte) b);
@@ -353,7 +356,7 @@ public class Trace {
     }
 
     if (b >= 8L) {
-      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+      throw new IllegalArgumentException("ecdata.CT has invalid value (" + b + ")");
     }
     ct.put((byte) b);
 
@@ -368,7 +371,7 @@ public class Trace {
     }
 
     if (b >= 8L) {
-      throw new IllegalArgumentException("ctMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("ecdata.CT_MAX has invalid value (" + b + ")");
     }
     ctMax.put((byte) b);
 
@@ -387,7 +390,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "extArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+          "ecdata.EXT_ARG1_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -413,7 +416,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "extArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+          "ecdata.EXT_ARG1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -439,7 +442,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "extArg2Hi has invalid width (" + bs.bitLength() + "bits)");
+          "ecdata.EXT_ARG2_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -465,7 +468,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "extArg2Lo has invalid width (" + bs.bitLength() + "bits)");
+          "ecdata.EXT_ARG2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -491,7 +494,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "extArg3Hi has invalid width (" + bs.bitLength() + "bits)");
+          "ecdata.EXT_ARG3_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -517,7 +520,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "extArg3Lo has invalid width (" + bs.bitLength() + "bits)");
+          "ecdata.EXT_ARG3_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -566,7 +569,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("extResHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ecdata.EXT_RES_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -591,7 +595,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("extResLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ecdata.EXT_RES_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -637,7 +642,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("id has invalid value (" + b + ")");
+      throw new IllegalArgumentException("ecdata.ID has invalid value (" + b + ")");
     }
     id.put((byte) (b >> 24));
     id.put((byte) (b >> 16));
@@ -655,7 +660,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("index has invalid value (" + b + ")");
+      throw new IllegalArgumentException("ecdata.INDEX has invalid value (" + b + ")");
     }
     index.put((byte) (b >> 8));
     index.put((byte) b);
@@ -671,7 +676,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("indexMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("ecdata.INDEX_MAX has invalid value (" + b + ")");
     }
     indexMax.put((byte) (b >> 8));
     indexMax.put((byte) b);
@@ -834,7 +839,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ecdata.LIMB has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -904,7 +910,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("phase has invalid value (" + b + ")");
+      throw new IllegalArgumentException("ecdata.PHASE has invalid value (" + b + ")");
     }
     phase.put((byte) (b >> 8));
     phase.put((byte) b);
@@ -920,7 +926,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("ecdata.STAMP has invalid value (" + b + ")");
     }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));
@@ -950,7 +956,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("totalPairings has invalid value (" + b + ")");
+      throw new IllegalArgumentException("ecdata.TOTAL_PAIRINGS has invalid value (" + b + ")");
     }
     totalPairings.put((byte) (b >> 8));
     totalPairings.put((byte) b);
@@ -966,7 +972,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("totalSize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("ecdata.TOTAL_SIZE has invalid value (" + b + ")");
     }
     totalSize.put((byte) (b >> 8));
     totalSize.put((byte) b);
@@ -986,7 +992,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "wcpArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+          "ecdata.WCP_ARG1_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1012,7 +1018,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "wcpArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+          "ecdata.WCP_ARG1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1038,7 +1044,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "wcpArg2Hi has invalid width (" + bs.bitLength() + "bits)");
+          "ecdata.WCP_ARG2_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1064,7 +1070,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "wcpArg2Lo has invalid width (" + bs.bitLength() + "bits)");
+          "ecdata.WCP_ARG2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.euc;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -48,19 +49,20 @@ public class Trace {
   private final MappedByteBuffer remainderByte;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("euc.CEIL", 8, length),
-        new ColumnHeader("euc.CT", 1, length),
-        new ColumnHeader("euc.CT_MAX", 1, length),
-        new ColumnHeader("euc.DIVIDEND", 8, length),
-        new ColumnHeader("euc.DIVISOR", 8, length),
-        new ColumnHeader("euc.DIVISOR_BYTE", 1, length),
-        new ColumnHeader("euc.DONE", 1, length),
-        new ColumnHeader("euc.IOMF", 1, length),
-        new ColumnHeader("euc.QUOTIENT", 8, length),
-        new ColumnHeader("euc.QUOTIENT_BYTE", 1, length),
-        new ColumnHeader("euc.REMAINDER", 8, length),
-        new ColumnHeader("euc.REMAINDER_BYTE", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("euc.CEIL", 8, length));
+    headers.add(new ColumnHeader("euc.CT", 1, length));
+    headers.add(new ColumnHeader("euc.CT_MAX", 1, length));
+    headers.add(new ColumnHeader("euc.DIVIDEND", 8, length));
+    headers.add(new ColumnHeader("euc.DIVISOR", 8, length));
+    headers.add(new ColumnHeader("euc.DIVISOR_BYTE", 1, length));
+    headers.add(new ColumnHeader("euc.DONE", 1, length));
+    headers.add(new ColumnHeader("euc.IOMF", 1, length));
+    headers.add(new ColumnHeader("euc.QUOTIENT", 8, length));
+    headers.add(new ColumnHeader("euc.QUOTIENT_BYTE", 1, length));
+    headers.add(new ColumnHeader("euc.REMAINDER", 8, length));
+    headers.add(new ColumnHeader("euc.REMAINDER_BYTE", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -97,7 +99,7 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("ceil has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException("euc.CEIL has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -119,7 +121,7 @@ public class Trace {
     }
 
     if (b >= 256L) {
-      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+      throw new IllegalArgumentException("euc.CT has invalid value (" + b + ")");
     }
     ct.put((byte) b);
 
@@ -134,7 +136,7 @@ public class Trace {
     }
 
     if (b >= 256L) {
-      throw new IllegalArgumentException("ctMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("euc.CT_MAX has invalid value (" + b + ")");
     }
     ctMax.put((byte) b);
 
@@ -152,7 +154,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("dividend has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "euc.DIVIDEND has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -177,7 +180,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("divisor has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "euc.DIVISOR has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -238,7 +242,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("quotient has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "euc.QUOTIENT has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -276,7 +281,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "remainder has invalid width (" + bs.bitLength() + "bits)");
+          "euc.REMAINDER has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.exp;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -67,32 +68,33 @@ public class Trace {
   private final MappedByteBuffer trimByte;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("exp.CMPTN", 1, length),
-        new ColumnHeader("exp.CT", 1, length),
-        new ColumnHeader("exp.CT_MAX", 1, length),
-        new ColumnHeader("exp.DATA_3_xor_WCP_ARG_2_HI", 16, length),
-        new ColumnHeader("exp.DATA_4_xor_WCP_ARG_2_LO", 16, length),
-        new ColumnHeader("exp.DATA_5", 16, length),
-        new ColumnHeader("exp.EXP_INST", 2, length),
-        new ColumnHeader("exp.IS_EXP_LOG", 1, length),
-        new ColumnHeader("exp.IS_MODEXP_LOG", 1, length),
-        new ColumnHeader("exp.MACRO", 1, length),
-        new ColumnHeader("exp.MANZB_ACC", 1, length),
-        new ColumnHeader("exp.MANZB_xor_WCP_FLAG", 1, length),
-        new ColumnHeader("exp.MSB_ACC", 1, length),
-        new ColumnHeader("exp.MSB_BIT_xor_WCP_RES", 1, length),
-        new ColumnHeader("exp.MSB_xor_WCP_INST", 1, length),
-        new ColumnHeader("exp.PLT_BIT", 1, length),
-        new ColumnHeader("exp.PLT_JMP", 1, length),
-        new ColumnHeader("exp.PRPRC", 1, length),
-        new ColumnHeader("exp.RAW_ACC_xor_DATA_1_xor_WCP_ARG_1_HI", 16, length),
-        new ColumnHeader("exp.RAW_BYTE", 1, length),
-        new ColumnHeader("exp.STAMP", 4, length),
-        new ColumnHeader("exp.TANZB", 1, length),
-        new ColumnHeader("exp.TANZB_ACC", 1, length),
-        new ColumnHeader("exp.TRIM_ACC_xor_DATA_2_xor_WCP_ARG_1_LO", 16, length),
-        new ColumnHeader("exp.TRIM_BYTE", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("exp.CMPTN", 1, length));
+    headers.add(new ColumnHeader("exp.CT", 1, length));
+    headers.add(new ColumnHeader("exp.CT_MAX", 1, length));
+    headers.add(new ColumnHeader("exp.DATA_3_xor_WCP_ARG_2_HI", 16, length));
+    headers.add(new ColumnHeader("exp.DATA_4_xor_WCP_ARG_2_LO", 16, length));
+    headers.add(new ColumnHeader("exp.DATA_5", 16, length));
+    headers.add(new ColumnHeader("exp.EXP_INST", 2, length));
+    headers.add(new ColumnHeader("exp.IS_EXP_LOG", 1, length));
+    headers.add(new ColumnHeader("exp.IS_MODEXP_LOG", 1, length));
+    headers.add(new ColumnHeader("exp.MACRO", 1, length));
+    headers.add(new ColumnHeader("exp.MANZB_ACC", 1, length));
+    headers.add(new ColumnHeader("exp.MANZB_xor_WCP_FLAG", 1, length));
+    headers.add(new ColumnHeader("exp.MSB_ACC", 1, length));
+    headers.add(new ColumnHeader("exp.MSB_BIT_xor_WCP_RES", 1, length));
+    headers.add(new ColumnHeader("exp.MSB_xor_WCP_INST", 1, length));
+    headers.add(new ColumnHeader("exp.PLT_BIT", 1, length));
+    headers.add(new ColumnHeader("exp.PLT_JMP", 1, length));
+    headers.add(new ColumnHeader("exp.PRPRC", 1, length));
+    headers.add(new ColumnHeader("exp.RAW_ACC_xor_DATA_1_xor_WCP_ARG_1_HI", 16, length));
+    headers.add(new ColumnHeader("exp.RAW_BYTE", 1, length));
+    headers.add(new ColumnHeader("exp.STAMP", 4, length));
+    headers.add(new ColumnHeader("exp.TANZB", 1, length));
+    headers.add(new ColumnHeader("exp.TANZB_ACC", 1, length));
+    headers.add(new ColumnHeader("exp.TRIM_ACC_xor_DATA_2_xor_WCP_ARG_1_LO", 16, length));
+    headers.add(new ColumnHeader("exp.TRIM_BYTE", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -151,7 +153,7 @@ public class Trace {
     }
 
     if (b >= 16L) {
-      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+      throw new IllegalArgumentException("exp.CT has invalid value (" + b + ")");
     }
     ct.put((byte) b);
 
@@ -166,7 +168,7 @@ public class Trace {
     }
 
     if (b >= 16L) {
-      throw new IllegalArgumentException("ctMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("exp.CT_MAX has invalid value (" + b + ")");
     }
     ctMax.put((byte) b);
 
@@ -229,7 +231,7 @@ public class Trace {
     }
 
     if (b >= 16L) {
-      throw new IllegalArgumentException("manzbAcc has invalid value (" + b + ")");
+      throw new IllegalArgumentException("exp.computation/MANZB_ACC has invalid value (" + b + ")");
     }
     manzbAcc.put((byte) b);
 
@@ -292,7 +294,7 @@ public class Trace {
     }
 
     if (b >= 64L) {
-      throw new IllegalArgumentException("pltJmp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("exp.computation/PLT_JMP has invalid value (" + b + ")");
     }
     pltJmp.put((byte) b);
 
@@ -311,7 +313,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "rawAccXorData1XorWcpArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+          "exp.computation/RAW_ACC has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -357,7 +359,7 @@ public class Trace {
     }
 
     if (b >= 32L) {
-      throw new IllegalArgumentException("tanzbAcc has invalid value (" + b + ")");
+      throw new IllegalArgumentException("exp.computation/TANZB_ACC has invalid value (" + b + ")");
     }
     tanzbAcc.put((byte) b);
 
@@ -376,7 +378,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "trimAccXorData2XorWcpArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+          "exp.computation/TRIM_ACC has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -414,7 +416,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "rawAccXorData1XorWcpArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+          "exp.macro/DATA_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -440,7 +442,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "trimAccXorData2XorWcpArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+          "exp.macro/DATA_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -466,7 +468,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "data3XorWcpArg2Hi has invalid width (" + bs.bitLength() + "bits)");
+          "exp.macro/DATA_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -492,7 +494,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "data4XorWcpArg2Lo has invalid width (" + bs.bitLength() + "bits)");
+          "exp.macro/DATA_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -517,7 +519,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("data5 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "exp.macro/DATA_5 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -539,7 +542,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("expInst has invalid value (" + b + ")");
+      throw new IllegalArgumentException("exp.macro/EXP_INST has invalid value (" + b + ")");
     }
     expInst.put((byte) (b >> 8));
     expInst.put((byte) b);
@@ -559,7 +562,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "rawAccXorData1XorWcpArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+          "exp.preprocessing/WCP_ARG_1_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -585,7 +588,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "trimAccXorData2XorWcpArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+          "exp.preprocessing/WCP_ARG_1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -611,7 +614,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "data3XorWcpArg2Hi has invalid width (" + bs.bitLength() + "bits)");
+          "exp.preprocessing/WCP_ARG_2_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -637,7 +640,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "data4XorWcpArg2Lo has invalid width (" + bs.bitLength() + "bits)");
+          "exp.preprocessing/WCP_ARG_2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -707,7 +710,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("exp.STAMP has invalid value (" + b + ")");
     }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ext/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ext/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.ext;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -154,125 +155,126 @@ public class Trace {
   private final MappedByteBuffer stamp;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("ext.ACC_A_0", 8, length),
-        new ColumnHeader("ext.ACC_A_1", 8, length),
-        new ColumnHeader("ext.ACC_A_2", 8, length),
-        new ColumnHeader("ext.ACC_A_3", 8, length),
-        new ColumnHeader("ext.ACC_B_0", 8, length),
-        new ColumnHeader("ext.ACC_B_1", 8, length),
-        new ColumnHeader("ext.ACC_B_2", 8, length),
-        new ColumnHeader("ext.ACC_B_3", 8, length),
-        new ColumnHeader("ext.ACC_C_0", 8, length),
-        new ColumnHeader("ext.ACC_C_1", 8, length),
-        new ColumnHeader("ext.ACC_C_2", 8, length),
-        new ColumnHeader("ext.ACC_C_3", 8, length),
-        new ColumnHeader("ext.ACC_DELTA_0", 8, length),
-        new ColumnHeader("ext.ACC_DELTA_1", 8, length),
-        new ColumnHeader("ext.ACC_DELTA_2", 8, length),
-        new ColumnHeader("ext.ACC_DELTA_3", 8, length),
-        new ColumnHeader("ext.ACC_H_0", 8, length),
-        new ColumnHeader("ext.ACC_H_1", 8, length),
-        new ColumnHeader("ext.ACC_H_2", 8, length),
-        new ColumnHeader("ext.ACC_H_3", 8, length),
-        new ColumnHeader("ext.ACC_H_4", 8, length),
-        new ColumnHeader("ext.ACC_H_5", 8, length),
-        new ColumnHeader("ext.ACC_I_0", 8, length),
-        new ColumnHeader("ext.ACC_I_1", 8, length),
-        new ColumnHeader("ext.ACC_I_2", 8, length),
-        new ColumnHeader("ext.ACC_I_3", 8, length),
-        new ColumnHeader("ext.ACC_I_4", 8, length),
-        new ColumnHeader("ext.ACC_I_5", 8, length),
-        new ColumnHeader("ext.ACC_I_6", 8, length),
-        new ColumnHeader("ext.ACC_J_0", 8, length),
-        new ColumnHeader("ext.ACC_J_1", 8, length),
-        new ColumnHeader("ext.ACC_J_2", 8, length),
-        new ColumnHeader("ext.ACC_J_3", 8, length),
-        new ColumnHeader("ext.ACC_J_4", 8, length),
-        new ColumnHeader("ext.ACC_J_5", 8, length),
-        new ColumnHeader("ext.ACC_J_6", 8, length),
-        new ColumnHeader("ext.ACC_J_7", 8, length),
-        new ColumnHeader("ext.ACC_Q_0", 8, length),
-        new ColumnHeader("ext.ACC_Q_1", 8, length),
-        new ColumnHeader("ext.ACC_Q_2", 8, length),
-        new ColumnHeader("ext.ACC_Q_3", 8, length),
-        new ColumnHeader("ext.ACC_Q_4", 8, length),
-        new ColumnHeader("ext.ACC_Q_5", 8, length),
-        new ColumnHeader("ext.ACC_Q_6", 8, length),
-        new ColumnHeader("ext.ACC_Q_7", 8, length),
-        new ColumnHeader("ext.ACC_R_0", 8, length),
-        new ColumnHeader("ext.ACC_R_1", 8, length),
-        new ColumnHeader("ext.ACC_R_2", 8, length),
-        new ColumnHeader("ext.ACC_R_3", 8, length),
-        new ColumnHeader("ext.ARG_1_HI", 16, length),
-        new ColumnHeader("ext.ARG_1_LO", 16, length),
-        new ColumnHeader("ext.ARG_2_HI", 16, length),
-        new ColumnHeader("ext.ARG_2_LO", 16, length),
-        new ColumnHeader("ext.ARG_3_HI", 16, length),
-        new ColumnHeader("ext.ARG_3_LO", 16, length),
-        new ColumnHeader("ext.BIT_1", 1, length),
-        new ColumnHeader("ext.BIT_2", 1, length),
-        new ColumnHeader("ext.BIT_3", 1, length),
-        new ColumnHeader("ext.BYTE_A_0", 1, length),
-        new ColumnHeader("ext.BYTE_A_1", 1, length),
-        new ColumnHeader("ext.BYTE_A_2", 1, length),
-        new ColumnHeader("ext.BYTE_A_3", 1, length),
-        new ColumnHeader("ext.BYTE_B_0", 1, length),
-        new ColumnHeader("ext.BYTE_B_1", 1, length),
-        new ColumnHeader("ext.BYTE_B_2", 1, length),
-        new ColumnHeader("ext.BYTE_B_3", 1, length),
-        new ColumnHeader("ext.BYTE_C_0", 1, length),
-        new ColumnHeader("ext.BYTE_C_1", 1, length),
-        new ColumnHeader("ext.BYTE_C_2", 1, length),
-        new ColumnHeader("ext.BYTE_C_3", 1, length),
-        new ColumnHeader("ext.BYTE_DELTA_0", 1, length),
-        new ColumnHeader("ext.BYTE_DELTA_1", 1, length),
-        new ColumnHeader("ext.BYTE_DELTA_2", 1, length),
-        new ColumnHeader("ext.BYTE_DELTA_3", 1, length),
-        new ColumnHeader("ext.BYTE_H_0", 1, length),
-        new ColumnHeader("ext.BYTE_H_1", 1, length),
-        new ColumnHeader("ext.BYTE_H_2", 1, length),
-        new ColumnHeader("ext.BYTE_H_3", 1, length),
-        new ColumnHeader("ext.BYTE_H_4", 1, length),
-        new ColumnHeader("ext.BYTE_H_5", 1, length),
-        new ColumnHeader("ext.BYTE_I_0", 1, length),
-        new ColumnHeader("ext.BYTE_I_1", 1, length),
-        new ColumnHeader("ext.BYTE_I_2", 1, length),
-        new ColumnHeader("ext.BYTE_I_3", 1, length),
-        new ColumnHeader("ext.BYTE_I_4", 1, length),
-        new ColumnHeader("ext.BYTE_I_5", 1, length),
-        new ColumnHeader("ext.BYTE_I_6", 1, length),
-        new ColumnHeader("ext.BYTE_J_0", 1, length),
-        new ColumnHeader("ext.BYTE_J_1", 1, length),
-        new ColumnHeader("ext.BYTE_J_2", 1, length),
-        new ColumnHeader("ext.BYTE_J_3", 1, length),
-        new ColumnHeader("ext.BYTE_J_4", 1, length),
-        new ColumnHeader("ext.BYTE_J_5", 1, length),
-        new ColumnHeader("ext.BYTE_J_6", 1, length),
-        new ColumnHeader("ext.BYTE_J_7", 1, length),
-        new ColumnHeader("ext.BYTE_Q_0", 1, length),
-        new ColumnHeader("ext.BYTE_Q_1", 1, length),
-        new ColumnHeader("ext.BYTE_Q_2", 1, length),
-        new ColumnHeader("ext.BYTE_Q_3", 1, length),
-        new ColumnHeader("ext.BYTE_Q_4", 1, length),
-        new ColumnHeader("ext.BYTE_Q_5", 1, length),
-        new ColumnHeader("ext.BYTE_Q_6", 1, length),
-        new ColumnHeader("ext.BYTE_Q_7", 1, length),
-        new ColumnHeader("ext.BYTE_R_0", 1, length),
-        new ColumnHeader("ext.BYTE_R_1", 1, length),
-        new ColumnHeader("ext.BYTE_R_2", 1, length),
-        new ColumnHeader("ext.BYTE_R_3", 1, length),
-        new ColumnHeader("ext.CMP", 1, length),
-        new ColumnHeader("ext.CT", 1, length),
-        new ColumnHeader("ext.INST", 1, length),
-        new ColumnHeader("ext.OF_H", 1, length),
-        new ColumnHeader("ext.OF_I", 1, length),
-        new ColumnHeader("ext.OF_J", 1, length),
-        new ColumnHeader("ext.OF_RES", 1, length),
-        new ColumnHeader("ext.OLI", 1, length),
-        new ColumnHeader("ext.RES_HI", 16, length),
-        new ColumnHeader("ext.RES_LO", 16, length),
-        new ColumnHeader("ext.STAMP", 4, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("ext.ACC_A_0", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_A_1", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_A_2", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_A_3", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_B_0", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_B_1", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_B_2", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_B_3", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_C_0", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_C_1", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_C_2", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_C_3", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_DELTA_0", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_DELTA_1", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_DELTA_2", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_DELTA_3", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_H_0", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_H_1", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_H_2", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_H_3", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_H_4", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_H_5", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_I_0", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_I_1", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_I_2", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_I_3", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_I_4", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_I_5", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_I_6", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_J_0", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_J_1", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_J_2", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_J_3", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_J_4", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_J_5", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_J_6", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_J_7", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_Q_0", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_Q_1", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_Q_2", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_Q_3", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_Q_4", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_Q_5", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_Q_6", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_Q_7", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_R_0", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_R_1", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_R_2", 8, length));
+    headers.add(new ColumnHeader("ext.ACC_R_3", 8, length));
+    headers.add(new ColumnHeader("ext.ARG_1_HI", 16, length));
+    headers.add(new ColumnHeader("ext.ARG_1_LO", 16, length));
+    headers.add(new ColumnHeader("ext.ARG_2_HI", 16, length));
+    headers.add(new ColumnHeader("ext.ARG_2_LO", 16, length));
+    headers.add(new ColumnHeader("ext.ARG_3_HI", 16, length));
+    headers.add(new ColumnHeader("ext.ARG_3_LO", 16, length));
+    headers.add(new ColumnHeader("ext.BIT_1", 1, length));
+    headers.add(new ColumnHeader("ext.BIT_2", 1, length));
+    headers.add(new ColumnHeader("ext.BIT_3", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_A_0", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_A_1", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_A_2", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_A_3", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_B_0", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_B_1", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_B_2", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_B_3", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_C_0", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_C_1", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_C_2", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_C_3", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_DELTA_0", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_DELTA_1", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_DELTA_2", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_DELTA_3", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_H_0", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_H_1", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_H_2", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_H_3", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_H_4", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_H_5", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_I_0", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_I_1", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_I_2", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_I_3", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_I_4", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_I_5", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_I_6", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_J_0", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_J_1", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_J_2", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_J_3", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_J_4", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_J_5", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_J_6", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_J_7", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_Q_0", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_Q_1", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_Q_2", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_Q_3", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_Q_4", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_Q_5", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_Q_6", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_Q_7", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_R_0", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_R_1", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_R_2", 1, length));
+    headers.add(new ColumnHeader("ext.BYTE_R_3", 1, length));
+    headers.add(new ColumnHeader("ext.CMP", 1, length));
+    headers.add(new ColumnHeader("ext.CT", 1, length));
+    headers.add(new ColumnHeader("ext.INST", 1, length));
+    headers.add(new ColumnHeader("ext.OF_H", 1, length));
+    headers.add(new ColumnHeader("ext.OF_I", 1, length));
+    headers.add(new ColumnHeader("ext.OF_J", 1, length));
+    headers.add(new ColumnHeader("ext.OF_RES", 1, length));
+    headers.add(new ColumnHeader("ext.OLI", 1, length));
+    headers.add(new ColumnHeader("ext.RES_HI", 16, length));
+    headers.add(new ColumnHeader("ext.RES_LO", 16, length));
+    headers.add(new ColumnHeader("ext.STAMP", 4, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -415,7 +417,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accA0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_A_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -440,7 +443,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accA1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_A_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -465,7 +469,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accA2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_A_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -490,7 +495,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accA3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_A_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -515,7 +521,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accB0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_B_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -540,7 +547,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accB1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_B_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -565,7 +573,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accB2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_B_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -590,7 +599,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accB3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_B_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -615,7 +625,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accC0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_C_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -640,7 +651,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accC1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_C_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -665,7 +677,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accC2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_C_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -690,7 +703,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accC3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_C_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -716,7 +730,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "accDelta0 has invalid width (" + bs.bitLength() + "bits)");
+          "ext.ACC_DELTA_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -742,7 +756,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "accDelta1 has invalid width (" + bs.bitLength() + "bits)");
+          "ext.ACC_DELTA_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -768,7 +782,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "accDelta2 has invalid width (" + bs.bitLength() + "bits)");
+          "ext.ACC_DELTA_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -794,7 +808,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "accDelta3 has invalid width (" + bs.bitLength() + "bits)");
+          "ext.ACC_DELTA_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -819,7 +833,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accH0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_H_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -844,7 +859,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accH1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_H_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -869,7 +885,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accH2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_H_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -894,7 +911,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accH3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_H_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -919,7 +937,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accH4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_H_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -944,7 +963,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accH5 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_H_5 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -969,7 +989,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accI0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_I_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -994,7 +1015,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accI1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_I_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1019,7 +1041,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accI2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_I_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1044,7 +1067,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accI3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_I_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1069,7 +1093,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accI4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_I_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1094,7 +1119,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accI5 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_I_5 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1119,7 +1145,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accI6 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_I_6 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1144,7 +1171,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accJ0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_J_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1169,7 +1197,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accJ1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_J_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1194,7 +1223,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accJ2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_J_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1219,7 +1249,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accJ3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_J_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1244,7 +1275,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accJ4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_J_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1269,7 +1301,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accJ5 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_J_5 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1294,7 +1327,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accJ6 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_J_6 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1319,7 +1353,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accJ7 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_J_7 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1344,7 +1379,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accQ0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_Q_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1369,7 +1405,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accQ1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_Q_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1394,7 +1431,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accQ2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_Q_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1419,7 +1457,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accQ3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_Q_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1444,7 +1483,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accQ4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_Q_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1469,7 +1509,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accQ5 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_Q_5 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1494,7 +1535,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accQ6 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_Q_6 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1519,7 +1561,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accQ7 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_Q_7 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1544,7 +1587,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accR0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_R_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1569,7 +1613,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accR1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_R_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1594,7 +1639,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accR2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_R_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1619,7 +1665,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accR3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ACC_R_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1644,7 +1691,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ARG_1_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1669,7 +1717,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ARG_1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1694,7 +1743,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ARG_2_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1719,7 +1769,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ARG_2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1744,7 +1795,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg3Hi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ARG_3_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1769,7 +1821,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg3Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.ARG_3_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -2427,7 +2480,7 @@ public class Trace {
     }
 
     if (b >= 8L) {
-      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+      throw new IllegalArgumentException("ext.CT has invalid value (" + b + ")");
     }
     ct.put((byte) b);
 
@@ -2517,7 +2570,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.RES_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -2542,7 +2596,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "ext.RES_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -2564,7 +2619,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("ext.STAMP has invalid value (" + b + ")");
     }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/gas/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/gas/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.gas;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -48,19 +49,20 @@ public class Trace {
   private final MappedByteBuffer wcpRes;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("gas.CT", 1, length),
-        new ColumnHeader("gas.CT_MAX", 1, length),
-        new ColumnHeader("gas.EXCEPTIONS_AHOY", 1, length),
-        new ColumnHeader("gas.FIRST", 1, length),
-        new ColumnHeader("gas.GAS_ACTUAL", 8, length),
-        new ColumnHeader("gas.GAS_COST", 8, length),
-        new ColumnHeader("gas.INPUTS_AND_OUTPUTS_ARE_MEANINGFUL", 1, length),
-        new ColumnHeader("gas.OUT_OF_GAS_EXCEPTION", 1, length),
-        new ColumnHeader("gas.WCP_ARG1_LO", 16, length),
-        new ColumnHeader("gas.WCP_ARG2_LO", 16, length),
-        new ColumnHeader("gas.WCP_INST", 1, length),
-        new ColumnHeader("gas.WCP_RES", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("gas.CT", 1, length));
+    headers.add(new ColumnHeader("gas.CT_MAX", 1, length));
+    headers.add(new ColumnHeader("gas.EXCEPTIONS_AHOY", 1, length));
+    headers.add(new ColumnHeader("gas.FIRST", 1, length));
+    headers.add(new ColumnHeader("gas.GAS_ACTUAL", 8, length));
+    headers.add(new ColumnHeader("gas.GAS_COST", 8, length));
+    headers.add(new ColumnHeader("gas.INPUTS_AND_OUTPUTS_ARE_MEANINGFUL", 1, length));
+    headers.add(new ColumnHeader("gas.OUT_OF_GAS_EXCEPTION", 1, length));
+    headers.add(new ColumnHeader("gas.WCP_ARG1_LO", 16, length));
+    headers.add(new ColumnHeader("gas.WCP_ARG2_LO", 16, length));
+    headers.add(new ColumnHeader("gas.WCP_INST", 1, length));
+    headers.add(new ColumnHeader("gas.WCP_RES", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -94,7 +96,7 @@ public class Trace {
     }
 
     if (b >= 8L) {
-      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+      throw new IllegalArgumentException("gas.CT has invalid value (" + b + ")");
     }
     ct.put((byte) b);
 
@@ -109,7 +111,7 @@ public class Trace {
     }
 
     if (b >= 8L) {
-      throw new IllegalArgumentException("ctMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("gas.CT_MAX has invalid value (" + b + ")");
     }
     ctMax.put((byte) b);
 
@@ -152,7 +154,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "gasActual has invalid width (" + bs.bitLength() + "bits)");
+          "gas.GAS_ACTUAL has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -177,7 +179,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("gasCost has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "gas.GAS_COST has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -227,7 +230,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "wcpArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+          "gas.WCP_ARG1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -253,7 +256,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "wcpArg2Lo has invalid width (" + bs.bitLength() + "bits)");
+          "gas.WCP_ARG2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/logdata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/logdata/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.logdata;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -43,15 +44,16 @@ public class Trace {
   private final MappedByteBuffer sizeTotal;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("logdata.ABS_LOG_NUM", 3, length),
-        new ColumnHeader("logdata.ABS_LOG_NUM_MAX", 3, length),
-        new ColumnHeader("logdata.INDEX", 3, length),
-        new ColumnHeader("logdata.LIMB", 16, length),
-        new ColumnHeader("logdata.LOGS_DATA", 1, length),
-        new ColumnHeader("logdata.SIZE_ACC", 4, length),
-        new ColumnHeader("logdata.SIZE_LIMB", 1, length),
-        new ColumnHeader("logdata.SIZE_TOTAL", 4, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("logdata.ABS_LOG_NUM", 3, length));
+    headers.add(new ColumnHeader("logdata.ABS_LOG_NUM_MAX", 3, length));
+    headers.add(new ColumnHeader("logdata.INDEX", 3, length));
+    headers.add(new ColumnHeader("logdata.LIMB", 16, length));
+    headers.add(new ColumnHeader("logdata.LOGS_DATA", 1, length));
+    headers.add(new ColumnHeader("logdata.SIZE_ACC", 4, length));
+    headers.add(new ColumnHeader("logdata.SIZE_LIMB", 1, length));
+    headers.add(new ColumnHeader("logdata.SIZE_TOTAL", 4, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -81,7 +83,7 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("absLogNum has invalid value (" + b + ")");
+      throw new IllegalArgumentException("logdata.ABS_LOG_NUM has invalid value (" + b + ")");
     }
     absLogNum.put((byte) (b >> 16));
     absLogNum.put((byte) (b >> 8));
@@ -98,7 +100,7 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("absLogNumMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("logdata.ABS_LOG_NUM_MAX has invalid value (" + b + ")");
     }
     absLogNumMax.put((byte) (b >> 16));
     absLogNumMax.put((byte) (b >> 8));
@@ -115,7 +117,7 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("index has invalid value (" + b + ")");
+      throw new IllegalArgumentException("logdata.INDEX has invalid value (" + b + ")");
     }
     index.put((byte) (b >> 16));
     index.put((byte) (b >> 8));
@@ -135,7 +137,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "logdata.LIMB has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -169,7 +172,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("sizeAcc has invalid value (" + b + ")");
+      throw new IllegalArgumentException("logdata.SIZE_ACC has invalid value (" + b + ")");
     }
     sizeAcc.put((byte) (b >> 24));
     sizeAcc.put((byte) (b >> 16));
@@ -187,7 +190,7 @@ public class Trace {
     }
 
     if (b >= 32L) {
-      throw new IllegalArgumentException("sizeLimb has invalid value (" + b + ")");
+      throw new IllegalArgumentException("logdata.SIZE_LIMB has invalid value (" + b + ")");
     }
     sizeLimb.put((byte) b);
 
@@ -202,7 +205,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("sizeTotal has invalid value (" + b + ")");
+      throw new IllegalArgumentException("logdata.SIZE_TOTAL has invalid value (" + b + ")");
     }
     sizeTotal.put((byte) (b >> 24));
     sizeTotal.put((byte) (b >> 16));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/loginfo/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/loginfo/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.loginfo;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -63,34 +64,35 @@ public class Trace {
   private final MappedByteBuffer txnEmitsLogs;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("loginfo.ABS_LOG_NUM", 3, length),
-        new ColumnHeader("loginfo.ABS_LOG_NUM_MAX", 3, length),
-        new ColumnHeader("loginfo.ABS_TXN_NUM", 3, length),
-        new ColumnHeader("loginfo.ABS_TXN_NUM_MAX", 3, length),
-        new ColumnHeader("loginfo.ADDR_HI", 4, length),
-        new ColumnHeader("loginfo.ADDR_LO", 16, length),
-        new ColumnHeader("loginfo.CT", 1, length),
-        new ColumnHeader("loginfo.CT_MAX", 1, length),
-        new ColumnHeader("loginfo.DATA_HI", 16, length),
-        new ColumnHeader("loginfo.DATA_LO", 16, length),
-        new ColumnHeader("loginfo.DATA_SIZE", 4, length),
-        new ColumnHeader("loginfo.INST", 1, length),
-        new ColumnHeader("loginfo.IS_LOG_X_0", 1, length),
-        new ColumnHeader("loginfo.IS_LOG_X_1", 1, length),
-        new ColumnHeader("loginfo.IS_LOG_X_2", 1, length),
-        new ColumnHeader("loginfo.IS_LOG_X_3", 1, length),
-        new ColumnHeader("loginfo.IS_LOG_X_4", 1, length),
-        new ColumnHeader("loginfo.PHASE", 2, length),
-        new ColumnHeader("loginfo.TOPIC_HI_1", 32, length),
-        new ColumnHeader("loginfo.TOPIC_HI_2", 32, length),
-        new ColumnHeader("loginfo.TOPIC_HI_3", 32, length),
-        new ColumnHeader("loginfo.TOPIC_HI_4", 32, length),
-        new ColumnHeader("loginfo.TOPIC_LO_1", 32, length),
-        new ColumnHeader("loginfo.TOPIC_LO_2", 32, length),
-        new ColumnHeader("loginfo.TOPIC_LO_3", 32, length),
-        new ColumnHeader("loginfo.TOPIC_LO_4", 32, length),
-        new ColumnHeader("loginfo.TXN_EMITS_LOGS", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("loginfo.ABS_LOG_NUM", 3, length));
+    headers.add(new ColumnHeader("loginfo.ABS_LOG_NUM_MAX", 3, length));
+    headers.add(new ColumnHeader("loginfo.ABS_TXN_NUM", 3, length));
+    headers.add(new ColumnHeader("loginfo.ABS_TXN_NUM_MAX", 3, length));
+    headers.add(new ColumnHeader("loginfo.ADDR_HI", 4, length));
+    headers.add(new ColumnHeader("loginfo.ADDR_LO", 16, length));
+    headers.add(new ColumnHeader("loginfo.CT", 1, length));
+    headers.add(new ColumnHeader("loginfo.CT_MAX", 1, length));
+    headers.add(new ColumnHeader("loginfo.DATA_HI", 16, length));
+    headers.add(new ColumnHeader("loginfo.DATA_LO", 16, length));
+    headers.add(new ColumnHeader("loginfo.DATA_SIZE", 4, length));
+    headers.add(new ColumnHeader("loginfo.INST", 1, length));
+    headers.add(new ColumnHeader("loginfo.IS_LOG_X_0", 1, length));
+    headers.add(new ColumnHeader("loginfo.IS_LOG_X_1", 1, length));
+    headers.add(new ColumnHeader("loginfo.IS_LOG_X_2", 1, length));
+    headers.add(new ColumnHeader("loginfo.IS_LOG_X_3", 1, length));
+    headers.add(new ColumnHeader("loginfo.IS_LOG_X_4", 1, length));
+    headers.add(new ColumnHeader("loginfo.PHASE", 2, length));
+    headers.add(new ColumnHeader("loginfo.TOPIC_HI_1", 32, length));
+    headers.add(new ColumnHeader("loginfo.TOPIC_HI_2", 32, length));
+    headers.add(new ColumnHeader("loginfo.TOPIC_HI_3", 32, length));
+    headers.add(new ColumnHeader("loginfo.TOPIC_HI_4", 32, length));
+    headers.add(new ColumnHeader("loginfo.TOPIC_LO_1", 32, length));
+    headers.add(new ColumnHeader("loginfo.TOPIC_LO_2", 32, length));
+    headers.add(new ColumnHeader("loginfo.TOPIC_LO_3", 32, length));
+    headers.add(new ColumnHeader("loginfo.TOPIC_LO_4", 32, length));
+    headers.add(new ColumnHeader("loginfo.TXN_EMITS_LOGS", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -139,7 +141,7 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("absLogNum has invalid value (" + b + ")");
+      throw new IllegalArgumentException("loginfo.ABS_LOG_NUM has invalid value (" + b + ")");
     }
     absLogNum.put((byte) (b >> 16));
     absLogNum.put((byte) (b >> 8));
@@ -156,7 +158,7 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("absLogNumMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("loginfo.ABS_LOG_NUM_MAX has invalid value (" + b + ")");
     }
     absLogNumMax.put((byte) (b >> 16));
     absLogNumMax.put((byte) (b >> 8));
@@ -173,7 +175,7 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("absTxnNum has invalid value (" + b + ")");
+      throw new IllegalArgumentException("loginfo.ABS_TXN_NUM has invalid value (" + b + ")");
     }
     absTxnNum.put((byte) (b >> 16));
     absTxnNum.put((byte) (b >> 8));
@@ -190,7 +192,7 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("absTxnNumMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("loginfo.ABS_TXN_NUM_MAX has invalid value (" + b + ")");
     }
     absTxnNumMax.put((byte) (b >> 16));
     absTxnNumMax.put((byte) (b >> 8));
@@ -207,7 +209,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("addrHi has invalid value (" + b + ")");
+      throw new IllegalArgumentException("loginfo.ADDR_HI has invalid value (" + b + ")");
     }
     addrHi.put((byte) (b >> 24));
     addrHi.put((byte) (b >> 16));
@@ -228,7 +230,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("addrLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "loginfo.ADDR_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -277,7 +280,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("dataHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "loginfo.DATA_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -302,7 +306,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("dataLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "loginfo.DATA_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -324,7 +329,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("dataSize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("loginfo.DATA_SIZE has invalid value (" + b + ")");
     }
     dataSize.put((byte) (b >> 24));
     dataSize.put((byte) (b >> 16));
@@ -414,7 +419,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("phase has invalid value (" + b + ")");
+      throw new IllegalArgumentException("loginfo.PHASE has invalid value (" + b + ")");
     }
     phase.put((byte) (b >> 8));
     phase.put((byte) b);
@@ -433,7 +438,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 256) {
-      throw new IllegalArgumentException("topicHi1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "loginfo.TOPIC_HI_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 32; i++) {
@@ -458,7 +464,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 256) {
-      throw new IllegalArgumentException("topicHi2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "loginfo.TOPIC_HI_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 32; i++) {
@@ -483,7 +490,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 256) {
-      throw new IllegalArgumentException("topicHi3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "loginfo.TOPIC_HI_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 32; i++) {
@@ -508,7 +516,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 256) {
-      throw new IllegalArgumentException("topicHi4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "loginfo.TOPIC_HI_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 32; i++) {
@@ -533,7 +542,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 256) {
-      throw new IllegalArgumentException("topicLo1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "loginfo.TOPIC_LO_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 32; i++) {
@@ -558,7 +568,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 256) {
-      throw new IllegalArgumentException("topicLo2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "loginfo.TOPIC_LO_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 32; i++) {
@@ -583,7 +594,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 256) {
-      throw new IllegalArgumentException("topicLo3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "loginfo.TOPIC_LO_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 32; i++) {
@@ -608,7 +620,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 256) {
-      throw new IllegalArgumentException("topicLo4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "loginfo.TOPIC_LO_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 32; i++) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Trace.java
@@ -276,7 +276,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.ACC_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -301,7 +302,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.ACC_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -326,7 +328,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.ACC_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -351,7 +354,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.ACC_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -376,7 +380,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("accA has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.ACC_A has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -401,7 +406,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("accB has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.ACC_B has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -426,7 +432,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("accC has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.ACC_C has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -451,7 +458,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("accLimb has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.ACC_LIMB has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -584,7 +592,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("cnA has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.CN_A has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -609,7 +618,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("cnB has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.CN_B has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -634,7 +644,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("cnC has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.CN_C has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -660,7 +671,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "contextSource has invalid width (" + bs.bitLength() + "bits)");
+          "mmio.CONTEXT_SOURCE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -686,7 +697,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "contextTarget has invalid width (" + bs.bitLength() + "bits)");
+          "mmio.CONTEXT_TARGET has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -708,7 +719,7 @@ public class Trace {
     }
 
     if (b >= 256L) {
-      throw new IllegalArgumentException("counter has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmio.COUNTER has invalid value (" + b + ")");
     }
     counter.put((byte) b);
 
@@ -723,7 +734,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("exoId has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmio.EXO_ID has invalid value (" + b + ")");
     }
     exoId.put((byte) (b >> 24));
     exoId.put((byte) (b >> 16));
@@ -825,7 +836,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("exoSum has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmio.EXO_SUM has invalid value (" + b + ")");
     }
     exoSum.put((byte) (b >> 24));
     exoSum.put((byte) (b >> 16));
@@ -858,7 +869,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("indexA has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.INDEX_A has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -883,7 +895,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("indexB has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.INDEX_B has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -908,7 +921,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("indexC has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.INDEX_C has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -933,7 +947,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("indexX has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.INDEX_X has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1111,7 +1126,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("kecId has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmio.KEC_ID has invalid value (" + b + ")");
     }
     kecId.put((byte) (b >> 24));
     kecId.put((byte) (b >> 16));
@@ -1132,7 +1147,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.LIMB has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1154,7 +1170,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("mmioInstruction has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmio.MMIO_INSTRUCTION has invalid value (" + b + ")");
     }
     mmioInstruction.put((byte) (b >> 8));
     mmioInstruction.put((byte) b);
@@ -1170,7 +1186,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("mmioStamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmio.MMIO_STAMP has invalid value (" + b + ")");
     }
     mmioStamp.put((byte) (b >> 24));
     mmioStamp.put((byte) (b >> 16));
@@ -1188,7 +1204,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("phase has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmio.PHASE has invalid value (" + b + ")");
     }
     phase.put((byte) (b >> 24));
     phase.put((byte) (b >> 16));
@@ -1209,7 +1225,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("pow2561 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.POW_256_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1234,7 +1251,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("pow2562 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.POW_256_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1259,7 +1277,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("size has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.SIZE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1293,7 +1312,7 @@ public class Trace {
     }
 
     if (b >= 256L) {
-      throw new IllegalArgumentException("sourceByteOffset has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmio.SOURCE_BYTE_OFFSET has invalid value (" + b + ")");
     }
     sourceByteOffset.put((byte) b);
 
@@ -1312,7 +1331,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "sourceLimbOffset has invalid width (" + bs.bitLength() + "bits)");
+          "mmio.SOURCE_LIMB_OFFSET has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1346,7 +1365,7 @@ public class Trace {
     }
 
     if (b >= 256L) {
-      throw new IllegalArgumentException("targetByteOffset has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmio.TARGET_BYTE_OFFSET has invalid value (" + b + ")");
     }
     targetByteOffset.put((byte) b);
 
@@ -1365,7 +1384,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "targetLimbOffset has invalid width (" + bs.bitLength() + "bits)");
+          "mmio.TARGET_LIMB_OFFSET has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1391,7 +1410,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "totalSize has invalid width (" + bs.bitLength() + "bits)");
+          "mmio.TOTAL_SIZE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1416,7 +1435,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("valA has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.VAL_A has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1441,7 +1461,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("valANew has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.VAL_A_NEW has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1466,7 +1487,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("valB has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.VAL_B has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1491,7 +1513,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("valBNew has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.VAL_B_NEW has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1516,7 +1539,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("valC has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.VAL_C has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1541,7 +1565,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("valCNew has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmio.VAL_C_NEW has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/Trace.java
@@ -539,7 +539,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("mmioStamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.MMIO_STAMP has invalid value (" + b + ")");
     }
     mmioStamp.put((byte) (b >> 24));
     mmioStamp.put((byte) (b >> 16));
@@ -608,7 +608,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("out1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmu.OUT_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -633,7 +634,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("out2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmu.OUT_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -658,7 +660,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("out3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmu.OUT_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -683,7 +686,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("out4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmu.OUT_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -708,7 +712,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("out5 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmu.OUT_5 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -734,7 +739,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "auxIdXorCnSXorEucA has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.macro/AUX_ID has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -756,7 +761,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("exoSumXorExoId has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.macro/EXO_SUM has invalid value (" + b + ")");
     }
     exoSumXorExoId.put((byte) (b >> 24));
     exoSumXorExoId.put((byte) (b >> 16));
@@ -774,7 +779,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("instXorInstXorCt has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.macro/INST has invalid value (" + b + ")");
     }
     instXorInstXorCt.put((byte) (b >> 8));
     instXorInstXorCt.put((byte) b);
@@ -794,7 +799,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "limb1XorLimbXorWcpArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.macro/LIMB_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -820,7 +825,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "limb2XorWcpArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.macro/LIMB_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -842,7 +847,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("phaseXorExoSum has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.macro/PHASE has invalid value (" + b + ")");
     }
     phaseXorExoSum.put((byte) (b >> 24));
     phaseXorExoSum.put((byte) (b >> 16));
@@ -864,7 +869,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "refOffsetXorCnTXorEucB has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.macro/REF_OFFSET has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -890,7 +895,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "refSizeXorSloXorEucCeil has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.macro/REF_SIZE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -916,7 +921,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "sizeXorTloXorEucQuot has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.macro/SIZE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -942,7 +947,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "srcIdXorTotalSizeXorEucRem has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.macro/SRC_ID has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -968,7 +973,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "srcOffsetHiXorWcpArg2Lo has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.macro/SRC_OFFSET_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -994,7 +999,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "srcOffsetLo has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.macro/SRC_OFFSET_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1031,7 +1036,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("tgtId has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mmu.macro/TGT_ID has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1057,7 +1063,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "tgtOffsetLo has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.macro/TGT_OFFSET_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1083,7 +1089,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "auxIdXorCnSXorEucA has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.micro/CN_S has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1109,7 +1115,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "refOffsetXorCnTXorEucB has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.micro/CN_T has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1131,7 +1137,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("exoSumXorExoId has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.micro/EXO_ID has invalid value (" + b + ")");
     }
     exoSumXorExoId.put((byte) (b >> 24));
     exoSumXorExoId.put((byte) (b >> 16));
@@ -1149,7 +1155,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("phaseXorExoSum has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.micro/EXO_SUM has invalid value (" + b + ")");
     }
     phaseXorExoSum.put((byte) (b >> 24));
     phaseXorExoSum.put((byte) (b >> 16));
@@ -1167,7 +1173,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("instXorInstXorCt has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.micro/INST has invalid value (" + b + ")");
     }
     instXorInstXorCt.put((byte) (b >> 8));
     instXorInstXorCt.put((byte) b);
@@ -1183,7 +1189,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("kecId has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.micro/KEC_ID has invalid value (" + b + ")");
     }
     kecId.put((byte) (b >> 24));
     kecId.put((byte) (b >> 16));
@@ -1205,7 +1211,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "limb1XorLimbXorWcpArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.micro/LIMB has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1227,7 +1233,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("phase has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.micro/PHASE has invalid value (" + b + ")");
     }
     phase.put((byte) (b >> 24));
     phase.put((byte) (b >> 16));
@@ -1273,7 +1279,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "refSizeXorSloXorEucCeil has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.micro/SLO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1323,7 +1329,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "sizeXorTloXorEucQuot has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.micro/TLO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1349,7 +1355,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "srcIdXorTotalSizeXorEucRem has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.micro/TOTAL_SIZE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1371,7 +1377,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("instXorInstXorCt has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.prprc/CT has invalid value (" + b + ")");
     }
     instXorInstXorCt.put((byte) (b >> 8));
     instXorInstXorCt.put((byte) b);
@@ -1391,7 +1397,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "auxIdXorCnSXorEucA has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.prprc/EUC_A has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1417,7 +1423,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "refOffsetXorCnTXorEucB has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.prprc/EUC_B has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1443,7 +1449,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "refSizeXorSloXorEucCeil has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.prprc/EUC_CEIL has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1481,7 +1487,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "sizeXorTloXorEucQuot has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.prprc/EUC_QUOT has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1507,7 +1513,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "srcIdXorTotalSizeXorEucRem has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.prprc/EUC_REM has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1533,7 +1539,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "limb1XorLimbXorWcpArg1Hi has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.prprc/WCP_ARG_1_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1559,7 +1565,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "limb2XorWcpArg1Lo has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.prprc/WCP_ARG_1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1585,7 +1591,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "srcOffsetHiXorWcpArg2Lo has invalid width (" + bs.bitLength() + "bits)");
+          "mmu.prprc/WCP_ARG_2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1703,7 +1709,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.STAMP has invalid value (" + b + ")");
     }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));
@@ -1721,7 +1727,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("tot has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.TOT has invalid value (" + b + ")");
     }
     tot.put((byte) (b >> 24));
     tot.put((byte) (b >> 16));
@@ -1739,7 +1745,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("totlz has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.TOTLZ has invalid value (" + b + ")");
     }
     totlz.put((byte) (b >> 24));
     totlz.put((byte) (b >> 16));
@@ -1757,7 +1763,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("totnt has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.TOTNT has invalid value (" + b + ")");
     }
     totnt.put((byte) (b >> 24));
     totnt.put((byte) (b >> 16));
@@ -1775,7 +1781,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("totrz has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mmu.TOTRZ has invalid value (" + b + ")");
     }
     totrz.put((byte) (b >> 24));
     totrz.put((byte) (b >> 16));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mod/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mod/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.mod;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -102,73 +103,74 @@ public class Trace {
   private final MappedByteBuffer stamp;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("mod.ACC_1_2", 8, length),
-        new ColumnHeader("mod.ACC_1_3", 8, length),
-        new ColumnHeader("mod.ACC_2_2", 8, length),
-        new ColumnHeader("mod.ACC_2_3", 8, length),
-        new ColumnHeader("mod.ACC_B_0", 8, length),
-        new ColumnHeader("mod.ACC_B_1", 8, length),
-        new ColumnHeader("mod.ACC_B_2", 8, length),
-        new ColumnHeader("mod.ACC_B_3", 8, length),
-        new ColumnHeader("mod.ACC_DELTA_0", 8, length),
-        new ColumnHeader("mod.ACC_DELTA_1", 8, length),
-        new ColumnHeader("mod.ACC_DELTA_2", 8, length),
-        new ColumnHeader("mod.ACC_DELTA_3", 8, length),
-        new ColumnHeader("mod.ACC_H_0", 8, length),
-        new ColumnHeader("mod.ACC_H_1", 8, length),
-        new ColumnHeader("mod.ACC_H_2", 8, length),
-        new ColumnHeader("mod.ACC_Q_0", 8, length),
-        new ColumnHeader("mod.ACC_Q_1", 8, length),
-        new ColumnHeader("mod.ACC_Q_2", 8, length),
-        new ColumnHeader("mod.ACC_Q_3", 8, length),
-        new ColumnHeader("mod.ACC_R_0", 8, length),
-        new ColumnHeader("mod.ACC_R_1", 8, length),
-        new ColumnHeader("mod.ACC_R_2", 8, length),
-        new ColumnHeader("mod.ACC_R_3", 8, length),
-        new ColumnHeader("mod.ARG_1_HI", 16, length),
-        new ColumnHeader("mod.ARG_1_LO", 16, length),
-        new ColumnHeader("mod.ARG_2_HI", 16, length),
-        new ColumnHeader("mod.ARG_2_LO", 16, length),
-        new ColumnHeader("mod.BYTE_1_2", 1, length),
-        new ColumnHeader("mod.BYTE_1_3", 1, length),
-        new ColumnHeader("mod.BYTE_2_2", 1, length),
-        new ColumnHeader("mod.BYTE_2_3", 1, length),
-        new ColumnHeader("mod.BYTE_B_0", 1, length),
-        new ColumnHeader("mod.BYTE_B_1", 1, length),
-        new ColumnHeader("mod.BYTE_B_2", 1, length),
-        new ColumnHeader("mod.BYTE_B_3", 1, length),
-        new ColumnHeader("mod.BYTE_DELTA_0", 1, length),
-        new ColumnHeader("mod.BYTE_DELTA_1", 1, length),
-        new ColumnHeader("mod.BYTE_DELTA_2", 1, length),
-        new ColumnHeader("mod.BYTE_DELTA_3", 1, length),
-        new ColumnHeader("mod.BYTE_H_0", 1, length),
-        new ColumnHeader("mod.BYTE_H_1", 1, length),
-        new ColumnHeader("mod.BYTE_H_2", 1, length),
-        new ColumnHeader("mod.BYTE_Q_0", 1, length),
-        new ColumnHeader("mod.BYTE_Q_1", 1, length),
-        new ColumnHeader("mod.BYTE_Q_2", 1, length),
-        new ColumnHeader("mod.BYTE_Q_3", 1, length),
-        new ColumnHeader("mod.BYTE_R_0", 1, length),
-        new ColumnHeader("mod.BYTE_R_1", 1, length),
-        new ColumnHeader("mod.BYTE_R_2", 1, length),
-        new ColumnHeader("mod.BYTE_R_3", 1, length),
-        new ColumnHeader("mod.CMP_1", 1, length),
-        new ColumnHeader("mod.CMP_2", 1, length),
-        new ColumnHeader("mod.CT", 1, length),
-        new ColumnHeader("mod.INST", 1, length),
-        new ColumnHeader("mod.IS_DIV", 1, length),
-        new ColumnHeader("mod.IS_MOD", 1, length),
-        new ColumnHeader("mod.IS_SDIV", 1, length),
-        new ColumnHeader("mod.IS_SMOD", 1, length),
-        new ColumnHeader("mod.MLI", 1, length),
-        new ColumnHeader("mod.MSB_1", 1, length),
-        new ColumnHeader("mod.MSB_2", 1, length),
-        new ColumnHeader("mod.OLI", 1, length),
-        new ColumnHeader("mod.RES_HI", 16, length),
-        new ColumnHeader("mod.RES_LO", 16, length),
-        new ColumnHeader("mod.SIGNED", 1, length),
-        new ColumnHeader("mod.STAMP", 4, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("mod.ACC_1_2", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_1_3", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_2_2", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_2_3", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_B_0", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_B_1", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_B_2", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_B_3", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_DELTA_0", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_DELTA_1", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_DELTA_2", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_DELTA_3", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_H_0", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_H_1", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_H_2", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_Q_0", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_Q_1", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_Q_2", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_Q_3", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_R_0", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_R_1", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_R_2", 8, length));
+    headers.add(new ColumnHeader("mod.ACC_R_3", 8, length));
+    headers.add(new ColumnHeader("mod.ARG_1_HI", 16, length));
+    headers.add(new ColumnHeader("mod.ARG_1_LO", 16, length));
+    headers.add(new ColumnHeader("mod.ARG_2_HI", 16, length));
+    headers.add(new ColumnHeader("mod.ARG_2_LO", 16, length));
+    headers.add(new ColumnHeader("mod.BYTE_1_2", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_1_3", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_2_2", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_2_3", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_B_0", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_B_1", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_B_2", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_B_3", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_DELTA_0", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_DELTA_1", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_DELTA_2", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_DELTA_3", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_H_0", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_H_1", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_H_2", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_Q_0", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_Q_1", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_Q_2", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_Q_3", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_R_0", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_R_1", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_R_2", 1, length));
+    headers.add(new ColumnHeader("mod.BYTE_R_3", 1, length));
+    headers.add(new ColumnHeader("mod.CMP_1", 1, length));
+    headers.add(new ColumnHeader("mod.CMP_2", 1, length));
+    headers.add(new ColumnHeader("mod.CT", 1, length));
+    headers.add(new ColumnHeader("mod.INST", 1, length));
+    headers.add(new ColumnHeader("mod.IS_DIV", 1, length));
+    headers.add(new ColumnHeader("mod.IS_MOD", 1, length));
+    headers.add(new ColumnHeader("mod.IS_SDIV", 1, length));
+    headers.add(new ColumnHeader("mod.IS_SMOD", 1, length));
+    headers.add(new ColumnHeader("mod.MLI", 1, length));
+    headers.add(new ColumnHeader("mod.MSB_1", 1, length));
+    headers.add(new ColumnHeader("mod.MSB_2", 1, length));
+    headers.add(new ColumnHeader("mod.OLI", 1, length));
+    headers.add(new ColumnHeader("mod.RES_HI", 16, length));
+    headers.add(new ColumnHeader("mod.RES_LO", 16, length));
+    headers.add(new ColumnHeader("mod.SIGNED", 1, length));
+    headers.add(new ColumnHeader("mod.STAMP", 4, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -259,7 +261,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("acc12 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_1_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -284,7 +287,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("acc13 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_1_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -309,7 +313,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("acc22 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_2_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -334,7 +339,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("acc23 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_2_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -359,7 +365,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accB0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_B_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -384,7 +391,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accB1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_B_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -409,7 +417,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accB2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_B_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -434,7 +443,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accB3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_B_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -460,7 +470,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "accDelta0 has invalid width (" + bs.bitLength() + "bits)");
+          "mod.ACC_DELTA_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -486,7 +496,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "accDelta1 has invalid width (" + bs.bitLength() + "bits)");
+          "mod.ACC_DELTA_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -512,7 +522,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "accDelta2 has invalid width (" + bs.bitLength() + "bits)");
+          "mod.ACC_DELTA_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -538,7 +548,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "accDelta3 has invalid width (" + bs.bitLength() + "bits)");
+          "mod.ACC_DELTA_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -563,7 +573,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accH0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_H_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -588,7 +599,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accH1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_H_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -613,7 +625,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accH2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_H_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -638,7 +651,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accQ0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_Q_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -663,7 +677,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accQ1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_Q_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -688,7 +703,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accQ2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_Q_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -713,7 +729,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accQ3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_Q_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -738,7 +755,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accR0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_R_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -763,7 +781,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accR1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_R_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -788,7 +807,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accR2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_R_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -813,7 +833,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accR3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ACC_R_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -838,7 +859,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ARG_1_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -863,7 +885,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ARG_1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -888,7 +911,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ARG_2_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -913,7 +937,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.ARG_2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1235,7 +1260,7 @@ public class Trace {
     }
 
     if (b >= 16L) {
-      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mod.CT has invalid value (" + b + ")");
     }
     ct.put((byte) b);
 
@@ -1361,7 +1386,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.RES_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1386,7 +1412,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mod.RES_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1420,7 +1447,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mod.STAMP has invalid value (" + b + ")");
     }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mul/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mul/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.mul;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -87,58 +88,59 @@ public class Trace {
   private final MappedByteBuffer tinyExponent;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("mul.ACC_A_0", 8, length),
-        new ColumnHeader("mul.ACC_A_1", 8, length),
-        new ColumnHeader("mul.ACC_A_2", 8, length),
-        new ColumnHeader("mul.ACC_A_3", 8, length),
-        new ColumnHeader("mul.ACC_B_0", 8, length),
-        new ColumnHeader("mul.ACC_B_1", 8, length),
-        new ColumnHeader("mul.ACC_B_2", 8, length),
-        new ColumnHeader("mul.ACC_B_3", 8, length),
-        new ColumnHeader("mul.ACC_C_0", 8, length),
-        new ColumnHeader("mul.ACC_C_1", 8, length),
-        new ColumnHeader("mul.ACC_C_2", 8, length),
-        new ColumnHeader("mul.ACC_C_3", 8, length),
-        new ColumnHeader("mul.ACC_H_0", 8, length),
-        new ColumnHeader("mul.ACC_H_1", 8, length),
-        new ColumnHeader("mul.ACC_H_2", 8, length),
-        new ColumnHeader("mul.ACC_H_3", 8, length),
-        new ColumnHeader("mul.ARG_1_HI", 16, length),
-        new ColumnHeader("mul.ARG_1_LO", 16, length),
-        new ColumnHeader("mul.ARG_2_HI", 16, length),
-        new ColumnHeader("mul.ARG_2_LO", 16, length),
-        new ColumnHeader("mul.BIT_NUM", 1, length),
-        new ColumnHeader("mul.BITS", 1, length),
-        new ColumnHeader("mul.BYTE_A_0", 1, length),
-        new ColumnHeader("mul.BYTE_A_1", 1, length),
-        new ColumnHeader("mul.BYTE_A_2", 1, length),
-        new ColumnHeader("mul.BYTE_A_3", 1, length),
-        new ColumnHeader("mul.BYTE_B_0", 1, length),
-        new ColumnHeader("mul.BYTE_B_1", 1, length),
-        new ColumnHeader("mul.BYTE_B_2", 1, length),
-        new ColumnHeader("mul.BYTE_B_3", 1, length),
-        new ColumnHeader("mul.BYTE_C_0", 1, length),
-        new ColumnHeader("mul.BYTE_C_1", 1, length),
-        new ColumnHeader("mul.BYTE_C_2", 1, length),
-        new ColumnHeader("mul.BYTE_C_3", 1, length),
-        new ColumnHeader("mul.BYTE_H_0", 1, length),
-        new ColumnHeader("mul.BYTE_H_1", 1, length),
-        new ColumnHeader("mul.BYTE_H_2", 1, length),
-        new ColumnHeader("mul.BYTE_H_3", 1, length),
-        new ColumnHeader("mul.COUNTER", 1, length),
-        new ColumnHeader("mul.EXPONENT_BIT", 1, length),
-        new ColumnHeader("mul.EXPONENT_BIT_ACCUMULATOR", 16, length),
-        new ColumnHeader("mul.EXPONENT_BIT_SOURCE", 1, length),
-        new ColumnHeader("mul.INSTRUCTION", 1, length),
-        new ColumnHeader("mul.MUL_STAMP", 4, length),
-        new ColumnHeader("mul.OLI", 1, length),
-        new ColumnHeader("mul.RES_HI", 16, length),
-        new ColumnHeader("mul.RES_LO", 16, length),
-        new ColumnHeader("mul.RESULT_VANISHES", 1, length),
-        new ColumnHeader("mul.SQUARE_AND_MULTIPLY", 1, length),
-        new ColumnHeader("mul.TINY_BASE", 1, length),
-        new ColumnHeader("mul.TINY_EXPONENT", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("mul.ACC_A_0", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_A_1", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_A_2", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_A_3", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_B_0", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_B_1", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_B_2", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_B_3", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_C_0", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_C_1", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_C_2", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_C_3", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_H_0", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_H_1", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_H_2", 8, length));
+    headers.add(new ColumnHeader("mul.ACC_H_3", 8, length));
+    headers.add(new ColumnHeader("mul.ARG_1_HI", 16, length));
+    headers.add(new ColumnHeader("mul.ARG_1_LO", 16, length));
+    headers.add(new ColumnHeader("mul.ARG_2_HI", 16, length));
+    headers.add(new ColumnHeader("mul.ARG_2_LO", 16, length));
+    headers.add(new ColumnHeader("mul.BIT_NUM", 1, length));
+    headers.add(new ColumnHeader("mul.BITS", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_A_0", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_A_1", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_A_2", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_A_3", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_B_0", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_B_1", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_B_2", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_B_3", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_C_0", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_C_1", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_C_2", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_C_3", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_H_0", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_H_1", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_H_2", 1, length));
+    headers.add(new ColumnHeader("mul.BYTE_H_3", 1, length));
+    headers.add(new ColumnHeader("mul.COUNTER", 1, length));
+    headers.add(new ColumnHeader("mul.EXPONENT_BIT", 1, length));
+    headers.add(new ColumnHeader("mul.EXPONENT_BIT_ACCUMULATOR", 16, length));
+    headers.add(new ColumnHeader("mul.EXPONENT_BIT_SOURCE", 1, length));
+    headers.add(new ColumnHeader("mul.INSTRUCTION", 1, length));
+    headers.add(new ColumnHeader("mul.MUL_STAMP", 4, length));
+    headers.add(new ColumnHeader("mul.OLI", 1, length));
+    headers.add(new ColumnHeader("mul.RES_HI", 16, length));
+    headers.add(new ColumnHeader("mul.RES_LO", 16, length));
+    headers.add(new ColumnHeader("mul.RESULT_VANISHES", 1, length));
+    headers.add(new ColumnHeader("mul.SQUARE_AND_MULTIPLY", 1, length));
+    headers.add(new ColumnHeader("mul.TINY_BASE", 1, length));
+    headers.add(new ColumnHeader("mul.TINY_EXPONENT", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -214,7 +216,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accA0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_A_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -239,7 +242,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accA1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_A_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -264,7 +268,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accA2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_A_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -289,7 +294,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accA3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_A_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -314,7 +320,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accB0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_B_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -339,7 +346,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accB1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_B_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -364,7 +372,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accB2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_B_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -389,7 +398,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accB3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_B_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -414,7 +424,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accC0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_C_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -439,7 +450,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accC1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_C_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -464,7 +476,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accC2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_C_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -489,7 +502,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accC3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_C_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -514,7 +528,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accH0 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_H_0 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -539,7 +554,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accH1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_H_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -564,7 +580,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accH2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_H_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -589,7 +606,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("accH3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ACC_H_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -614,7 +632,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ARG_1_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -639,7 +658,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ARG_1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -664,7 +684,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ARG_2_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -689,7 +710,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.ARG_2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -711,7 +733,7 @@ public class Trace {
     }
 
     if (b >= 128L) {
-      throw new IllegalArgumentException("bitNum has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mul.BIT_NUM has invalid value (" + b + ")");
     }
     bitNum.put((byte) b);
 
@@ -958,7 +980,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "exponentBitAccumulator has invalid width (" + bs.bitLength() + "bits)");
+          "mul.EXPONENT_BIT_ACCUMULATOR has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1004,7 +1026,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("mulStamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mul.MUL_STAMP has invalid value (" + b + ")");
     }
     mulStamp.put((byte) (b >> 24));
     mulStamp.put((byte) (b >> 16));
@@ -1037,7 +1059,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.RES_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1062,7 +1085,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mul.RES_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/Trace.java
@@ -229,7 +229,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 136) {
-      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.ACC_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 17; i++) {
@@ -254,7 +255,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 136) {
-      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.ACC_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 17; i++) {
@@ -279,7 +281,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 136) {
-      throw new IllegalArgumentException("acc3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.ACC_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 17; i++) {
@@ -304,7 +307,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 136) {
-      throw new IllegalArgumentException("acc4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.ACC_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 17; i++) {
@@ -329,7 +333,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 136) {
-      throw new IllegalArgumentException("accA has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.ACC_A has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 17; i++) {
@@ -354,7 +359,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 136) {
-      throw new IllegalArgumentException("accQ has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.ACC_Q has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 17; i++) {
@@ -379,7 +385,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 136) {
-      throw new IllegalArgumentException("accW has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.ACC_W has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 17; i++) {
@@ -512,7 +519,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("cMem has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.C_MEM has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -537,7 +545,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("cMemNew has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.C_MEM_NEW has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -562,7 +571,7 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("cn has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException("mxp.CN has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -596,7 +605,7 @@ public class Trace {
     }
 
     if (b >= 32L) {
-      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mxp.CT has invalid value (" + b + ")");
     }
     ct.put((byte) b);
 
@@ -638,7 +647,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("gasMxp has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.GAS_MXP has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -663,7 +673,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("gbyte has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.GBYTE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -688,7 +699,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("gword has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.GWORD has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -725,7 +737,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("linCost has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.LIN_COST has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -751,7 +764,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "maxOffset has invalid width (" + bs.bitLength() + "bits)");
+          "mxp.MAX_OFFSET has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -777,7 +790,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "maxOffset1 has invalid width (" + bs.bitLength() + "bits)");
+          "mxp.MAX_OFFSET_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -803,7 +816,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "maxOffset2 has invalid width (" + bs.bitLength() + "bits)");
+          "mxp.MAX_OFFSET_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -925,7 +938,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "offset1Hi has invalid width (" + bs.bitLength() + "bits)");
+          "mxp.OFFSET_1_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -951,7 +964,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "offset1Lo has invalid width (" + bs.bitLength() + "bits)");
+          "mxp.OFFSET_1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -977,7 +990,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "offset2Hi has invalid width (" + bs.bitLength() + "bits)");
+          "mxp.OFFSET_2_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1003,7 +1016,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "offset2Lo has invalid width (" + bs.bitLength() + "bits)");
+          "mxp.OFFSET_2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1028,7 +1041,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("quadCost has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.QUAD_COST has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1065,7 +1079,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("size1Hi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.SIZE_1_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1090,7 +1105,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("size1Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.SIZE_1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1127,7 +1143,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("size2Hi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.SIZE_2_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1152,7 +1169,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("size2Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.SIZE_2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1186,7 +1204,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("mxp.STAMP has invalid value (" + b + ")");
     }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));
@@ -1207,7 +1225,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("words has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.WORDS has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1232,7 +1251,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("wordsNew has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "mxp.WORDS_NEW has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/oob/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/oob/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.oob;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -105,52 +106,53 @@ public class Trace {
   private final MappedByteBuffer wcpFlag;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("oob.ADD_FLAG", 1, length),
-        new ColumnHeader("oob.CT", 1, length),
-        new ColumnHeader("oob.CT_MAX", 1, length),
-        new ColumnHeader("oob.DATA_1", 16, length),
-        new ColumnHeader("oob.DATA_2", 16, length),
-        new ColumnHeader("oob.DATA_3", 16, length),
-        new ColumnHeader("oob.DATA_4", 16, length),
-        new ColumnHeader("oob.DATA_5", 16, length),
-        new ColumnHeader("oob.DATA_6", 16, length),
-        new ColumnHeader("oob.DATA_7", 16, length),
-        new ColumnHeader("oob.DATA_8", 16, length),
-        new ColumnHeader("oob.DATA_9", 16, length),
-        new ColumnHeader("oob.IS_BLAKE2F_CDS", 1, length),
-        new ColumnHeader("oob.IS_BLAKE2F_PARAMS", 1, length),
-        new ColumnHeader("oob.IS_CALL", 1, length),
-        new ColumnHeader("oob.IS_CDL", 1, length),
-        new ColumnHeader("oob.IS_CREATE", 1, length),
-        new ColumnHeader("oob.IS_DEPLOYMENT", 1, length),
-        new ColumnHeader("oob.IS_ECADD", 1, length),
-        new ColumnHeader("oob.IS_ECMUL", 1, length),
-        new ColumnHeader("oob.IS_ECPAIRING", 1, length),
-        new ColumnHeader("oob.IS_ECRECOVER", 1, length),
-        new ColumnHeader("oob.IS_IDENTITY", 1, length),
-        new ColumnHeader("oob.IS_JUMP", 1, length),
-        new ColumnHeader("oob.IS_JUMPI", 1, length),
-        new ColumnHeader("oob.IS_MODEXP_CDS", 1, length),
-        new ColumnHeader("oob.IS_MODEXP_EXTRACT", 1, length),
-        new ColumnHeader("oob.IS_MODEXP_LEAD", 1, length),
-        new ColumnHeader("oob.IS_MODEXP_PRICING", 1, length),
-        new ColumnHeader("oob.IS_MODEXP_XBS", 1, length),
-        new ColumnHeader("oob.IS_RDC", 1, length),
-        new ColumnHeader("oob.IS_RIPEMD", 1, length),
-        new ColumnHeader("oob.IS_SHA2", 1, length),
-        new ColumnHeader("oob.IS_SSTORE", 1, length),
-        new ColumnHeader("oob.IS_XCALL", 1, length),
-        new ColumnHeader("oob.MOD_FLAG", 1, length),
-        new ColumnHeader("oob.OOB_INST", 2, length),
-        new ColumnHeader("oob.OUTGOING_DATA_1", 16, length),
-        new ColumnHeader("oob.OUTGOING_DATA_2", 16, length),
-        new ColumnHeader("oob.OUTGOING_DATA_3", 16, length),
-        new ColumnHeader("oob.OUTGOING_DATA_4", 16, length),
-        new ColumnHeader("oob.OUTGOING_INST", 1, length),
-        new ColumnHeader("oob.OUTGOING_RES_LO", 16, length),
-        new ColumnHeader("oob.STAMP", 4, length),
-        new ColumnHeader("oob.WCP_FLAG", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("oob.ADD_FLAG", 1, length));
+    headers.add(new ColumnHeader("oob.CT", 1, length));
+    headers.add(new ColumnHeader("oob.CT_MAX", 1, length));
+    headers.add(new ColumnHeader("oob.DATA_1", 16, length));
+    headers.add(new ColumnHeader("oob.DATA_2", 16, length));
+    headers.add(new ColumnHeader("oob.DATA_3", 16, length));
+    headers.add(new ColumnHeader("oob.DATA_4", 16, length));
+    headers.add(new ColumnHeader("oob.DATA_5", 16, length));
+    headers.add(new ColumnHeader("oob.DATA_6", 16, length));
+    headers.add(new ColumnHeader("oob.DATA_7", 16, length));
+    headers.add(new ColumnHeader("oob.DATA_8", 16, length));
+    headers.add(new ColumnHeader("oob.DATA_9", 16, length));
+    headers.add(new ColumnHeader("oob.IS_BLAKE2F_CDS", 1, length));
+    headers.add(new ColumnHeader("oob.IS_BLAKE2F_PARAMS", 1, length));
+    headers.add(new ColumnHeader("oob.IS_CALL", 1, length));
+    headers.add(new ColumnHeader("oob.IS_CDL", 1, length));
+    headers.add(new ColumnHeader("oob.IS_CREATE", 1, length));
+    headers.add(new ColumnHeader("oob.IS_DEPLOYMENT", 1, length));
+    headers.add(new ColumnHeader("oob.IS_ECADD", 1, length));
+    headers.add(new ColumnHeader("oob.IS_ECMUL", 1, length));
+    headers.add(new ColumnHeader("oob.IS_ECPAIRING", 1, length));
+    headers.add(new ColumnHeader("oob.IS_ECRECOVER", 1, length));
+    headers.add(new ColumnHeader("oob.IS_IDENTITY", 1, length));
+    headers.add(new ColumnHeader("oob.IS_JUMP", 1, length));
+    headers.add(new ColumnHeader("oob.IS_JUMPI", 1, length));
+    headers.add(new ColumnHeader("oob.IS_MODEXP_CDS", 1, length));
+    headers.add(new ColumnHeader("oob.IS_MODEXP_EXTRACT", 1, length));
+    headers.add(new ColumnHeader("oob.IS_MODEXP_LEAD", 1, length));
+    headers.add(new ColumnHeader("oob.IS_MODEXP_PRICING", 1, length));
+    headers.add(new ColumnHeader("oob.IS_MODEXP_XBS", 1, length));
+    headers.add(new ColumnHeader("oob.IS_RDC", 1, length));
+    headers.add(new ColumnHeader("oob.IS_RIPEMD", 1, length));
+    headers.add(new ColumnHeader("oob.IS_SHA2", 1, length));
+    headers.add(new ColumnHeader("oob.IS_SSTORE", 1, length));
+    headers.add(new ColumnHeader("oob.IS_XCALL", 1, length));
+    headers.add(new ColumnHeader("oob.MOD_FLAG", 1, length));
+    headers.add(new ColumnHeader("oob.OOB_INST", 2, length));
+    headers.add(new ColumnHeader("oob.OUTGOING_DATA_1", 16, length));
+    headers.add(new ColumnHeader("oob.OUTGOING_DATA_2", 16, length));
+    headers.add(new ColumnHeader("oob.OUTGOING_DATA_3", 16, length));
+    headers.add(new ColumnHeader("oob.OUTGOING_DATA_4", 16, length));
+    headers.add(new ColumnHeader("oob.OUTGOING_INST", 1, length));
+    headers.add(new ColumnHeader("oob.OUTGOING_RES_LO", 16, length));
+    headers.add(new ColumnHeader("oob.STAMP", 4, length));
+    headers.add(new ColumnHeader("oob.WCP_FLAG", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -229,7 +231,7 @@ public class Trace {
     }
 
     if (b >= 8L) {
-      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+      throw new IllegalArgumentException("oob.CT has invalid value (" + b + ")");
     }
     ct.put((byte) b);
 
@@ -244,7 +246,7 @@ public class Trace {
     }
 
     if (b >= 8L) {
-      throw new IllegalArgumentException("ctMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("oob.CT_MAX has invalid value (" + b + ")");
     }
     ctMax.put((byte) b);
 
@@ -262,7 +264,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("data1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "oob.DATA_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -287,7 +290,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("data2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "oob.DATA_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -312,7 +316,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("data3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "oob.DATA_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -337,7 +342,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("data4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "oob.DATA_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -362,7 +368,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("data5 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "oob.DATA_5 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -387,7 +394,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("data6 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "oob.DATA_6 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -412,7 +420,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("data7 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "oob.DATA_7 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -437,7 +446,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("data8 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "oob.DATA_8 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -462,7 +472,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("data9 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "oob.DATA_9 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -772,7 +783,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("oobInst has invalid value (" + b + ")");
+      throw new IllegalArgumentException("oob.OOB_INST has invalid value (" + b + ")");
     }
     oobInst.put((byte) (b >> 8));
     oobInst.put((byte) b);
@@ -792,7 +803,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "outgoingData1 has invalid width (" + bs.bitLength() + "bits)");
+          "oob.OUTGOING_DATA_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -818,7 +829,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "outgoingData2 has invalid width (" + bs.bitLength() + "bits)");
+          "oob.OUTGOING_DATA_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -844,7 +855,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "outgoingData3 has invalid width (" + bs.bitLength() + "bits)");
+          "oob.OUTGOING_DATA_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -870,7 +881,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "outgoingData4 has invalid width (" + bs.bitLength() + "bits)");
+          "oob.OUTGOING_DATA_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -908,7 +919,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "outgoingResLo has invalid width (" + bs.bitLength() + "bits)");
+          "oob.OUTGOING_RES_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -930,7 +941,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("oob.STAMP has invalid value (" + b + ")");
     }
     stamp.put((byte) (b >> 24));
     stamp.put((byte) (b >> 16));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpaddr/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpaddr/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.rlpaddr;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -65,34 +66,35 @@ public class Trace {
   private final MappedByteBuffer tinyNonZeroNonce;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("rlpaddr.ACC", 8, length),
-        new ColumnHeader("rlpaddr.ACC_BYTESIZE", 1, length),
-        new ColumnHeader("rlpaddr.ADDR_HI", 4, length),
-        new ColumnHeader("rlpaddr.ADDR_LO", 16, length),
-        new ColumnHeader("rlpaddr.BIT1", 1, length),
-        new ColumnHeader("rlpaddr.BIT_ACC", 1, length),
-        new ColumnHeader("rlpaddr.BYTE1", 1, length),
-        new ColumnHeader("rlpaddr.COUNTER", 1, length),
-        new ColumnHeader("rlpaddr.DEP_ADDR_HI", 4, length),
-        new ColumnHeader("rlpaddr.DEP_ADDR_LO", 16, length),
-        new ColumnHeader("rlpaddr.INDEX", 1, length),
-        new ColumnHeader("rlpaddr.KEC_HI", 16, length),
-        new ColumnHeader("rlpaddr.KEC_LO", 16, length),
-        new ColumnHeader("rlpaddr.LC", 1, length),
-        new ColumnHeader("rlpaddr.LIMB", 16, length),
-        new ColumnHeader("rlpaddr.nBYTES", 1, length),
-        new ColumnHeader("rlpaddr.NONCE", 8, length),
-        new ColumnHeader("rlpaddr.POWER", 16, length),
-        new ColumnHeader("rlpaddr.RAW_ADDR_HI", 16, length),
-        new ColumnHeader("rlpaddr.RECIPE", 1, length),
-        new ColumnHeader("rlpaddr.RECIPE_1", 1, length),
-        new ColumnHeader("rlpaddr.RECIPE_2", 1, length),
-        new ColumnHeader("rlpaddr.SALT_HI", 16, length),
-        new ColumnHeader("rlpaddr.SALT_LO", 16, length),
-        new ColumnHeader("rlpaddr.SELECTOR_KECCAK_RES", 1, length),
-        new ColumnHeader("rlpaddr.STAMP", 3, length),
-        new ColumnHeader("rlpaddr.TINY_NON_ZERO_NONCE", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("rlpaddr.ACC", 8, length));
+    headers.add(new ColumnHeader("rlpaddr.ACC_BYTESIZE", 1, length));
+    headers.add(new ColumnHeader("rlpaddr.ADDR_HI", 4, length));
+    headers.add(new ColumnHeader("rlpaddr.ADDR_LO", 16, length));
+    headers.add(new ColumnHeader("rlpaddr.BIT1", 1, length));
+    headers.add(new ColumnHeader("rlpaddr.BIT_ACC", 1, length));
+    headers.add(new ColumnHeader("rlpaddr.BYTE1", 1, length));
+    headers.add(new ColumnHeader("rlpaddr.COUNTER", 1, length));
+    headers.add(new ColumnHeader("rlpaddr.DEP_ADDR_HI", 4, length));
+    headers.add(new ColumnHeader("rlpaddr.DEP_ADDR_LO", 16, length));
+    headers.add(new ColumnHeader("rlpaddr.INDEX", 1, length));
+    headers.add(new ColumnHeader("rlpaddr.KEC_HI", 16, length));
+    headers.add(new ColumnHeader("rlpaddr.KEC_LO", 16, length));
+    headers.add(new ColumnHeader("rlpaddr.LC", 1, length));
+    headers.add(new ColumnHeader("rlpaddr.LIMB", 16, length));
+    headers.add(new ColumnHeader("rlpaddr.nBYTES", 1, length));
+    headers.add(new ColumnHeader("rlpaddr.NONCE", 8, length));
+    headers.add(new ColumnHeader("rlpaddr.POWER", 16, length));
+    headers.add(new ColumnHeader("rlpaddr.RAW_ADDR_HI", 16, length));
+    headers.add(new ColumnHeader("rlpaddr.RECIPE", 1, length));
+    headers.add(new ColumnHeader("rlpaddr.RECIPE_1", 1, length));
+    headers.add(new ColumnHeader("rlpaddr.RECIPE_2", 1, length));
+    headers.add(new ColumnHeader("rlpaddr.SALT_HI", 16, length));
+    headers.add(new ColumnHeader("rlpaddr.SALT_LO", 16, length));
+    headers.add(new ColumnHeader("rlpaddr.SELECTOR_KECCAK_RES", 1, length));
+    headers.add(new ColumnHeader("rlpaddr.STAMP", 3, length));
+    headers.add(new ColumnHeader("rlpaddr.TINY_NON_ZERO_NONCE", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -144,7 +146,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("acc has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlpaddr.ACC has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -178,7 +181,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("addrHi has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlpaddr.ADDR_HI has invalid value (" + b + ")");
     }
     addrHi.put((byte) (b >> 24));
     addrHi.put((byte) (b >> 16));
@@ -199,7 +202,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("addrLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlpaddr.ADDR_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -269,7 +273,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("depAddrHi has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlpaddr.DEP_ADDR_HI has invalid value (" + b + ")");
     }
     depAddrHi.put((byte) (b >> 24));
     depAddrHi.put((byte) (b >> 16));
@@ -291,7 +295,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "depAddrLo has invalid width (" + bs.bitLength() + "bits)");
+          "rlpaddr.DEP_ADDR_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -328,7 +332,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("kecHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlpaddr.KEC_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -353,7 +358,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("kecLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlpaddr.KEC_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -390,7 +396,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlpaddr.LIMB has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -427,7 +434,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("nonce has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlpaddr.NONCE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -452,7 +460,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("power has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlpaddr.POWER has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -478,7 +487,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "rawAddrHi has invalid width (" + bs.bitLength() + "bits)");
+          "rlpaddr.RAW_ADDR_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -539,7 +548,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("saltHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlpaddr.SALT_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -564,7 +574,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("saltLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlpaddr.SALT_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -598,7 +609,7 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlpaddr.STAMP has invalid value (" + b + ")");
     }
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.rlptxn;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -96,67 +97,68 @@ public class Trace {
   private final MappedByteBuffer type;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("rlptxn.ABS_TX_NUM", 2, length),
-        new ColumnHeader("rlptxn.ABS_TX_NUM_INFINY", 2, length),
-        new ColumnHeader("rlptxn.ACC_1", 16, length),
-        new ColumnHeader("rlptxn.ACC_2", 16, length),
-        new ColumnHeader("rlptxn.ACC_BYTESIZE", 1, length),
-        new ColumnHeader("rlptxn.ACCESS_TUPLE_BYTESIZE", 3, length),
-        new ColumnHeader("rlptxn.ADDR_HI", 4, length),
-        new ColumnHeader("rlptxn.ADDR_LO", 16, length),
-        new ColumnHeader("rlptxn.BIT", 1, length),
-        new ColumnHeader("rlptxn.BIT_ACC", 1, length),
-        new ColumnHeader("rlptxn.BYTE_1", 1, length),
-        new ColumnHeader("rlptxn.BYTE_2", 1, length),
-        new ColumnHeader("rlptxn.CODE_FRAGMENT_INDEX", 4, length),
-        new ColumnHeader("rlptxn.COUNTER", 1, length),
-        new ColumnHeader("rlptxn.DATA_GAS_COST", 4, length),
-        new ColumnHeader("rlptxn.DATA_HI", 16, length),
-        new ColumnHeader("rlptxn.DATA_LO", 16, length),
-        new ColumnHeader("rlptxn.DEPTH_1", 1, length),
-        new ColumnHeader("rlptxn.DEPTH_2", 1, length),
-        new ColumnHeader("rlptxn.DONE", 1, length),
-        new ColumnHeader("rlptxn.INDEX_DATA", 4, length),
-        new ColumnHeader("rlptxn.INDEX_LT", 4, length),
-        new ColumnHeader("rlptxn.INDEX_LX", 4, length),
-        new ColumnHeader("rlptxn.INPUT_1", 16, length),
-        new ColumnHeader("rlptxn.INPUT_2", 16, length),
-        new ColumnHeader("rlptxn.IS_PHASE_ACCESS_LIST", 1, length),
-        new ColumnHeader("rlptxn.IS_PHASE_BETA", 1, length),
-        new ColumnHeader("rlptxn.IS_PHASE_CHAIN_ID", 1, length),
-        new ColumnHeader("rlptxn.IS_PHASE_DATA", 1, length),
-        new ColumnHeader("rlptxn.IS_PHASE_GAS_LIMIT", 1, length),
-        new ColumnHeader("rlptxn.IS_PHASE_GAS_PRICE", 1, length),
-        new ColumnHeader("rlptxn.IS_PHASE_MAX_FEE_PER_GAS", 1, length),
-        new ColumnHeader("rlptxn.IS_PHASE_MAX_PRIORITY_FEE_PER_GAS", 1, length),
-        new ColumnHeader("rlptxn.IS_PHASE_NONCE", 1, length),
-        new ColumnHeader("rlptxn.IS_PHASE_R", 1, length),
-        new ColumnHeader("rlptxn.IS_PHASE_RLP_PREFIX", 1, length),
-        new ColumnHeader("rlptxn.IS_PHASE_S", 1, length),
-        new ColumnHeader("rlptxn.IS_PHASE_TO", 1, length),
-        new ColumnHeader("rlptxn.IS_PHASE_VALUE", 1, length),
-        new ColumnHeader("rlptxn.IS_PHASE_Y", 1, length),
-        new ColumnHeader("rlptxn.IS_PREFIX", 1, length),
-        new ColumnHeader("rlptxn.LC_CORRECTION", 1, length),
-        new ColumnHeader("rlptxn.LIMB", 16, length),
-        new ColumnHeader("rlptxn.LIMB_CONSTRUCTED", 1, length),
-        new ColumnHeader("rlptxn.LT", 1, length),
-        new ColumnHeader("rlptxn.LX", 1, length),
-        new ColumnHeader("rlptxn.nADDR", 2, length),
-        new ColumnHeader("rlptxn.nBYTES", 1, length),
-        new ColumnHeader("rlptxn.nKEYS", 2, length),
-        new ColumnHeader("rlptxn.nKEYS_PER_ADDR", 2, length),
-        new ColumnHeader("rlptxn.nSTEP", 1, length),
-        new ColumnHeader("rlptxn.PHASE", 1, length),
-        new ColumnHeader("rlptxn.PHASE_END", 1, length),
-        new ColumnHeader("rlptxn.PHASE_SIZE", 4, length),
-        new ColumnHeader("rlptxn.POWER", 16, length),
-        new ColumnHeader("rlptxn.REQUIRES_EVM_EXECUTION", 1, length),
-        new ColumnHeader("rlptxn.RLP_LT_BYTESIZE", 3, length),
-        new ColumnHeader("rlptxn.RLP_LX_BYTESIZE", 3, length),
-        new ColumnHeader("rlptxn.TO_HASH_BY_PROVER", 1, length),
-        new ColumnHeader("rlptxn.TYPE", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("rlptxn.ABS_TX_NUM", 2, length));
+    headers.add(new ColumnHeader("rlptxn.ABS_TX_NUM_INFINY", 2, length));
+    headers.add(new ColumnHeader("rlptxn.ACC_1", 16, length));
+    headers.add(new ColumnHeader("rlptxn.ACC_2", 16, length));
+    headers.add(new ColumnHeader("rlptxn.ACC_BYTESIZE", 1, length));
+    headers.add(new ColumnHeader("rlptxn.ACCESS_TUPLE_BYTESIZE", 3, length));
+    headers.add(new ColumnHeader("rlptxn.ADDR_HI", 4, length));
+    headers.add(new ColumnHeader("rlptxn.ADDR_LO", 16, length));
+    headers.add(new ColumnHeader("rlptxn.BIT", 1, length));
+    headers.add(new ColumnHeader("rlptxn.BIT_ACC", 1, length));
+    headers.add(new ColumnHeader("rlptxn.BYTE_1", 1, length));
+    headers.add(new ColumnHeader("rlptxn.BYTE_2", 1, length));
+    headers.add(new ColumnHeader("rlptxn.CODE_FRAGMENT_INDEX", 4, length));
+    headers.add(new ColumnHeader("rlptxn.COUNTER", 1, length));
+    headers.add(new ColumnHeader("rlptxn.DATA_GAS_COST", 4, length));
+    headers.add(new ColumnHeader("rlptxn.DATA_HI", 16, length));
+    headers.add(new ColumnHeader("rlptxn.DATA_LO", 16, length));
+    headers.add(new ColumnHeader("rlptxn.DEPTH_1", 1, length));
+    headers.add(new ColumnHeader("rlptxn.DEPTH_2", 1, length));
+    headers.add(new ColumnHeader("rlptxn.DONE", 1, length));
+    headers.add(new ColumnHeader("rlptxn.INDEX_DATA", 4, length));
+    headers.add(new ColumnHeader("rlptxn.INDEX_LT", 4, length));
+    headers.add(new ColumnHeader("rlptxn.INDEX_LX", 4, length));
+    headers.add(new ColumnHeader("rlptxn.INPUT_1", 16, length));
+    headers.add(new ColumnHeader("rlptxn.INPUT_2", 16, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_ACCESS_LIST", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_BETA", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_CHAIN_ID", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_DATA", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_GAS_LIMIT", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_GAS_PRICE", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_MAX_FEE_PER_GAS", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_MAX_PRIORITY_FEE_PER_GAS", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_NONCE", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_R", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_RLP_PREFIX", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_S", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_TO", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_VALUE", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PHASE_Y", 1, length));
+    headers.add(new ColumnHeader("rlptxn.IS_PREFIX", 1, length));
+    headers.add(new ColumnHeader("rlptxn.LC_CORRECTION", 1, length));
+    headers.add(new ColumnHeader("rlptxn.LIMB", 16, length));
+    headers.add(new ColumnHeader("rlptxn.LIMB_CONSTRUCTED", 1, length));
+    headers.add(new ColumnHeader("rlptxn.LT", 1, length));
+    headers.add(new ColumnHeader("rlptxn.LX", 1, length));
+    headers.add(new ColumnHeader("rlptxn.nADDR", 2, length));
+    headers.add(new ColumnHeader("rlptxn.nBYTES", 1, length));
+    headers.add(new ColumnHeader("rlptxn.nKEYS", 2, length));
+    headers.add(new ColumnHeader("rlptxn.nKEYS_PER_ADDR", 2, length));
+    headers.add(new ColumnHeader("rlptxn.nSTEP", 1, length));
+    headers.add(new ColumnHeader("rlptxn.PHASE", 1, length));
+    headers.add(new ColumnHeader("rlptxn.PHASE_END", 1, length));
+    headers.add(new ColumnHeader("rlptxn.PHASE_SIZE", 4, length));
+    headers.add(new ColumnHeader("rlptxn.POWER", 16, length));
+    headers.add(new ColumnHeader("rlptxn.REQUIRES_EVM_EXECUTION", 1, length));
+    headers.add(new ColumnHeader("rlptxn.RLP_LT_BYTESIZE", 3, length));
+    headers.add(new ColumnHeader("rlptxn.RLP_LX_BYTESIZE", 3, length));
+    headers.add(new ColumnHeader("rlptxn.TO_HASH_BY_PROVER", 1, length));
+    headers.add(new ColumnHeader("rlptxn.TYPE", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -238,7 +240,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("absTxNum has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.ABS_TX_NUM has invalid value (" + b + ")");
     }
     absTxNum.put((byte) (b >> 8));
     absTxNum.put((byte) b);
@@ -254,7 +256,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("absTxNumInfiny has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.ABS_TX_NUM_INFINY has invalid value (" + b + ")");
     }
     absTxNumInfiny.put((byte) (b >> 8));
     absTxNumInfiny.put((byte) b);
@@ -273,7 +275,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxn.ACC_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -298,7 +301,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxn.ACC_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -320,7 +324,7 @@ public class Trace {
     }
 
     if (b >= 32L) {
-      throw new IllegalArgumentException("accBytesize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.ACC_BYTESIZE has invalid value (" + b + ")");
     }
     accBytesize.put((byte) b);
 
@@ -335,7 +339,8 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("accessTupleBytesize has invalid value (" + b + ")");
+      throw new IllegalArgumentException(
+          "rlptxn.ACCESS_TUPLE_BYTESIZE has invalid value (" + b + ")");
     }
     accessTupleBytesize.put((byte) (b >> 16));
     accessTupleBytesize.put((byte) (b >> 8));
@@ -352,7 +357,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("addrHi has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.ADDR_HI has invalid value (" + b + ")");
     }
     addrHi.put((byte) (b >> 24));
     addrHi.put((byte) (b >> 16));
@@ -373,7 +378,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("addrLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxn.ADDR_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -443,7 +449,8 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")");
+      throw new IllegalArgumentException(
+          "rlptxn.CODE_FRAGMENT_INDEX has invalid value (" + b + ")");
     }
     codeFragmentIndex.put((byte) (b >> 24));
     codeFragmentIndex.put((byte) (b >> 16));
@@ -461,7 +468,7 @@ public class Trace {
     }
 
     if (b >= 32L) {
-      throw new IllegalArgumentException("counter has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.COUNTER has invalid value (" + b + ")");
     }
     counter.put((byte) b);
 
@@ -476,7 +483,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("dataGasCost has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.DATA_GAS_COST has invalid value (" + b + ")");
     }
     dataGasCost.put((byte) (b >> 24));
     dataGasCost.put((byte) (b >> 16));
@@ -497,7 +504,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("dataHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxn.DATA_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -522,7 +530,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("dataLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxn.DATA_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -580,7 +589,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("indexData has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.INDEX_DATA has invalid value (" + b + ")");
     }
     indexData.put((byte) (b >> 24));
     indexData.put((byte) (b >> 16));
@@ -598,7 +607,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("indexLt has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.INDEX_LT has invalid value (" + b + ")");
     }
     indexLt.put((byte) (b >> 24));
     indexLt.put((byte) (b >> 16));
@@ -616,7 +625,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("indexLx has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.INDEX_LX has invalid value (" + b + ")");
     }
     indexLx.put((byte) (b >> 24));
     indexLx.put((byte) (b >> 16));
@@ -637,7 +646,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("input1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxn.INPUT_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -662,7 +672,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("input2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxn.INPUT_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -891,7 +902,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxn.LIMB has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -949,7 +961,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("nAddr has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.nADDR has invalid value (" + b + ")");
     }
     nAddr.put((byte) (b >> 8));
     nAddr.put((byte) b);
@@ -965,7 +977,7 @@ public class Trace {
     }
 
     if (b >= 32L) {
-      throw new IllegalArgumentException("nBytes has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.nBYTES has invalid value (" + b + ")");
     }
     nBytes.put((byte) b);
 
@@ -980,7 +992,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("nKeys has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.nKEYS has invalid value (" + b + ")");
     }
     nKeys.put((byte) (b >> 8));
     nKeys.put((byte) b);
@@ -996,7 +1008,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("nKeysPerAddr has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.nKEYS_PER_ADDR has invalid value (" + b + ")");
     }
     nKeysPerAddr.put((byte) (b >> 8));
     nKeysPerAddr.put((byte) b);
@@ -1012,7 +1024,7 @@ public class Trace {
     }
 
     if (b >= 32L) {
-      throw new IllegalArgumentException("nStep has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.nSTEP has invalid value (" + b + ")");
     }
     nStep.put((byte) b);
 
@@ -1027,7 +1039,7 @@ public class Trace {
     }
 
     if (b >= 32L) {
-      throw new IllegalArgumentException("phase has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.PHASE has invalid value (" + b + ")");
     }
     phase.put((byte) b);
 
@@ -1054,7 +1066,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("phaseSize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.PHASE_SIZE has invalid value (" + b + ")");
     }
     phaseSize.put((byte) (b >> 24));
     phaseSize.put((byte) (b >> 16));
@@ -1075,7 +1087,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("power has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxn.POWER has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1109,7 +1122,7 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("rlpLtBytesize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.RLP_LT_BYTESIZE has invalid value (" + b + ")");
     }
     rlpLtBytesize.put((byte) (b >> 16));
     rlpLtBytesize.put((byte) (b >> 8));
@@ -1126,7 +1139,7 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("rlpLxBytesize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.RLP_LX_BYTESIZE has invalid value (" + b + ")");
     }
     rlpLxBytesize.put((byte) (b >> 16));
     rlpLxBytesize.put((byte) (b >> 8));
@@ -1155,7 +1168,7 @@ public class Trace {
     }
 
     if (b >= 8L) {
-      throw new IllegalArgumentException("type has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxn.TYPE has invalid value (" + b + ")");
     }
     type.put((byte) b);
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxrcpt/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxrcpt/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.rlptxrcpt;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -85,51 +86,52 @@ public class Trace {
   private final MappedByteBuffer txrcptSize;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("rlptxrcpt.ABS_LOG_NUM", 4, length),
-        new ColumnHeader("rlptxrcpt.ABS_LOG_NUM_MAX", 4, length),
-        new ColumnHeader("rlptxrcpt.ABS_TX_NUM", 4, length),
-        new ColumnHeader("rlptxrcpt.ABS_TX_NUM_MAX", 4, length),
-        new ColumnHeader("rlptxrcpt.ACC_1", 16, length),
-        new ColumnHeader("rlptxrcpt.ACC_2", 16, length),
-        new ColumnHeader("rlptxrcpt.ACC_3", 16, length),
-        new ColumnHeader("rlptxrcpt.ACC_4", 16, length),
-        new ColumnHeader("rlptxrcpt.ACC_SIZE", 1, length),
-        new ColumnHeader("rlptxrcpt.BIT", 1, length),
-        new ColumnHeader("rlptxrcpt.BIT_ACC", 1, length),
-        new ColumnHeader("rlptxrcpt.BYTE_1", 1, length),
-        new ColumnHeader("rlptxrcpt.BYTE_2", 1, length),
-        new ColumnHeader("rlptxrcpt.BYTE_3", 1, length),
-        new ColumnHeader("rlptxrcpt.BYTE_4", 1, length),
-        new ColumnHeader("rlptxrcpt.COUNTER", 4, length),
-        new ColumnHeader("rlptxrcpt.DEPTH_1", 1, length),
-        new ColumnHeader("rlptxrcpt.DONE", 1, length),
-        new ColumnHeader("rlptxrcpt.INDEX", 3, length),
-        new ColumnHeader("rlptxrcpt.INDEX_LOCAL", 3, length),
-        new ColumnHeader("rlptxrcpt.INPUT_1", 16, length),
-        new ColumnHeader("rlptxrcpt.INPUT_2", 16, length),
-        new ColumnHeader("rlptxrcpt.INPUT_3", 16, length),
-        new ColumnHeader("rlptxrcpt.INPUT_4", 16, length),
-        new ColumnHeader("rlptxrcpt.IS_DATA", 1, length),
-        new ColumnHeader("rlptxrcpt.IS_PREFIX", 1, length),
-        new ColumnHeader("rlptxrcpt.IS_TOPIC", 1, length),
-        new ColumnHeader("rlptxrcpt.LC_CORRECTION", 1, length),
-        new ColumnHeader("rlptxrcpt.LIMB", 16, length),
-        new ColumnHeader("rlptxrcpt.LIMB_CONSTRUCTED", 1, length),
-        new ColumnHeader("rlptxrcpt.LOCAL_SIZE", 4, length),
-        new ColumnHeader("rlptxrcpt.LOG_ENTRY_SIZE", 4, length),
-        new ColumnHeader("rlptxrcpt.nBYTES", 1, length),
-        new ColumnHeader("rlptxrcpt.nSTEP", 4, length),
-        new ColumnHeader("rlptxrcpt.PHASE_1", 1, length),
-        new ColumnHeader("rlptxrcpt.PHASE_2", 1, length),
-        new ColumnHeader("rlptxrcpt.PHASE_3", 1, length),
-        new ColumnHeader("rlptxrcpt.PHASE_4", 1, length),
-        new ColumnHeader("rlptxrcpt.PHASE_5", 1, length),
-        new ColumnHeader("rlptxrcpt.PHASE_END", 1, length),
-        new ColumnHeader("rlptxrcpt.PHASE_ID", 2, length),
-        new ColumnHeader("rlptxrcpt.PHASE_SIZE", 4, length),
-        new ColumnHeader("rlptxrcpt.POWER", 16, length),
-        new ColumnHeader("rlptxrcpt.TXRCPT_SIZE", 4, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("rlptxrcpt.ABS_LOG_NUM", 4, length));
+    headers.add(new ColumnHeader("rlptxrcpt.ABS_LOG_NUM_MAX", 4, length));
+    headers.add(new ColumnHeader("rlptxrcpt.ABS_TX_NUM", 4, length));
+    headers.add(new ColumnHeader("rlptxrcpt.ABS_TX_NUM_MAX", 4, length));
+    headers.add(new ColumnHeader("rlptxrcpt.ACC_1", 16, length));
+    headers.add(new ColumnHeader("rlptxrcpt.ACC_2", 16, length));
+    headers.add(new ColumnHeader("rlptxrcpt.ACC_3", 16, length));
+    headers.add(new ColumnHeader("rlptxrcpt.ACC_4", 16, length));
+    headers.add(new ColumnHeader("rlptxrcpt.ACC_SIZE", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.BIT", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.BIT_ACC", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.BYTE_1", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.BYTE_2", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.BYTE_3", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.BYTE_4", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.COUNTER", 4, length));
+    headers.add(new ColumnHeader("rlptxrcpt.DEPTH_1", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.DONE", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.INDEX", 3, length));
+    headers.add(new ColumnHeader("rlptxrcpt.INDEX_LOCAL", 3, length));
+    headers.add(new ColumnHeader("rlptxrcpt.INPUT_1", 16, length));
+    headers.add(new ColumnHeader("rlptxrcpt.INPUT_2", 16, length));
+    headers.add(new ColumnHeader("rlptxrcpt.INPUT_3", 16, length));
+    headers.add(new ColumnHeader("rlptxrcpt.INPUT_4", 16, length));
+    headers.add(new ColumnHeader("rlptxrcpt.IS_DATA", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.IS_PREFIX", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.IS_TOPIC", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.LC_CORRECTION", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.LIMB", 16, length));
+    headers.add(new ColumnHeader("rlptxrcpt.LIMB_CONSTRUCTED", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.LOCAL_SIZE", 4, length));
+    headers.add(new ColumnHeader("rlptxrcpt.LOG_ENTRY_SIZE", 4, length));
+    headers.add(new ColumnHeader("rlptxrcpt.nBYTES", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.nSTEP", 4, length));
+    headers.add(new ColumnHeader("rlptxrcpt.PHASE_1", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.PHASE_2", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.PHASE_3", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.PHASE_4", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.PHASE_5", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.PHASE_END", 1, length));
+    headers.add(new ColumnHeader("rlptxrcpt.PHASE_ID", 2, length));
+    headers.add(new ColumnHeader("rlptxrcpt.PHASE_SIZE", 4, length));
+    headers.add(new ColumnHeader("rlptxrcpt.POWER", 16, length));
+    headers.add(new ColumnHeader("rlptxrcpt.TXRCPT_SIZE", 4, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -195,7 +197,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("absLogNum has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.ABS_LOG_NUM has invalid value (" + b + ")");
     }
     absLogNum.put((byte) (b >> 24));
     absLogNum.put((byte) (b >> 16));
@@ -213,7 +215,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("absLogNumMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.ABS_LOG_NUM_MAX has invalid value (" + b + ")");
     }
     absLogNumMax.put((byte) (b >> 24));
     absLogNumMax.put((byte) (b >> 16));
@@ -231,7 +233,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("absTxNum has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.ABS_TX_NUM has invalid value (" + b + ")");
     }
     absTxNum.put((byte) (b >> 24));
     absTxNum.put((byte) (b >> 16));
@@ -249,7 +251,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("absTxNumMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.ABS_TX_NUM_MAX has invalid value (" + b + ")");
     }
     absTxNumMax.put((byte) (b >> 24));
     absTxNumMax.put((byte) (b >> 16));
@@ -270,7 +272,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxrcpt.ACC_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -295,7 +298,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxrcpt.ACC_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -320,7 +324,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxrcpt.ACC_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -345,7 +350,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxrcpt.ACC_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -367,7 +373,7 @@ public class Trace {
     }
 
     if (b >= 32L) {
-      throw new IllegalArgumentException("accSize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.ACC_SIZE has invalid value (" + b + ")");
     }
     accSize.put((byte) b);
 
@@ -454,7 +460,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("counter has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.COUNTER has invalid value (" + b + ")");
     }
     counter.put((byte) (b >> 24));
     counter.put((byte) (b >> 16));
@@ -496,7 +502,7 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("index has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.INDEX has invalid value (" + b + ")");
     }
     index.put((byte) (b >> 16));
     index.put((byte) (b >> 8));
@@ -513,7 +519,7 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("indexLocal has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.INDEX_LOCAL has invalid value (" + b + ")");
     }
     indexLocal.put((byte) (b >> 16));
     indexLocal.put((byte) (b >> 8));
@@ -533,7 +539,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("input1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxrcpt.INPUT_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -558,7 +565,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("input2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxrcpt.INPUT_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -583,7 +591,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("input3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxrcpt.INPUT_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -608,7 +617,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("input4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxrcpt.INPUT_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -681,7 +691,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxrcpt.LIMB has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -715,7 +726,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("localSize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.LOCAL_SIZE has invalid value (" + b + ")");
     }
     localSize.put((byte) (b >> 24));
     localSize.put((byte) (b >> 16));
@@ -733,7 +744,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("logEntrySize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.LOG_ENTRY_SIZE has invalid value (" + b + ")");
     }
     logEntrySize.put((byte) (b >> 24));
     logEntrySize.put((byte) (b >> 16));
@@ -751,7 +762,7 @@ public class Trace {
     }
 
     if (b >= 32L) {
-      throw new IllegalArgumentException("nBytes has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.nBYTES has invalid value (" + b + ")");
     }
     nBytes.put((byte) b);
 
@@ -766,7 +777,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("nStep has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.nSTEP has invalid value (" + b + ")");
     }
     nStep.put((byte) (b >> 24));
     nStep.put((byte) (b >> 16));
@@ -856,7 +867,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("phaseId has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.PHASE_ID has invalid value (" + b + ")");
     }
     phaseId.put((byte) (b >> 8));
     phaseId.put((byte) b);
@@ -872,7 +883,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("phaseSize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.PHASE_SIZE has invalid value (" + b + ")");
     }
     phaseSize.put((byte) (b >> 24));
     phaseSize.put((byte) (b >> 16));
@@ -893,7 +904,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("power has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "rlptxrcpt.POWER has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -915,7 +927,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("txrcptSize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rlptxrcpt.TXRCPT_SIZE has invalid value (" + b + ")");
     }
     txrcptSize.put((byte) (b >> 24));
     txrcptSize.put((byte) (b >> 16));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rom/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rom/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.rom;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -59,30 +60,31 @@ public class Trace {
   private final MappedByteBuffer pushValueLo;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("rom.ACC", 16, length),
-        new ColumnHeader("rom.CODE_FRAGMENT_INDEX", 4, length),
-        new ColumnHeader("rom.CODE_FRAGMENT_INDEX_INFTY", 4, length),
-        new ColumnHeader("rom.CODE_SIZE", 4, length),
-        new ColumnHeader("rom.CODESIZE_REACHED", 1, length),
-        new ColumnHeader("rom.COUNTER", 1, length),
-        new ColumnHeader("rom.COUNTER_MAX", 1, length),
-        new ColumnHeader("rom.COUNTER_PUSH", 1, length),
-        new ColumnHeader("rom.INDEX", 4, length),
-        new ColumnHeader("rom.IS_JUMPDEST", 1, length),
-        new ColumnHeader("rom.IS_PUSH", 1, length),
-        new ColumnHeader("rom.IS_PUSH_DATA", 1, length),
-        new ColumnHeader("rom.LIMB", 16, length),
-        new ColumnHeader("rom.nBYTES", 1, length),
-        new ColumnHeader("rom.nBYTES_ACC", 1, length),
-        new ColumnHeader("rom.OPCODE", 1, length),
-        new ColumnHeader("rom.PADDED_BYTECODE_BYTE", 1, length),
-        new ColumnHeader("rom.PROGRAM_COUNTER", 4, length),
-        new ColumnHeader("rom.PUSH_FUNNEL_BIT", 1, length),
-        new ColumnHeader("rom.PUSH_PARAMETER", 1, length),
-        new ColumnHeader("rom.PUSH_VALUE_ACC", 16, length),
-        new ColumnHeader("rom.PUSH_VALUE_HI", 16, length),
-        new ColumnHeader("rom.PUSH_VALUE_LO", 16, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("rom.ACC", 16, length));
+    headers.add(new ColumnHeader("rom.CODE_FRAGMENT_INDEX", 4, length));
+    headers.add(new ColumnHeader("rom.CODE_FRAGMENT_INDEX_INFTY", 4, length));
+    headers.add(new ColumnHeader("rom.CODE_SIZE", 4, length));
+    headers.add(new ColumnHeader("rom.CODESIZE_REACHED", 1, length));
+    headers.add(new ColumnHeader("rom.COUNTER", 1, length));
+    headers.add(new ColumnHeader("rom.COUNTER_MAX", 1, length));
+    headers.add(new ColumnHeader("rom.COUNTER_PUSH", 1, length));
+    headers.add(new ColumnHeader("rom.INDEX", 4, length));
+    headers.add(new ColumnHeader("rom.IS_JUMPDEST", 1, length));
+    headers.add(new ColumnHeader("rom.IS_PUSH", 1, length));
+    headers.add(new ColumnHeader("rom.IS_PUSH_DATA", 1, length));
+    headers.add(new ColumnHeader("rom.LIMB", 16, length));
+    headers.add(new ColumnHeader("rom.nBYTES", 1, length));
+    headers.add(new ColumnHeader("rom.nBYTES_ACC", 1, length));
+    headers.add(new ColumnHeader("rom.OPCODE", 1, length));
+    headers.add(new ColumnHeader("rom.PADDED_BYTECODE_BYTE", 1, length));
+    headers.add(new ColumnHeader("rom.PROGRAM_COUNTER", 4, length));
+    headers.add(new ColumnHeader("rom.PUSH_FUNNEL_BIT", 1, length));
+    headers.add(new ColumnHeader("rom.PUSH_PARAMETER", 1, length));
+    headers.add(new ColumnHeader("rom.PUSH_VALUE_ACC", 16, length));
+    headers.add(new ColumnHeader("rom.PUSH_VALUE_HI", 16, length));
+    headers.add(new ColumnHeader("rom.PUSH_VALUE_LO", 16, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -130,7 +132,7 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException("rom.ACC has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -152,7 +154,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rom.CODE_FRAGMENT_INDEX has invalid value (" + b + ")");
     }
     codeFragmentIndex.put((byte) (b >> 24));
     codeFragmentIndex.put((byte) (b >> 16));
@@ -170,7 +172,8 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("codeFragmentIndexInfty has invalid value (" + b + ")");
+      throw new IllegalArgumentException(
+          "rom.CODE_FRAGMENT_INDEX_INFTY has invalid value (" + b + ")");
     }
     codeFragmentIndexInfty.put((byte) (b >> 24));
     codeFragmentIndexInfty.put((byte) (b >> 16));
@@ -188,7 +191,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("codeSize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rom.CODE_SIZE has invalid value (" + b + ")");
     }
     codeSize.put((byte) (b >> 24));
     codeSize.put((byte) (b >> 16));
@@ -254,7 +257,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("index has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rom.INDEX has invalid value (" + b + ")");
     }
     index.put((byte) (b >> 24));
     index.put((byte) (b >> 16));
@@ -311,7 +314,7 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException("rom.LIMB has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -381,7 +384,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("programCounter has invalid value (" + b + ")");
+      throw new IllegalArgumentException("rom.PROGRAM_COUNTER has invalid value (" + b + ")");
     }
     programCounter.put((byte) (b >> 24));
     programCounter.put((byte) (b >> 16));
@@ -427,7 +430,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "pushValueAcc has invalid width (" + bs.bitLength() + "bits)");
+          "rom.PUSH_VALUE_ACC has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -453,7 +456,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "pushValueHi has invalid width (" + bs.bitLength() + "bits)");
+          "rom.PUSH_VALUE_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -479,7 +482,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "pushValueLo has invalid width (" + bs.bitLength() + "bits)");
+          "rom.PUSH_VALUE_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.romlex;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -46,18 +47,19 @@ public class Trace {
   private final MappedByteBuffer readFromState;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("romlex.ADDRESS_HI", 4, length),
-        new ColumnHeader("romlex.ADDRESS_LO", 16, length),
-        new ColumnHeader("romlex.CODE_FRAGMENT_INDEX", 4, length),
-        new ColumnHeader("romlex.CODE_FRAGMENT_INDEX_INFTY", 4, length),
-        new ColumnHeader("romlex.CODE_HASH_HI", 16, length),
-        new ColumnHeader("romlex.CODE_HASH_LO", 16, length),
-        new ColumnHeader("romlex.CODE_SIZE", 4, length),
-        new ColumnHeader("romlex.COMMIT_TO_STATE", 1, length),
-        new ColumnHeader("romlex.DEPLOYMENT_NUMBER", 2, length),
-        new ColumnHeader("romlex.DEPLOYMENT_STATUS", 1, length),
-        new ColumnHeader("romlex.READ_FROM_STATE", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("romlex.ADDRESS_HI", 4, length));
+    headers.add(new ColumnHeader("romlex.ADDRESS_LO", 16, length));
+    headers.add(new ColumnHeader("romlex.CODE_FRAGMENT_INDEX", 4, length));
+    headers.add(new ColumnHeader("romlex.CODE_FRAGMENT_INDEX_INFTY", 4, length));
+    headers.add(new ColumnHeader("romlex.CODE_HASH_HI", 16, length));
+    headers.add(new ColumnHeader("romlex.CODE_HASH_LO", 16, length));
+    headers.add(new ColumnHeader("romlex.CODE_SIZE", 4, length));
+    headers.add(new ColumnHeader("romlex.COMMIT_TO_STATE", 1, length));
+    headers.add(new ColumnHeader("romlex.DEPLOYMENT_NUMBER", 2, length));
+    headers.add(new ColumnHeader("romlex.DEPLOYMENT_STATUS", 1, length));
+    headers.add(new ColumnHeader("romlex.READ_FROM_STATE", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -90,7 +92,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("addressHi has invalid value (" + b + ")");
+      throw new IllegalArgumentException("romlex.ADDRESS_HI has invalid value (" + b + ")");
     }
     addressHi.put((byte) (b >> 24));
     addressHi.put((byte) (b >> 16));
@@ -112,7 +114,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "addressLo has invalid width (" + bs.bitLength() + "bits)");
+          "romlex.ADDRESS_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -134,7 +136,8 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")");
+      throw new IllegalArgumentException(
+          "romlex.CODE_FRAGMENT_INDEX has invalid value (" + b + ")");
     }
     codeFragmentIndex.put((byte) (b >> 24));
     codeFragmentIndex.put((byte) (b >> 16));
@@ -152,7 +155,8 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("codeFragmentIndexInfty has invalid value (" + b + ")");
+      throw new IllegalArgumentException(
+          "romlex.CODE_FRAGMENT_INDEX_INFTY has invalid value (" + b + ")");
     }
     codeFragmentIndexInfty.put((byte) (b >> 24));
     codeFragmentIndexInfty.put((byte) (b >> 16));
@@ -174,7 +178,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "codeHashHi has invalid width (" + bs.bitLength() + "bits)");
+          "romlex.CODE_HASH_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -200,7 +204,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "codeHashLo has invalid width (" + bs.bitLength() + "bits)");
+          "romlex.CODE_HASH_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -222,7 +226,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("codeSize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("romlex.CODE_SIZE has invalid value (" + b + ")");
     }
     codeSize.put((byte) (b >> 24));
     codeSize.put((byte) (b >> 16));
@@ -252,7 +256,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("deploymentNumber has invalid value (" + b + ")");
+      throw new IllegalArgumentException("romlex.DEPLOYMENT_NUMBER has invalid value (" + b + ")");
     }
     deploymentNumber.put((byte) (b >> 8));
     deploymentNumber.put((byte) b);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shakiradata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shakiradata/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.shakiradata;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -55,25 +56,26 @@ public class Trace {
   private final MappedByteBuffer totalSize;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("shakiradata.ID", 4, length),
-        new ColumnHeader("shakiradata.INDEX", 4, length),
-        new ColumnHeader("shakiradata.INDEX_MAX", 4, length),
-        new ColumnHeader("shakiradata.IS_KECCAK_DATA", 1, length),
-        new ColumnHeader("shakiradata.IS_KECCAK_RESULT", 1, length),
-        new ColumnHeader("shakiradata.IS_RIPEMD_DATA", 1, length),
-        new ColumnHeader("shakiradata.IS_RIPEMD_RESULT", 1, length),
-        new ColumnHeader("shakiradata.IS_SHA2_DATA", 1, length),
-        new ColumnHeader("shakiradata.IS_SHA2_RESULT", 1, length),
-        new ColumnHeader("shakiradata.LIMB", 16, length),
-        new ColumnHeader("shakiradata.nBYTES", 1, length),
-        new ColumnHeader("shakiradata.nBYTES_ACC", 4, length),
-        new ColumnHeader("shakiradata.PHASE", 1, length),
-        new ColumnHeader("shakiradata.SELECTOR_KECCAK_RES_HI", 1, length),
-        new ColumnHeader("shakiradata.SELECTOR_RIPEMD_RES_HI", 1, length),
-        new ColumnHeader("shakiradata.SELECTOR_SHA2_RES_HI", 1, length),
-        new ColumnHeader("shakiradata.SHAKIRA_STAMP", 4, length),
-        new ColumnHeader("shakiradata.TOTAL_SIZE", 4, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("shakiradata.ID", 4, length));
+    headers.add(new ColumnHeader("shakiradata.INDEX", 4, length));
+    headers.add(new ColumnHeader("shakiradata.INDEX_MAX", 4, length));
+    headers.add(new ColumnHeader("shakiradata.IS_KECCAK_DATA", 1, length));
+    headers.add(new ColumnHeader("shakiradata.IS_KECCAK_RESULT", 1, length));
+    headers.add(new ColumnHeader("shakiradata.IS_RIPEMD_DATA", 1, length));
+    headers.add(new ColumnHeader("shakiradata.IS_RIPEMD_RESULT", 1, length));
+    headers.add(new ColumnHeader("shakiradata.IS_SHA2_DATA", 1, length));
+    headers.add(new ColumnHeader("shakiradata.IS_SHA2_RESULT", 1, length));
+    headers.add(new ColumnHeader("shakiradata.LIMB", 16, length));
+    headers.add(new ColumnHeader("shakiradata.nBYTES", 1, length));
+    headers.add(new ColumnHeader("shakiradata.nBYTES_ACC", 4, length));
+    headers.add(new ColumnHeader("shakiradata.PHASE", 1, length));
+    headers.add(new ColumnHeader("shakiradata.SELECTOR_KECCAK_RES_HI", 1, length));
+    headers.add(new ColumnHeader("shakiradata.SELECTOR_RIPEMD_RES_HI", 1, length));
+    headers.add(new ColumnHeader("shakiradata.SELECTOR_SHA2_RES_HI", 1, length));
+    headers.add(new ColumnHeader("shakiradata.SHAKIRA_STAMP", 4, length));
+    headers.add(new ColumnHeader("shakiradata.TOTAL_SIZE", 4, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -113,7 +115,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("id has invalid value (" + b + ")");
+      throw new IllegalArgumentException("shakiradata.ID has invalid value (" + b + ")");
     }
     id.put((byte) (b >> 24));
     id.put((byte) (b >> 16));
@@ -131,7 +133,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("index has invalid value (" + b + ")");
+      throw new IllegalArgumentException("shakiradata.INDEX has invalid value (" + b + ")");
     }
     index.put((byte) (b >> 24));
     index.put((byte) (b >> 16));
@@ -149,7 +151,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("indexMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("shakiradata.INDEX_MAX has invalid value (" + b + ")");
     }
     indexMax.put((byte) (b >> 24));
     indexMax.put((byte) (b >> 16));
@@ -242,7 +244,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("limb has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "shakiradata.LIMB has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -264,7 +267,7 @@ public class Trace {
     }
 
     if (b >= 32L) {
-      throw new IllegalArgumentException("nBytes has invalid value (" + b + ")");
+      throw new IllegalArgumentException("shakiradata.nBYTES has invalid value (" + b + ")");
     }
     nBytes.put((byte) b);
 
@@ -279,7 +282,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("nBytesAcc has invalid value (" + b + ")");
+      throw new IllegalArgumentException("shakiradata.nBYTES_ACC has invalid value (" + b + ")");
     }
     nBytesAcc.put((byte) (b >> 24));
     nBytesAcc.put((byte) (b >> 16));
@@ -345,7 +348,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("shakiraStamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("shakiradata.SHAKIRA_STAMP has invalid value (" + b + ")");
     }
     shakiraStamp.put((byte) (b >> 24));
     shakiraStamp.put((byte) (b >> 16));
@@ -363,7 +366,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("totalSize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("shakiradata.TOTAL_SIZE has invalid value (" + b + ")");
     }
     totalSize.put((byte) (b >> 24));
     totalSize.put((byte) (b >> 16));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.shf;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -87,58 +88,59 @@ public class Trace {
   private final MappedByteBuffer shiftStamp;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("shf.ACC_1", 16, length),
-        new ColumnHeader("shf.ACC_2", 16, length),
-        new ColumnHeader("shf.ACC_3", 16, length),
-        new ColumnHeader("shf.ACC_4", 16, length),
-        new ColumnHeader("shf.ACC_5", 16, length),
-        new ColumnHeader("shf.ARG_1_HI", 16, length),
-        new ColumnHeader("shf.ARG_1_LO", 16, length),
-        new ColumnHeader("shf.ARG_2_HI", 16, length),
-        new ColumnHeader("shf.ARG_2_LO", 16, length),
-        new ColumnHeader("shf.BIT_1", 1, length),
-        new ColumnHeader("shf.BIT_2", 1, length),
-        new ColumnHeader("shf.BIT_3", 1, length),
-        new ColumnHeader("shf.BIT_4", 1, length),
-        new ColumnHeader("shf.BIT_B_3", 1, length),
-        new ColumnHeader("shf.BIT_B_4", 1, length),
-        new ColumnHeader("shf.BIT_B_5", 1, length),
-        new ColumnHeader("shf.BIT_B_6", 1, length),
-        new ColumnHeader("shf.BIT_B_7", 1, length),
-        new ColumnHeader("shf.BITS", 1, length),
-        new ColumnHeader("shf.BYTE_1", 1, length),
-        new ColumnHeader("shf.BYTE_2", 1, length),
-        new ColumnHeader("shf.BYTE_3", 1, length),
-        new ColumnHeader("shf.BYTE_4", 1, length),
-        new ColumnHeader("shf.BYTE_5", 1, length),
-        new ColumnHeader("shf.COUNTER", 1, length),
-        new ColumnHeader("shf.INST", 1, length),
-        new ColumnHeader("shf.IOMF", 1, length),
-        new ColumnHeader("shf.KNOWN", 1, length),
-        new ColumnHeader("shf.LEFT_ALIGNED_SUFFIX_HIGH", 1, length),
-        new ColumnHeader("shf.LEFT_ALIGNED_SUFFIX_LOW", 1, length),
-        new ColumnHeader("shf.LOW_3", 16, length),
-        new ColumnHeader("shf.MICRO_SHIFT_PARAMETER", 1, length),
-        new ColumnHeader("shf.NEG", 1, length),
-        new ColumnHeader("shf.ONE_LINE_INSTRUCTION", 1, length),
-        new ColumnHeader("shf.ONES", 1, length),
-        new ColumnHeader("shf.RES_HI", 16, length),
-        new ColumnHeader("shf.RES_LO", 16, length),
-        new ColumnHeader("shf.RIGHT_ALIGNED_PREFIX_HIGH", 1, length),
-        new ColumnHeader("shf.RIGHT_ALIGNED_PREFIX_LOW", 1, length),
-        new ColumnHeader("shf.SHB_3_HI", 1, length),
-        new ColumnHeader("shf.SHB_3_LO", 1, length),
-        new ColumnHeader("shf.SHB_4_HI", 1, length),
-        new ColumnHeader("shf.SHB_4_LO", 1, length),
-        new ColumnHeader("shf.SHB_5_HI", 1, length),
-        new ColumnHeader("shf.SHB_5_LO", 1, length),
-        new ColumnHeader("shf.SHB_6_HI", 1, length),
-        new ColumnHeader("shf.SHB_6_LO", 1, length),
-        new ColumnHeader("shf.SHB_7_HI", 1, length),
-        new ColumnHeader("shf.SHB_7_LO", 1, length),
-        new ColumnHeader("shf.SHIFT_DIRECTION", 1, length),
-        new ColumnHeader("shf.SHIFT_STAMP", 4, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("shf.ACC_1", 16, length));
+    headers.add(new ColumnHeader("shf.ACC_2", 16, length));
+    headers.add(new ColumnHeader("shf.ACC_3", 16, length));
+    headers.add(new ColumnHeader("shf.ACC_4", 16, length));
+    headers.add(new ColumnHeader("shf.ACC_5", 16, length));
+    headers.add(new ColumnHeader("shf.ARG_1_HI", 16, length));
+    headers.add(new ColumnHeader("shf.ARG_1_LO", 16, length));
+    headers.add(new ColumnHeader("shf.ARG_2_HI", 16, length));
+    headers.add(new ColumnHeader("shf.ARG_2_LO", 16, length));
+    headers.add(new ColumnHeader("shf.BIT_1", 1, length));
+    headers.add(new ColumnHeader("shf.BIT_2", 1, length));
+    headers.add(new ColumnHeader("shf.BIT_3", 1, length));
+    headers.add(new ColumnHeader("shf.BIT_4", 1, length));
+    headers.add(new ColumnHeader("shf.BIT_B_3", 1, length));
+    headers.add(new ColumnHeader("shf.BIT_B_4", 1, length));
+    headers.add(new ColumnHeader("shf.BIT_B_5", 1, length));
+    headers.add(new ColumnHeader("shf.BIT_B_6", 1, length));
+    headers.add(new ColumnHeader("shf.BIT_B_7", 1, length));
+    headers.add(new ColumnHeader("shf.BITS", 1, length));
+    headers.add(new ColumnHeader("shf.BYTE_1", 1, length));
+    headers.add(new ColumnHeader("shf.BYTE_2", 1, length));
+    headers.add(new ColumnHeader("shf.BYTE_3", 1, length));
+    headers.add(new ColumnHeader("shf.BYTE_4", 1, length));
+    headers.add(new ColumnHeader("shf.BYTE_5", 1, length));
+    headers.add(new ColumnHeader("shf.COUNTER", 1, length));
+    headers.add(new ColumnHeader("shf.INST", 1, length));
+    headers.add(new ColumnHeader("shf.IOMF", 1, length));
+    headers.add(new ColumnHeader("shf.KNOWN", 1, length));
+    headers.add(new ColumnHeader("shf.LEFT_ALIGNED_SUFFIX_HIGH", 1, length));
+    headers.add(new ColumnHeader("shf.LEFT_ALIGNED_SUFFIX_LOW", 1, length));
+    headers.add(new ColumnHeader("shf.LOW_3", 16, length));
+    headers.add(new ColumnHeader("shf.MICRO_SHIFT_PARAMETER", 1, length));
+    headers.add(new ColumnHeader("shf.NEG", 1, length));
+    headers.add(new ColumnHeader("shf.ONE_LINE_INSTRUCTION", 1, length));
+    headers.add(new ColumnHeader("shf.ONES", 1, length));
+    headers.add(new ColumnHeader("shf.RES_HI", 16, length));
+    headers.add(new ColumnHeader("shf.RES_LO", 16, length));
+    headers.add(new ColumnHeader("shf.RIGHT_ALIGNED_PREFIX_HIGH", 1, length));
+    headers.add(new ColumnHeader("shf.RIGHT_ALIGNED_PREFIX_LOW", 1, length));
+    headers.add(new ColumnHeader("shf.SHB_3_HI", 1, length));
+    headers.add(new ColumnHeader("shf.SHB_3_LO", 1, length));
+    headers.add(new ColumnHeader("shf.SHB_4_HI", 1, length));
+    headers.add(new ColumnHeader("shf.SHB_4_LO", 1, length));
+    headers.add(new ColumnHeader("shf.SHB_5_HI", 1, length));
+    headers.add(new ColumnHeader("shf.SHB_5_LO", 1, length));
+    headers.add(new ColumnHeader("shf.SHB_6_HI", 1, length));
+    headers.add(new ColumnHeader("shf.SHB_6_LO", 1, length));
+    headers.add(new ColumnHeader("shf.SHB_7_HI", 1, length));
+    headers.add(new ColumnHeader("shf.SHB_7_LO", 1, length));
+    headers.add(new ColumnHeader("shf.SHIFT_DIRECTION", 1, length));
+    headers.add(new ColumnHeader("shf.SHIFT_STAMP", 4, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -214,7 +216,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "shf.ACC_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -239,7 +242,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "shf.ACC_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -264,7 +268,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "shf.ACC_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -289,7 +294,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "shf.ACC_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -314,7 +320,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc5 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "shf.ACC_5 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -339,7 +346,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "shf.ARG_1_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -364,7 +372,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "shf.ARG_1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -389,7 +398,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg2Hi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "shf.ARG_2_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -414,7 +424,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "shf.ARG_2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -616,7 +627,7 @@ public class Trace {
     }
 
     if (b >= 256L) {
-      throw new IllegalArgumentException("counter has invalid value (" + b + ")");
+      throw new IllegalArgumentException("shf.COUNTER has invalid value (" + b + ")");
     }
     counter.put((byte) b);
 
@@ -694,7 +705,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("low3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "shf.LOW_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -716,7 +728,7 @@ public class Trace {
     }
 
     if (b >= 256L) {
-      throw new IllegalArgumentException("microShiftParameter has invalid value (" + b + ")");
+      throw new IllegalArgumentException("shf.MICRO_SHIFT_PARAMETER has invalid value (" + b + ")");
     }
     microShiftParameter.put((byte) b);
 
@@ -770,7 +782,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "shf.RES_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -795,7 +808,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "shf.RES_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -973,7 +987,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("shiftStamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("shf.SHIFT_STAMP has invalid value (" + b + ")");
     }
     shiftStamp.put((byte) (b >> 24));
     shiftStamp.put((byte) (b >> 16));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.stp;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -65,36 +66,37 @@ public class Trace {
   private final MappedByteBuffer wcpFlag;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("stp.ARG_1_HI", 16, length),
-        new ColumnHeader("stp.ARG_1_LO", 16, length),
-        new ColumnHeader("stp.ARG_2_LO", 16, length),
-        new ColumnHeader("stp.CT", 1, length),
-        new ColumnHeader("stp.CT_MAX", 1, length),
-        new ColumnHeader("stp.EXISTS", 1, length),
-        new ColumnHeader("stp.EXOGENOUS_MODULE_INSTRUCTION", 1, length),
-        new ColumnHeader("stp.GAS_ACTUAL", 8, length),
-        new ColumnHeader("stp.GAS_HI", 16, length),
-        new ColumnHeader("stp.GAS_LO", 16, length),
-        new ColumnHeader("stp.GAS_MXP", 8, length),
-        new ColumnHeader("stp.GAS_OUT_OF_POCKET", 8, length),
-        new ColumnHeader("stp.GAS_STIPEND", 8, length),
-        new ColumnHeader("stp.GAS_UPFRONT", 8, length),
-        new ColumnHeader("stp.INSTRUCTION", 1, length),
-        new ColumnHeader("stp.IS_CALL", 1, length),
-        new ColumnHeader("stp.IS_CALLCODE", 1, length),
-        new ColumnHeader("stp.IS_CREATE", 1, length),
-        new ColumnHeader("stp.IS_CREATE2", 1, length),
-        new ColumnHeader("stp.IS_DELEGATECALL", 1, length),
-        new ColumnHeader("stp.IS_STATICCALL", 1, length),
-        new ColumnHeader("stp.MOD_FLAG", 1, length),
-        new ColumnHeader("stp.OUT_OF_GAS_EXCEPTION", 1, length),
-        new ColumnHeader("stp.RES_LO", 16, length),
-        new ColumnHeader("stp.STAMP", 3, length),
-        new ColumnHeader("stp.VAL_HI", 16, length),
-        new ColumnHeader("stp.VAL_LO", 16, length),
-        new ColumnHeader("stp.WARM", 1, length),
-        new ColumnHeader("stp.WCP_FLAG", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("stp.ARG_1_HI", 16, length));
+    headers.add(new ColumnHeader("stp.ARG_1_LO", 16, length));
+    headers.add(new ColumnHeader("stp.ARG_2_LO", 16, length));
+    headers.add(new ColumnHeader("stp.CT", 1, length));
+    headers.add(new ColumnHeader("stp.CT_MAX", 1, length));
+    headers.add(new ColumnHeader("stp.EXISTS", 1, length));
+    headers.add(new ColumnHeader("stp.EXOGENOUS_MODULE_INSTRUCTION", 1, length));
+    headers.add(new ColumnHeader("stp.GAS_ACTUAL", 8, length));
+    headers.add(new ColumnHeader("stp.GAS_HI", 16, length));
+    headers.add(new ColumnHeader("stp.GAS_LO", 16, length));
+    headers.add(new ColumnHeader("stp.GAS_MXP", 8, length));
+    headers.add(new ColumnHeader("stp.GAS_OUT_OF_POCKET", 8, length));
+    headers.add(new ColumnHeader("stp.GAS_STIPEND", 8, length));
+    headers.add(new ColumnHeader("stp.GAS_UPFRONT", 8, length));
+    headers.add(new ColumnHeader("stp.INSTRUCTION", 1, length));
+    headers.add(new ColumnHeader("stp.IS_CALL", 1, length));
+    headers.add(new ColumnHeader("stp.IS_CALLCODE", 1, length));
+    headers.add(new ColumnHeader("stp.IS_CREATE", 1, length));
+    headers.add(new ColumnHeader("stp.IS_CREATE2", 1, length));
+    headers.add(new ColumnHeader("stp.IS_DELEGATECALL", 1, length));
+    headers.add(new ColumnHeader("stp.IS_STATICCALL", 1, length));
+    headers.add(new ColumnHeader("stp.MOD_FLAG", 1, length));
+    headers.add(new ColumnHeader("stp.OUT_OF_GAS_EXCEPTION", 1, length));
+    headers.add(new ColumnHeader("stp.RES_LO", 16, length));
+    headers.add(new ColumnHeader("stp.STAMP", 3, length));
+    headers.add(new ColumnHeader("stp.VAL_HI", 16, length));
+    headers.add(new ColumnHeader("stp.VAL_LO", 16, length));
+    headers.add(new ColumnHeader("stp.WARM", 1, length));
+    headers.add(new ColumnHeader("stp.WCP_FLAG", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -148,7 +150,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg1Hi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "stp.ARG_1_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -173,7 +176,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg1Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "stp.ARG_1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -198,7 +202,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("arg2Lo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "stp.ARG_2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -272,7 +277,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "gasActual has invalid width (" + bs.bitLength() + "bits)");
+          "stp.GAS_ACTUAL has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -297,7 +302,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("gasHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "stp.GAS_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -322,7 +328,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("gasLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "stp.GAS_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -347,7 +354,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("gasMxp has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "stp.GAS_MXP has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -373,7 +381,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "gasOutOfPocket has invalid width (" + bs.bitLength() + "bits)");
+          "stp.GAS_OUT_OF_POCKET has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -399,7 +407,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "gasStipend has invalid width (" + bs.bitLength() + "bits)");
+          "stp.GAS_STIPEND has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -425,7 +433,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "gasUpfront has invalid width (" + bs.bitLength() + "bits)");
+          "stp.GAS_UPFRONT has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -558,7 +566,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("resLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "stp.RES_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -580,7 +589,7 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("stp.STAMP has invalid value (" + b + ")");
     }
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));
@@ -600,7 +609,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("valHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "stp.VAL_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -625,7 +635,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("valLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "stp.VAL_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/bin/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/bin/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.tables.bin;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -39,11 +40,12 @@ public class Trace {
   private final MappedByteBuffer resultByte;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("binreftable.INPUT_BYTE_1", 1, length),
-        new ColumnHeader("binreftable.INPUT_BYTE_2", 1, length),
-        new ColumnHeader("binreftable.INST", 1, length),
-        new ColumnHeader("binreftable.RESULT_BYTE", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("binreftable.INPUT_BYTE_1", 1, length));
+    headers.add(new ColumnHeader("binreftable.INPUT_BYTE_2", 1, length));
+    headers.add(new ColumnHeader("binreftable.INST", 1, length));
+    headers.add(new ColumnHeader("binreftable.RESULT_BYTE", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/shf/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/shf/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.tables.shf;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -40,14 +41,15 @@ public class Trace {
   private final MappedByteBuffer ones;
   private final MappedByteBuffer rap;
 
-  public static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("shfreftable.BYTE1", 1, length),
-        new ColumnHeader("shfreftable.IOMF", 1, length),
-        new ColumnHeader("shfreftable.LAS", 1, length),
-        new ColumnHeader("shfreftable.MSHP", 1, length),
-        new ColumnHeader("shfreftable.ONES", 1, length),
-        new ColumnHeader("shfreftable.RAP", 1, length));
+  static List<ColumnHeader> headers(int length) {
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("shfreftable.BYTE1", 1, length));
+    headers.add(new ColumnHeader("shfreftable.IOMF", 1, length));
+    headers.add(new ColumnHeader("shfreftable.LAS", 1, length));
+    headers.add(new ColumnHeader("shfreftable.MSHP", 1, length));
+    headers.add(new ColumnHeader("shfreftable.ONES", 1, length));
+    headers.add(new ColumnHeader("shfreftable.RAP", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/trm/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/trm/Trace.java
@@ -102,7 +102,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("accHi has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "trm.ACC_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -127,7 +128,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("accLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "trm.ACC_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -149,7 +151,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("accT has invalid value (" + b + ")");
+      throw new IllegalArgumentException("trm.ACC_T has invalid value (" + b + ")");
     }
     accT.put((byte) (b >> 24));
     accT.put((byte) (b >> 16));
@@ -191,7 +193,7 @@ public class Trace {
     }
 
     if (b >= 16L) {
-      throw new IllegalArgumentException("ct has invalid value (" + b + ")");
+      throw new IllegalArgumentException("trm.CT has invalid value (" + b + ")");
     }
     ct.put((byte) b);
 
@@ -246,7 +248,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "rawAddressHi has invalid width (" + bs.bitLength() + "bits)");
+          "trm.RAW_ADDRESS_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -272,7 +274,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "rawAddressLo has invalid width (" + bs.bitLength() + "bits)");
+          "trm.RAW_ADDRESS_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -294,7 +296,7 @@ public class Trace {
     }
 
     if (b >= 16777216L) {
-      throw new IllegalArgumentException("stamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("trm.STAMP has invalid value (" + b + ")");
     }
     stamp.put((byte) (b >> 16));
     stamp.put((byte) (b >> 8));
@@ -311,7 +313,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("trmAddressHi has invalid value (" + b + ")");
+      throw new IllegalArgumentException("trm.TRM_ADDRESS_HI has invalid value (" + b + ")");
     }
     trmAddressHi.put((byte) (b >> 24));
     trmAddressHi.put((byte) (b >> 16));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/Trace.java
@@ -17,6 +17,7 @@ package net.consensys.linea.zktracer.module.txndata;
 
 import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -441,54 +442,55 @@ public class Trace {
   private final MappedByteBuffer wcpFlag;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("txndata.ABS_TX_NUM", 2, length),
-        new ColumnHeader("txndata.ABS_TX_NUM_MAX", 2, length),
-        new ColumnHeader("txndata.ARG_ONE_LO", 16, length),
-        new ColumnHeader("txndata.ARG_TWO_LO", 16, length),
-        new ColumnHeader("txndata.BASEFEE", 16, length),
-        new ColumnHeader("txndata.BLOCK_GAS_LIMIT", 8, length),
-        new ColumnHeader("txndata.CALL_DATA_SIZE", 4, length),
-        new ColumnHeader("txndata.CODE_FRAGMENT_INDEX", 4, length),
-        new ColumnHeader("txndata.COINBASE_HI", 4, length),
-        new ColumnHeader("txndata.COINBASE_LO", 16, length),
-        new ColumnHeader("txndata.COPY_TXCD", 1, length),
-        new ColumnHeader("txndata.CT", 1, length),
-        new ColumnHeader("txndata.EUC_FLAG", 1, length),
-        new ColumnHeader("txndata.FROM_HI", 4, length),
-        new ColumnHeader("txndata.FROM_LO", 16, length),
-        new ColumnHeader("txndata.GAS_CUMULATIVE", 16, length),
-        new ColumnHeader("txndata.GAS_INITIALLY_AVAILABLE", 16, length),
-        new ColumnHeader("txndata.GAS_LEFTOVER", 16, length),
-        new ColumnHeader("txndata.GAS_LIMIT", 8, length),
-        new ColumnHeader("txndata.GAS_PRICE", 8, length),
-        new ColumnHeader("txndata.INIT_CODE_SIZE", 4, length),
-        new ColumnHeader("txndata.INITIAL_BALANCE", 16, length),
-        new ColumnHeader("txndata.INST", 1, length),
-        new ColumnHeader("txndata.IS_DEP", 1, length),
-        new ColumnHeader("txndata.IS_LAST_TX_OF_BLOCK", 1, length),
-        new ColumnHeader("txndata.NONCE", 8, length),
-        new ColumnHeader("txndata.OUTGOING_HI", 8, length),
-        new ColumnHeader("txndata.OUTGOING_LO", 16, length),
-        new ColumnHeader("txndata.OUTGOING_RLP_TXNRCPT", 16, length),
-        new ColumnHeader("txndata.PHASE_RLP_TXN", 1, length),
-        new ColumnHeader("txndata.PHASE_RLP_TXNRCPT", 1, length),
-        new ColumnHeader("txndata.PRIORITY_FEE_PER_GAS", 16, length),
-        new ColumnHeader("txndata.REFUND_COUNTER", 16, length),
-        new ColumnHeader("txndata.REFUND_EFFECTIVE", 16, length),
-        new ColumnHeader("txndata.REL_BLOCK", 2, length),
-        new ColumnHeader("txndata.REL_TX_NUM", 2, length),
-        new ColumnHeader("txndata.REL_TX_NUM_MAX", 2, length),
-        new ColumnHeader("txndata.REQUIRES_EVM_EXECUTION", 1, length),
-        new ColumnHeader("txndata.RES", 8, length),
-        new ColumnHeader("txndata.STATUS_CODE", 1, length),
-        new ColumnHeader("txndata.TO_HI", 4, length),
-        new ColumnHeader("txndata.TO_LO", 16, length),
-        new ColumnHeader("txndata.TYPE0", 1, length),
-        new ColumnHeader("txndata.TYPE1", 1, length),
-        new ColumnHeader("txndata.TYPE2", 1, length),
-        new ColumnHeader("txndata.VALUE", 16, length),
-        new ColumnHeader("txndata.WCP_FLAG", 1, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("txndata.ABS_TX_NUM", 2, length));
+    headers.add(new ColumnHeader("txndata.ABS_TX_NUM_MAX", 2, length));
+    headers.add(new ColumnHeader("txndata.ARG_ONE_LO", 16, length));
+    headers.add(new ColumnHeader("txndata.ARG_TWO_LO", 16, length));
+    headers.add(new ColumnHeader("txndata.BASEFEE", 16, length));
+    headers.add(new ColumnHeader("txndata.BLOCK_GAS_LIMIT", 8, length));
+    headers.add(new ColumnHeader("txndata.CALL_DATA_SIZE", 4, length));
+    headers.add(new ColumnHeader("txndata.CODE_FRAGMENT_INDEX", 4, length));
+    headers.add(new ColumnHeader("txndata.COINBASE_HI", 4, length));
+    headers.add(new ColumnHeader("txndata.COINBASE_LO", 16, length));
+    headers.add(new ColumnHeader("txndata.COPY_TXCD", 1, length));
+    headers.add(new ColumnHeader("txndata.CT", 1, length));
+    headers.add(new ColumnHeader("txndata.EUC_FLAG", 1, length));
+    headers.add(new ColumnHeader("txndata.FROM_HI", 4, length));
+    headers.add(new ColumnHeader("txndata.FROM_LO", 16, length));
+    headers.add(new ColumnHeader("txndata.GAS_CUMULATIVE", 16, length));
+    headers.add(new ColumnHeader("txndata.GAS_INITIALLY_AVAILABLE", 16, length));
+    headers.add(new ColumnHeader("txndata.GAS_LEFTOVER", 16, length));
+    headers.add(new ColumnHeader("txndata.GAS_LIMIT", 8, length));
+    headers.add(new ColumnHeader("txndata.GAS_PRICE", 8, length));
+    headers.add(new ColumnHeader("txndata.INIT_CODE_SIZE", 4, length));
+    headers.add(new ColumnHeader("txndata.INITIAL_BALANCE", 16, length));
+    headers.add(new ColumnHeader("txndata.INST", 1, length));
+    headers.add(new ColumnHeader("txndata.IS_DEP", 1, length));
+    headers.add(new ColumnHeader("txndata.IS_LAST_TX_OF_BLOCK", 1, length));
+    headers.add(new ColumnHeader("txndata.NONCE", 8, length));
+    headers.add(new ColumnHeader("txndata.OUTGOING_HI", 8, length));
+    headers.add(new ColumnHeader("txndata.OUTGOING_LO", 16, length));
+    headers.add(new ColumnHeader("txndata.OUTGOING_RLP_TXNRCPT", 16, length));
+    headers.add(new ColumnHeader("txndata.PHASE_RLP_TXN", 1, length));
+    headers.add(new ColumnHeader("txndata.PHASE_RLP_TXNRCPT", 1, length));
+    headers.add(new ColumnHeader("txndata.PRIORITY_FEE_PER_GAS", 16, length));
+    headers.add(new ColumnHeader("txndata.REFUND_COUNTER", 16, length));
+    headers.add(new ColumnHeader("txndata.REFUND_EFFECTIVE", 16, length));
+    headers.add(new ColumnHeader("txndata.REL_BLOCK", 2, length));
+    headers.add(new ColumnHeader("txndata.REL_TX_NUM", 2, length));
+    headers.add(new ColumnHeader("txndata.REL_TX_NUM_MAX", 2, length));
+    headers.add(new ColumnHeader("txndata.REQUIRES_EVM_EXECUTION", 1, length));
+    headers.add(new ColumnHeader("txndata.RES", 8, length));
+    headers.add(new ColumnHeader("txndata.STATUS_CODE", 1, length));
+    headers.add(new ColumnHeader("txndata.TO_HI", 4, length));
+    headers.add(new ColumnHeader("txndata.TO_LO", 16, length));
+    headers.add(new ColumnHeader("txndata.TYPE0", 1, length));
+    headers.add(new ColumnHeader("txndata.TYPE1", 1, length));
+    headers.add(new ColumnHeader("txndata.TYPE2", 1, length));
+    headers.add(new ColumnHeader("txndata.VALUE", 16, length));
+    headers.add(new ColumnHeader("txndata.WCP_FLAG", 1, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -557,7 +559,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("absTxNum has invalid value (" + b + ")");
+      throw new IllegalArgumentException("txndata.ABS_TX_NUM has invalid value (" + b + ")");
     }
     absTxNum.put((byte) (b >> 8));
     absTxNum.put((byte) b);
@@ -573,7 +575,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("absTxNumMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("txndata.ABS_TX_NUM_MAX has invalid value (" + b + ")");
     }
     absTxNumMax.put((byte) (b >> 8));
     absTxNumMax.put((byte) b);
@@ -592,7 +594,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("argOneLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "txndata.ARG_ONE_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -617,7 +620,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("argTwoLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "txndata.ARG_TWO_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -642,7 +646,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("basefee has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "txndata.BASEFEE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -668,7 +673,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "blockGasLimit has invalid width (" + bs.bitLength() + "bits)");
+          "txndata.BLOCK_GAS_LIMIT has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -690,7 +695,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("callDataSize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("txndata.CALL_DATA_SIZE has invalid value (" + b + ")");
     }
     callDataSize.put((byte) (b >> 24));
     callDataSize.put((byte) (b >> 16));
@@ -708,7 +713,8 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("codeFragmentIndex has invalid value (" + b + ")");
+      throw new IllegalArgumentException(
+          "txndata.CODE_FRAGMENT_INDEX has invalid value (" + b + ")");
     }
     codeFragmentIndex.put((byte) (b >> 24));
     codeFragmentIndex.put((byte) (b >> 16));
@@ -726,7 +732,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("coinbaseHi has invalid value (" + b + ")");
+      throw new IllegalArgumentException("txndata.COINBASE_HI has invalid value (" + b + ")");
     }
     coinbaseHi.put((byte) (b >> 24));
     coinbaseHi.put((byte) (b >> 16));
@@ -748,7 +754,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "coinbaseLo has invalid width (" + bs.bitLength() + "bits)");
+          "txndata.COINBASE_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -806,7 +812,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("fromHi has invalid value (" + b + ")");
+      throw new IllegalArgumentException("txndata.FROM_HI has invalid value (" + b + ")");
     }
     fromHi.put((byte) (b >> 24));
     fromHi.put((byte) (b >> 16));
@@ -827,7 +833,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("fromLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "txndata.FROM_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -853,7 +860,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "gasCumulative has invalid width (" + bs.bitLength() + "bits)");
+          "txndata.GAS_CUMULATIVE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -879,7 +886,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "gasInitiallyAvailable has invalid width (" + bs.bitLength() + "bits)");
+          "txndata.GAS_INITIALLY_AVAILABLE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -905,7 +912,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "gasLeftover has invalid width (" + bs.bitLength() + "bits)");
+          "txndata.GAS_LEFTOVER has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -930,7 +937,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("gasLimit has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "txndata.GAS_LIMIT has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -955,7 +963,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("gasPrice has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "txndata.GAS_PRICE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -977,7 +986,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("initCodeSize has invalid value (" + b + ")");
+      throw new IllegalArgumentException("txndata.INIT_CODE_SIZE has invalid value (" + b + ")");
     }
     initCodeSize.put((byte) (b >> 24));
     initCodeSize.put((byte) (b >> 16));
@@ -999,7 +1008,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "initialBalance has invalid width (" + bs.bitLength() + "bits)");
+          "txndata.INITIAL_BALANCE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1060,7 +1069,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("nonce has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "txndata.NONCE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1086,7 +1096,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
       throw new IllegalArgumentException(
-          "outgoingHi has invalid width (" + bs.bitLength() + "bits)");
+          "txndata.OUTGOING_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1112,7 +1122,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "outgoingLo has invalid width (" + bs.bitLength() + "bits)");
+          "txndata.OUTGOING_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1138,7 +1148,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "outgoingRlpTxnrcpt has invalid width (" + bs.bitLength() + "bits)");
+          "txndata.OUTGOING_RLP_TXNRCPT has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1188,7 +1198,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "priorityFeePerGas has invalid width (" + bs.bitLength() + "bits)");
+          "txndata.PRIORITY_FEE_PER_GAS has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1214,7 +1224,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "refundCounter has invalid width (" + bs.bitLength() + "bits)");
+          "txndata.REFUND_COUNTER has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1240,7 +1250,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "refundEffective has invalid width (" + bs.bitLength() + "bits)");
+          "txndata.REFUND_EFFECTIVE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1262,7 +1272,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("relBlock has invalid value (" + b + ")");
+      throw new IllegalArgumentException("txndata.REL_BLOCK has invalid value (" + b + ")");
     }
     relBlock.put((byte) (b >> 8));
     relBlock.put((byte) b);
@@ -1278,7 +1288,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("relTxNum has invalid value (" + b + ")");
+      throw new IllegalArgumentException("txndata.REL_TX_NUM has invalid value (" + b + ")");
     }
     relTxNum.put((byte) (b >> 8));
     relTxNum.put((byte) b);
@@ -1294,7 +1304,7 @@ public class Trace {
     }
 
     if (b >= 65536L) {
-      throw new IllegalArgumentException("relTxNumMax has invalid value (" + b + ")");
+      throw new IllegalArgumentException("txndata.REL_TX_NUM_MAX has invalid value (" + b + ")");
     }
     relTxNumMax.put((byte) (b >> 8));
     relTxNumMax.put((byte) b);
@@ -1325,7 +1335,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 64) {
-      throw new IllegalArgumentException("res has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "txndata.RES has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 8; i++) {
@@ -1359,7 +1370,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("toHi has invalid value (" + b + ")");
+      throw new IllegalArgumentException("txndata.TO_HI has invalid value (" + b + ")");
     }
     toHi.put((byte) (b >> 24));
     toHi.put((byte) (b >> 16));
@@ -1380,7 +1391,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("toLo has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "txndata.TO_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -1441,7 +1453,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("value has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "txndata.VALUE has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Trace.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.wcp;
 
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -74,45 +75,46 @@ public class Trace {
   private final MappedByteBuffer wordComparisonStamp;
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        new ColumnHeader("wcp.ACC_1", 16, length),
-        new ColumnHeader("wcp.ACC_2", 16, length),
-        new ColumnHeader("wcp.ACC_3", 16, length),
-        new ColumnHeader("wcp.ACC_4", 16, length),
-        new ColumnHeader("wcp.ACC_5", 16, length),
-        new ColumnHeader("wcp.ACC_6", 16, length),
-        new ColumnHeader("wcp.ARGUMENT_1_HI", 16, length),
-        new ColumnHeader("wcp.ARGUMENT_1_LO", 16, length),
-        new ColumnHeader("wcp.ARGUMENT_2_HI", 16, length),
-        new ColumnHeader("wcp.ARGUMENT_2_LO", 16, length),
-        new ColumnHeader("wcp.BIT_1", 1, length),
-        new ColumnHeader("wcp.BIT_2", 1, length),
-        new ColumnHeader("wcp.BIT_3", 1, length),
-        new ColumnHeader("wcp.BIT_4", 1, length),
-        new ColumnHeader("wcp.BITS", 1, length),
-        new ColumnHeader("wcp.BYTE_1", 1, length),
-        new ColumnHeader("wcp.BYTE_2", 1, length),
-        new ColumnHeader("wcp.BYTE_3", 1, length),
-        new ColumnHeader("wcp.BYTE_4", 1, length),
-        new ColumnHeader("wcp.BYTE_5", 1, length),
-        new ColumnHeader("wcp.BYTE_6", 1, length),
-        new ColumnHeader("wcp.COUNTER", 1, length),
-        new ColumnHeader("wcp.CT_MAX", 1, length),
-        new ColumnHeader("wcp.INST", 1, length),
-        new ColumnHeader("wcp.IS_EQ", 1, length),
-        new ColumnHeader("wcp.IS_GEQ", 1, length),
-        new ColumnHeader("wcp.IS_GT", 1, length),
-        new ColumnHeader("wcp.IS_ISZERO", 1, length),
-        new ColumnHeader("wcp.IS_LEQ", 1, length),
-        new ColumnHeader("wcp.IS_LT", 1, length),
-        new ColumnHeader("wcp.IS_SGT", 1, length),
-        new ColumnHeader("wcp.IS_SLT", 1, length),
-        new ColumnHeader("wcp.NEG_1", 1, length),
-        new ColumnHeader("wcp.NEG_2", 1, length),
-        new ColumnHeader("wcp.ONE_LINE_INSTRUCTION", 1, length),
-        new ColumnHeader("wcp.RESULT", 1, length),
-        new ColumnHeader("wcp.VARIABLE_LENGTH_INSTRUCTION", 1, length),
-        new ColumnHeader("wcp.WORD_COMPARISON_STAMP", 4, length));
+    List<ColumnHeader> headers = new ArrayList<>();
+    headers.add(new ColumnHeader("wcp.ACC_1", 16, length));
+    headers.add(new ColumnHeader("wcp.ACC_2", 16, length));
+    headers.add(new ColumnHeader("wcp.ACC_3", 16, length));
+    headers.add(new ColumnHeader("wcp.ACC_4", 16, length));
+    headers.add(new ColumnHeader("wcp.ACC_5", 16, length));
+    headers.add(new ColumnHeader("wcp.ACC_6", 16, length));
+    headers.add(new ColumnHeader("wcp.ARGUMENT_1_HI", 16, length));
+    headers.add(new ColumnHeader("wcp.ARGUMENT_1_LO", 16, length));
+    headers.add(new ColumnHeader("wcp.ARGUMENT_2_HI", 16, length));
+    headers.add(new ColumnHeader("wcp.ARGUMENT_2_LO", 16, length));
+    headers.add(new ColumnHeader("wcp.BIT_1", 1, length));
+    headers.add(new ColumnHeader("wcp.BIT_2", 1, length));
+    headers.add(new ColumnHeader("wcp.BIT_3", 1, length));
+    headers.add(new ColumnHeader("wcp.BIT_4", 1, length));
+    headers.add(new ColumnHeader("wcp.BITS", 1, length));
+    headers.add(new ColumnHeader("wcp.BYTE_1", 1, length));
+    headers.add(new ColumnHeader("wcp.BYTE_2", 1, length));
+    headers.add(new ColumnHeader("wcp.BYTE_3", 1, length));
+    headers.add(new ColumnHeader("wcp.BYTE_4", 1, length));
+    headers.add(new ColumnHeader("wcp.BYTE_5", 1, length));
+    headers.add(new ColumnHeader("wcp.BYTE_6", 1, length));
+    headers.add(new ColumnHeader("wcp.COUNTER", 1, length));
+    headers.add(new ColumnHeader("wcp.CT_MAX", 1, length));
+    headers.add(new ColumnHeader("wcp.INST", 1, length));
+    headers.add(new ColumnHeader("wcp.IS_EQ", 1, length));
+    headers.add(new ColumnHeader("wcp.IS_GEQ", 1, length));
+    headers.add(new ColumnHeader("wcp.IS_GT", 1, length));
+    headers.add(new ColumnHeader("wcp.IS_ISZERO", 1, length));
+    headers.add(new ColumnHeader("wcp.IS_LEQ", 1, length));
+    headers.add(new ColumnHeader("wcp.IS_LT", 1, length));
+    headers.add(new ColumnHeader("wcp.IS_SGT", 1, length));
+    headers.add(new ColumnHeader("wcp.IS_SLT", 1, length));
+    headers.add(new ColumnHeader("wcp.NEG_1", 1, length));
+    headers.add(new ColumnHeader("wcp.NEG_2", 1, length));
+    headers.add(new ColumnHeader("wcp.ONE_LINE_INSTRUCTION", 1, length));
+    headers.add(new ColumnHeader("wcp.RESULT", 1, length));
+    headers.add(new ColumnHeader("wcp.VARIABLE_LENGTH_INSTRUCTION", 1, length));
+    headers.add(new ColumnHeader("wcp.WORD_COMPARISON_STAMP", 4, length));
+    return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {
@@ -175,7 +177,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc1 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "wcp.ACC_1 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -200,7 +203,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc2 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "wcp.ACC_2 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -225,7 +229,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc3 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "wcp.ACC_3 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -250,7 +255,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc4 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "wcp.ACC_4 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -275,7 +281,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc5 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "wcp.ACC_5 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -300,7 +307,8 @@ public class Trace {
     Bytes bs = b.trimLeadingZeros();
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
-      throw new IllegalArgumentException("acc6 has invalid width (" + bs.bitLength() + "bits)");
+      throw new IllegalArgumentException(
+          "wcp.ACC_6 has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -326,7 +334,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "argument1Hi has invalid width (" + bs.bitLength() + "bits)");
+          "wcp.ARGUMENT_1_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -352,7 +360,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "argument1Lo has invalid width (" + bs.bitLength() + "bits)");
+          "wcp.ARGUMENT_1_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -378,7 +386,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "argument2Hi has invalid width (" + bs.bitLength() + "bits)");
+          "wcp.ARGUMENT_2_HI has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -404,7 +412,7 @@ public class Trace {
     // Sanity check against expected width
     if (bs.bitLength() > 128) {
       throw new IllegalArgumentException(
-          "argument2Lo has invalid width (" + bs.bitLength() + "bits)");
+          "wcp.ARGUMENT_2_LO has invalid width (" + bs.bitLength() + "bits)");
     }
     // Write padding (if necessary)
     for (int i = bs.size(); i < 16; i++) {
@@ -750,7 +758,7 @@ public class Trace {
     }
 
     if (b >= 4294967296L) {
-      throw new IllegalArgumentException("wordComparisonStamp has invalid value (" + b + ")");
+      throw new IllegalArgumentException("wcp.WORD_COMPARISON_STAMP has invalid value (" + b + ")");
     }
     wordComparisonStamp.put((byte) (b >> 24));
     wordComparisonStamp.put((byte) (b >> 16));

--- a/buildSrc/src/main/groovy/TraceFilesTask.groovy
+++ b/buildSrc/src/main/groovy/TraceFilesTask.groovy
@@ -26,7 +26,7 @@ abstract class TraceFilesTask extends Exec {
                      "-P", "${moduleDir.getOrElse(module.get()).replaceAll('/','.')}",
                      "-o", "${project.projectDir}/src/main/java/net/consensys/linea/zktracer/module/${moduleDir.getOrElse(module.get())}"
     ]
-    if(className) {
+    if(project.hasProperty("className")) {
       arguments.add("-c")
       arguments.add("${className.get()}")
     }

--- a/buildSrc/src/main/groovy/TraceFilesTask.groovy
+++ b/buildSrc/src/main/groovy/TraceFilesTask.groovy
@@ -23,7 +23,7 @@ abstract class TraceFilesTask extends Exec {
   @Override
   protected void exec() {
     def arguments = ["besu",
-                     "-P", module.get(),
+                     "-P", "${moduleDir.getOrElse(module.get()).replaceAll('/','.')}",
                      "-o", "${project.projectDir}/src/main/java/net/consensys/linea/zktracer/module/${moduleDir.getOrElse(module.get())}"
     ]
     if(className) {

--- a/gradle/trace-files.gradle
+++ b/gradle/trace-files.gradle
@@ -18,7 +18,6 @@
     tasks.register(moduleName, TraceFilesTask) {
         group "Trace files generation"
         dependsOn corsetExists
-        className = "Trace"
         module = moduleName
         files = ["alu/${moduleName}/columns.lisp"]
     }
@@ -30,7 +29,6 @@
 tasks.register("hub", TraceFilesTask) {
     group "Trace files generation"
     dependsOn corsetExists
-    className = "Trace"
     module = 'hub'
     files = ['hub/constants.lisp', 'hub/columns/account.lisp', 'hub/columns/context.lisp', 'hub/columns/shared.lisp', 'hub/columns/stack.lisp',
              'hub/columns/storage.lisp', 'hub/columns/transaction.lisp', 'hub/columns/scenario.lisp', 'hub/columns/miscellaneous.lisp']
@@ -42,7 +40,6 @@ tasks.register("hub", TraceFilesTask) {
 tasks.register('instdecoder', TraceFilesTask) {
     group "Trace files generation"
     dependsOn corsetExists
-    className = "Trace"
     moduleDir = "tables/instructionDecoder"
     module = "instructionDecoder"
     files = ["reftables/inst_decoder.lisp"]
@@ -51,7 +48,6 @@ tasks.register('instdecoder', TraceFilesTask) {
 tasks.register('shfreftable', TraceFilesTask) {
     group "Trace files generation"
     dependsOn corsetExists
-    className = "Trace"
     moduleDir = "tables/shf"
     module = "ShfRt"
     files = ["reftables/shf_reftable.lisp"]
@@ -59,7 +55,6 @@ tasks.register('shfreftable', TraceFilesTask) {
 tasks.register('binreftable', TraceFilesTask) {
     group "Trace files generation"
     dependsOn corsetExists
-    className = "Trace"
     moduleDir = "tables/bin"
     module = "BinRt"
     files = ["reftables/bin_reftable.lisp"]
@@ -72,7 +67,6 @@ tasks.register('binreftable', TraceFilesTask) {
     tasks.register(moduleName, TraceFilesTask) {
         group "Trace files generation"
         dependsOn corsetExists
-className = "Trace"
         module = moduleName
         files = ["${moduleName}/columns.lisp"]
     }
@@ -85,7 +79,6 @@ className = "Trace"
     tasks.register(moduleName, TraceFilesTask) {
         group "Trace files generation"
         dependsOn corsetExists
-        className = "Trace"
         module = moduleName
         files = ["${moduleName}/columns.lisp", "${moduleName}/constants.lisp"]
     }
@@ -99,7 +92,6 @@ className = "Trace"
     tasks.register(moduleName, TraceFilesTask) {
         group "Trace files generation"
          dependsOn corsetExists
-        className = "Trace"
         module = moduleName
         files = ["${moduleName}/columns.lisp", "constants/constants.lisp", "${moduleName}/constants.lisp"]
     }
@@ -112,7 +104,6 @@ className = "Trace"
     tasks.register(moduleName, TraceFilesTask) {
         group "Trace files generation"
         dependsOn corsetExists
-
 	className = "GlobalConstants"
         module = moduleName
         files = [ "${moduleName}/constants.lisp"]


### PR DESCRIPTION
There was an issue with the groovy task `TraceFilesTask.groovy` which was not accounting correctly for modules located in subdirectories.  Specifically, it wasn't generating the correct Java package name.  