### PR TITLE
fix: many things

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -107,6 +107,7 @@ import net.consensys.linea.zktracer.module.wcp.Wcp;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.opcode.gas.projector.GasProjector;
+import net.consensys.linea.zktracer.runtime.callstack.CallDataInfo;
 import net.consensys.linea.zktracer.runtime.callstack.CallFrame;
 import net.consensys.linea.zktracer.runtime.callstack.CallFrameType;
 import net.consensys.linea.zktracer.runtime.callstack.CallStack;
@@ -121,7 +122,6 @@ import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.account.AccountState;
 import org.hyperledger.besu.evm.frame.MessageFrame;
-import org.hyperledger.besu.evm.internal.Words;
 import org.hyperledger.besu.evm.log.Log;
 import org.hyperledger.besu.evm.log.LogTopic;
 import org.hyperledger.besu.evm.operation.Operation;
@@ -606,41 +606,29 @@ public class Hub implements Module {
     // internal transaction (CALL) or internal deployment (CREATE)
     if (frame.getDepth() > 0) {
       final OpCode currentOpCode = callStack.currentCallFrame().opCode();
+      final boolean isDeployment = frame.getType() == CONTRACT_CREATION;
+
       checkState(currentOpCode.isCall() || currentOpCode.isCreate());
       checkState(
           currentTraceSection() instanceof CallSection
               || currentTraceSection() instanceof CreateSection);
-      final boolean isDeployment = frame.getType() == CONTRACT_CREATION;
+      checkState(currentTraceSection() instanceof CreateSection == isDeployment);
+
       final CallFrameType frameType =
           frame.isStatic() ? CallFrameType.STATIC : CallFrameType.STANDARD;
 
-      final long callDataOffset =
+      final CallDataInfo callDataInfo =
           isDeployment
-              ? 0
-              : Words.clampedToLong(
-                  callStack
-                      .currentCallFrame()
-                      .frame()
-                      .getStackItem(currentOpCode.callMayNotTransferValue() ? 2 : 3));
-
-      final long callDataSize =
-          isDeployment
-              ? 0
-              : Words.clampedToLong(
-                  callStack
-                      .currentCallFrame()
-                      .frame()
-                      .getStackItem(currentOpCode.callMayNotTransferValue() ? 3 : 4));
-
-      final long callDataContextNumber = callStack.currentCallFrame().contextNumber();
+              ? CallDataInfo.empty()
+              : ((CallSection) currentTraceSection()).getCallDataInfo();
 
       currentFrame().rememberGasNextBeforePausing(this);
       currentFrame().pauseCurrentFrame();
 
       MemorySpan returnDataTargetInCaller =
-          (currentTraceSection() instanceof CallSection)
-              ? ((CallSection) currentTraceSection()).getCallProvidedReturnDataTargetSpan()
-              : MemorySpan.empty();
+          isDeployment
+              ? MemorySpan.empty()
+              : ((CallSection) currentTraceSection()).getReturnAtMemorySpan();
 
       callStack.enter(
           frameType,
@@ -654,10 +642,7 @@ public class Hub implements Module {
           this.deploymentNumberOf(frame.getContractAddress()),
           new Bytecode(frame.getCode().getBytes()),
           frame.getSenderAddress(),
-          frame.getInputData(),
-          callDataOffset,
-          callDataSize,
-          callDataContextNumber,
+          callDataInfo,
           returnDataTargetInCaller);
 
       this.currentFrame().initializeFrame(frame);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/StpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/StpCall.java
@@ -77,7 +77,7 @@ public class StpCall implements TraceSubFragment {
   private void stpCallForCalls(Hub hub) {
     final MessageFrame frame = hub.messageFrame();
 
-    final boolean callCanTransferValue = opCode.callCanTransferValue();
+    final boolean callCanTransferValue = opCode.callHasValueArgument();
     final Address to = Words.toAddress(frame.getStackItem(1));
     final Account toAccount = frame.getWorldUpdater().get(to);
     this.gas = EWord.of(frame.getStackItem(0));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
@@ -20,7 +20,6 @@ import static net.consensys.linea.zktracer.module.hub.AccountSnapshot.canonical;
 import static net.consensys.linea.zktracer.module.hub.fragment.scenario.CallScenarioFragment.CallScenario.*;
 import static net.consensys.linea.zktracer.types.AddressUtils.isPrecompile;
 import static net.consensys.linea.zktracer.types.Conversions.bytesToBoolean;
-import static net.consensys.linea.zktracer.types.Conversions.bytesToInt;
 import static org.hyperledger.besu.datatypes.Address.*;
 
 import java.util.Map;
@@ -50,6 +49,7 @@ import net.consensys.linea.zktracer.module.hub.fragment.scenario.CallScenarioFra
 import net.consensys.linea.zktracer.module.hub.section.TraceSection;
 import net.consensys.linea.zktracer.module.hub.section.call.precompileSubsection.*;
 import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
+import net.consensys.linea.zktracer.runtime.callstack.CallDataInfo;
 import net.consensys.linea.zktracer.runtime.callstack.CallFrame;
 import net.consensys.linea.zktracer.types.EWord;
 import net.consensys.linea.zktracer.types.MemorySpan;
@@ -58,6 +58,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.internal.Words;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 import org.hyperledger.besu.evm.worldstate.WorldView;
@@ -123,7 +124,8 @@ public class CallSection extends TraceSection
   public StpCall stpCall;
   private PrecompileSubsection precompileSubsection;
 
-  @Getter private MemorySpan callProvidedReturnDataTargetSpan;
+  @Getter private MemorySpan returnAtMemorySpan;
+  @Getter private CallDataInfo callDataInfo;
 
   public CallSection(Hub hub, MessageFrame frame) {
     super(hub, maxNumberOfLines(hub));
@@ -183,12 +185,16 @@ public class CallSection extends TraceSection
     checkArgument(Exceptions.none(exceptions));
     currentFrame.childSpanningSection(this);
 
-    final boolean callCanTransferValue = currentFrame.opCode().callCanTransferValue();
-    callProvidedReturnDataTargetSpan =
-        returnDataMemorySpan(currentFrame.frame(), callCanTransferValue);
+    final boolean callHasValueArgument = currentFrame.opCode().callHasValueArgument();
+
+    // the call data span and ``return at'' spans are only required once the CALL is unexceptional
+    returnAtMemorySpan = returnAtMemorySpan(frame, callHasValueArgument);
+    callDataInfo =
+        new CallDataInfo(
+            frame, callDataSpan(frame, callHasValueArgument), currentFrame.contextNumber());
 
     value =
-        callCanTransferValue
+        callHasValueArgument
             ? Wei.of(currentFrame.frame().getStackItem(2).toUnsignedBigInteger())
             : Wei.ZERO;
 
@@ -623,15 +629,46 @@ public class CallSection extends TraceSection
     this.addFragments(firstCallerAccountFragment, firstCalleeAccountFragment);
   }
 
-  private MemorySpan returnDataMemorySpan(MessageFrame currentFrame, boolean callCanTransferValue) {
-    final int returnDataOffset =
-        callCanTransferValue
-            ? bytesToInt(currentFrame.getStackItem(5))
-            : bytesToInt(currentFrame.getStackItem(4));
-    final int returnDataLength =
-        callCanTransferValue
-            ? bytesToInt(currentFrame.getStackItem(6))
-            : bytesToInt(currentFrame.getStackItem(5));
-    return MemorySpan.fromStartLength(returnDataOffset, returnDataLength);
+  private MemorySpan callDataSpan(MessageFrame frame, boolean callHasValueArgument) {
+    final long callDataSize =
+        callHasValueArgument
+            ? Words.clampedToLong(frame.getStackItem(4))
+            : Words.clampedToLong(frame.getStackItem(3));
+
+    if (callDataSize == 0) {
+      return MemorySpan.empty();
+    }
+
+    final long returnAtOffset =
+        callHasValueArgument
+            ? Words.clampedToLong(frame.getStackItem(3))
+            : Words.clampedToLong(frame.getStackItem(2));
+    return MemorySpan.fromStartLength(returnAtOffset, callDataSize);
+  }
+
+  /**
+   * The {@link #returnAtMemorySpan(MessageFrame, boolean)} method implements the spec logic for
+   * defining the ``returnAtMemorySpan`` of a CALL. The main point being: if its capacity is zero we
+   * require that {@link MemorySpan} to be {@link MemorySpan#empty()}.
+   *
+   * @param frame
+   * @param callHasValueArgument
+   * @return
+   */
+  private MemorySpan returnAtMemorySpan(MessageFrame frame, boolean callHasValueArgument) {
+    final long returnAtCapacity =
+        callHasValueArgument
+            ? Words.clampedToLong(frame.getStackItem(6))
+            : Words.clampedToLong(frame.getStackItem(5));
+
+    if (returnAtCapacity == 0) {
+      return MemorySpan.empty();
+    }
+
+    final long returnAtOffset =
+        callHasValueArgument
+            ? Words.clampedToLong(frame.getStackItem(5))
+            : Words.clampedToLong(frame.getStackItem(4));
+    return MemorySpan.fromStartLength(returnAtOffset, returnAtCapacity);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/PrecompileSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/PrecompileSubsection.java
@@ -115,12 +115,12 @@ public class PrecompileSubsection
     final OpCode opCode = hub.opCode();
     final long offset =
         Words.clampedToLong(
-            opCode.callCanTransferValue()
+            opCode.callHasValueArgument()
                 ? messageFrame.getStackItem(3)
                 : messageFrame.getStackItem(2));
     final long length =
         Words.clampedToLong(
-            opCode.callCanTransferValue()
+            opCode.callHasValueArgument()
                 ? messageFrame.getStackItem(4)
                 : messageFrame.getStackItem(3));
     callDataMemorySpan = new MemorySpan(offset, length);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/oob/OobOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/oob/OobOperation.java
@@ -256,7 +256,7 @@ public class OobOperation extends ModuleOperation {
 
         // DELEGATECALL, STATICCALL can't trasfer value,
         // CALL, CALLCODE may transfer value
-        EWord value = opCode.callCanTransferValue() ? EWord.of(frame.getStackItem(2)) : EWord.ZERO;
+        EWord value = opCode.callHasValueArgument() ? EWord.of(frame.getStackItem(2)) : EWord.ZERO;
         CallOobCall callOobCall = (CallOobCall) oobCall;
         callOobCall.setValue(value);
         callOobCall.setBalance(callerAccount.getBalance().toUnsignedBigInteger());
@@ -302,11 +302,11 @@ public class OobOperation extends ModuleOperation {
     final OpCode opCode = getOpCode(frame);
     final long argsOffset =
         Words.clampedToLong(
-            opCode.callCanTransferValue()
+            opCode.callHasValueArgument()
                 ? hub.messageFrame().getStackItem(3)
                 : hub.messageFrame().getStackItem(2));
-    final int cdsIndex = opCode.callCanTransferValue() ? 4 : 3;
-    final int returnAtCapacityIndex = opCode.callCanTransferValue() ? 6 : 5;
+    final int cdsIndex = opCode.callHasValueArgument() ? 4 : 3;
+    final int returnAtCapacityIndex = opCode.callHasValueArgument() ? 6 : 5;
 
     BigInteger calleeGas = BigInteger.ZERO;
     if (oobCall instanceof PrecompileCommonOobCall) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/Stp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/Stp.java
@@ -61,7 +61,7 @@ public class Stp implements OperationSetModule<StpOperation> {
 
     if (stpCall.opCode().isCall()) {
       wcp.callLT(longToBytes32(stpCall.gasActual()), Bytes32.ZERO);
-      if (stpCall.opCode().callCanTransferValue()) {
+      if (stpCall.opCode().callHasValueArgument()) {
         wcp.callISZERO(Bytes32.leftPad(stpCall.value()));
       }
       wcp.callLT(longToBytes32(stpCall.gasActual()), longToBytes32(stpCall.upfrontGasCost()));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/StpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/StpOperation.java
@@ -180,7 +180,7 @@ public final class StpOperation extends ModuleOperation {
             .arg2Lo(Bytes.EMPTY)
             .exogenousModuleInstruction(UnsignedByte.of(OpCode.ISZERO.byteValue()))
             .resLo(Bytes.of(stpCall.value().isZero() ? 1 : 0))
-            .wcpFlag(stpCall.opCode().callCanTransferValue())
+            .wcpFlag(stpCall.opCode().callHasValueArgument())
             .modFlag(false)
             .fillAndValidateRow();
         case 2 -> trace

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCode.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCode.java
@@ -237,12 +237,12 @@ public enum OpCode {
     return getData().isCall();
   }
 
-  public boolean callMayNotTransferValue() {
+  public boolean callHasNoValueArgument() {
     checkArgument(isCall());
     return this == OpCode.DELEGATECALL || this == OpCode.STATICCALL;
   }
 
-  public boolean callCanTransferValue() {
+  public boolean callHasValueArgument() {
     checkArgument(isCall());
     return this == OpCode.CALL || this == OpCode.CALLCODE;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/callstack/CallDataInfo.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/callstack/CallDataInfo.java
@@ -15,14 +15,23 @@
 
 package net.consensys.linea.zktracer.runtime.callstack;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.types.MemorySpan;
 import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.evm.frame.MessageFrame;
 
 @Accessors(fluent = true)
 @Getter
 public class CallDataInfo {
+  private static final CallDataInfo EMPTY = new CallDataInfo(Bytes.EMPTY, 0, 0, 0);
+
+  public static CallDataInfo empty() {
+    return EMPTY;
+  }
+
   private final Bytes data;
   private final MemorySpan memorySpan;
   private final long callDataContextNumber;
@@ -32,8 +41,18 @@ public class CallDataInfo {
       final long callDataOffset,
       final long callDataSize,
       final long callDataContextNumber) {
+
+    checkArgument(data.size() == callDataSize);
     this.data = data;
     this.memorySpan = new MemorySpan(callDataOffset, callDataSize);
     this.callDataContextNumber = callDataContextNumber;
+  }
+
+  public CallDataInfo(
+      final MessageFrame frame, final MemorySpan span, final int callDataContextNumber) {
+    this.callDataContextNumber = callDataContextNumber;
+    this.memorySpan = span;
+    this.data =
+        (span.isEmpty()) ? Bytes.EMPTY : frame.shadowReadMemory(span.offset(), span.length());
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/callstack/CallFrame.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/callstack/CallFrame.java
@@ -216,11 +216,8 @@ public class CallFrame {
    * @param byteCodeDeploymentNumber DN of this call frame in the {@link Hub}
    * @param byteCode byteCode that executes in the present context
    * @param callerAddress either account address of the caller/creator context
-   * @param callDataContextNumber CN of the RAM segment wherein the call data lives
    * @param parentId ID of the caller frame in the {@link CallStack}
-   * @param callData {@link Bytes} containing this frame's call data
-   * @param callDataOffset offset of call data in the caller's RAM (if applicable)
-   * @param callDataSize size (in bytes) of the call data
+   * @param callDataInfo call data of the current frame
    */
   CallFrame(
       CallFrameType type,
@@ -236,11 +233,8 @@ public class CallFrame {
       int byteCodeDeploymentNumber,
       Bytecode byteCode,
       Address callerAddress,
-      long callDataContextNumber,
       int parentId,
-      Bytes callData,
-      long callDataOffset,
-      long callDataSize,
+      CallDataInfo callDataInfo,
       MemorySpan returnDataTargetInCaller) {
     this.type = type;
     this.id = id;
@@ -256,8 +250,7 @@ public class CallFrame {
     this.code = byteCode;
     this.callerAddress = callerAddress;
     this.parentId = parentId;
-    this.callDataInfo =
-        new CallDataInfo(callData, callDataOffset, callDataSize, callDataContextNumber);
+    this.callDataInfo = callDataInfo;
     this.outputDataSpan = MemorySpan.empty();
     this.returnDataSpan = MemorySpan.empty();
     this.returnDataTargetInCaller = returnDataTargetInCaller;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/callstack/CallStack.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/callstack/CallStack.java
@@ -84,10 +84,7 @@ public final class CallStack {
         codeDeploymentNumber,
         toCode == null ? Bytecode.EMPTY : toCode,
         from,
-        callData,
-        0,
-        callData.size(),
-        callDataContextNumber,
+        new CallDataInfo(callData, 0, callData.size(), callDataContextNumber),
         MemorySpan.empty());
     this.currentId = this.callFrames.size() - 1;
   }
@@ -113,16 +110,7 @@ public final class CallStack {
         0,
         Bytecode.EMPTY,
         Address.ZERO, // useless
-        // useless
-        // useless
-        // useless
-        callData,
-        0,
-        callData.size(),
-        transactionCallDataContextNumber,
-        // useless
-        // useless
-        // useless
+        CallDataInfo.empty(),
         MemorySpan.empty());
     this.currentId = this.callFrames.size() - 1;
   }
@@ -169,7 +157,6 @@ public final class CallStack {
    * @param accountDeploymentNumber
    * @param byteCodeDeploymentNumber
    * @param byteCode the {@link Code} being executed
-   * @param inputData the call data sent to this call frame
    */
   public void enter(
       CallFrameType type,
@@ -183,19 +170,12 @@ public final class CallStack {
       int byteCodeDeploymentNumber,
       Bytecode byteCode,
       Address callerAddress,
-      Bytes inputData,
-      long callDataOffset,
-      long callDataSize,
-      long callDataContextNumber,
+      CallDataInfo callDataInfo,
       MemorySpan returnDataTargetInCaller) {
     final int callerId = this.depth == -1 ? -1 : this.currentId;
     final int newCallFrameId = this.callFrames.size();
     this.depth += 1;
 
-    Bytes callData = Bytes.EMPTY;
-    if (type != CallFrameType.INIT_CODE) {
-      callData = inputData;
-    }
     final CallFrame newFrame =
         new CallFrame(
             type,
@@ -211,11 +191,8 @@ public final class CallStack {
             byteCodeDeploymentNumber,
             byteCode,
             callerAddress,
-            callDataContextNumber,
             callerId,
-            callData,
-            callDataOffset,
-            callDataSize,
+            callDataInfo,
             returnDataTargetInCaller);
 
     this.callFrames.add(newFrame);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/stack/Stack.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/stack/Stack.java
@@ -278,7 +278,7 @@ public class Stack {
     Bytes val5 = getStack(frame, 4);
     Bytes val6 = getStack(frame, 5);
 
-    boolean callCanTransferValue = currentOpcodeData.mnemonic().callCanTransferValue();
+    boolean callCanTransferValue = currentOpcodeData.mnemonic().callHasValueArgument();
 
     if (callCanTransferValue) {
       Bytes val7 = getStack(frame, 6);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/types/MemorySpan.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/types/MemorySpan.java
@@ -22,8 +22,11 @@ package net.consensys.linea.zktracer.types;
  * @param length the region length
  */
 public record MemorySpan(long offset, long length) {
+
+  private static final MemorySpan EMPTY = new MemorySpan(0, 0);
+
   public static MemorySpan empty() {
-    return new MemorySpan(0, 0);
+    return EMPTY;
   }
 
   /**

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/Utilities.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/Utilities.java
@@ -39,7 +39,7 @@ public class Utilities {
       int rao,
       int rac) {
     program.push(rac).push(rao).push(cds).push(cdo);
-    if (callOpcode.callCanTransferValue()) {
+    if (callOpcode.callHasValueArgument()) {
       program.push(value);
     }
     program.push(to).op(GAS).op(callOpcode).op(POP);
@@ -56,7 +56,7 @@ public class Utilities {
       int rao,
       int rac) {
     program.push(rac).push(rao).push(cds).push(cdo);
-    if (callOpcode.callCanTransferValue()) {
+    if (callOpcode.callHasValueArgument()) {
       program.push(value);
     }
     program.push(to).push(gas).op(callOpcode);
@@ -71,7 +71,7 @@ public class Utilities {
       int cds,
       int rao,
       int rac) {
-    checkArgument(callOpcode.callCanTransferValue());
+    checkArgument(callOpcode.callHasValueArgument());
     program
         .push(rac)
         .push(rao)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/ZeroSizeArgumentTests.javaX
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/ZeroSizeArgumentTests.javaX
@@ -1,0 +1,121 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package net.consensys.linea.zktracer.instructionprocessing.callTests;
+
+import java.util.List;
+
+import net.consensys.linea.testing.BytecodeCompiler;
+import net.consensys.linea.testing.BytecodeRunner;
+import net.consensys.linea.testing.ToyAccount;
+import net.consensys.linea.zktracer.opcode.OpCode;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Wei;
+import org.junit.jupiter.api.Test;
+
+public class ZeroSizeArgumentTests {
+  /*
+   * Copyright ConsenSys Inc.
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+   * the License. You may obtain a copy of the License at
+   *
+   * http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+   * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   * specific language governing permissions and limitations under the License.
+   *
+   * SPDX-License-Identifier: Apache-2.0
+   */
+
+  @Test
+  void zeroReturnAtCapacityTest() {
+    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    program
+        .push(0) // return at capacity
+        .push("ff".repeat(32)) // return at offset
+        .push(0) // call data size
+        .push(0) // call data offset
+        .push("ca11ee") // address
+        .push(1000) // gas
+        .op(OpCode.STATICCALL);
+
+    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram();
+    calleeProgram.op(OpCode.CALLDATASIZE);
+
+    final ToyAccount calleeAccount =
+        ToyAccount.builder()
+            .balance(Wei.fromEth(1))
+            .nonce(10)
+            .address(Address.fromHexString("ca11ee"))
+            .code(calleeProgram.compile())
+            .build();
+
+    BytecodeRunner.of(program.compile()).run(Wei.fromEth(1), 30000L, List.of(calleeAccount));
+    // TODO: this test is supposed to fail as the ones below, but it does not. Understand why
+  }
+
+  @Test
+  void zeroCallDataSizeTest() {
+    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    program
+        .push(0) // return at capacity
+        .push(0) // return at offset
+        .push(0) // call data size
+        .push("ff".repeat(32)) // call data offset
+        .push("ca11ee") // address
+        .push(1000) // gas
+        .op(OpCode.STATICCALL);
+
+    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram();
+    calleeProgram.op(OpCode.CALLDATASIZE);
+
+    final ToyAccount calleeAccount =
+        ToyAccount.builder()
+            .balance(Wei.fromEth(1))
+            .nonce(10)
+            .address(Address.fromHexString("ca11ee"))
+            .code(calleeProgram.compile())
+            .build();
+
+    BytecodeRunner.of(program.compile()).run(Wei.fromEth(1), 30000L, List.of(calleeAccount));
+  }
+
+  @Test
+  void zeroCallDataSizeAndReturnAtCapacityTest() {
+    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    program
+        .push(0) // return at capacity
+            .push("ff".repeat(32)) // return at offset
+        .push(0) // call data size
+            .push("ff".repeat(32)) // call data offset
+        .push("ca11ee") // address
+        .push(1000) // gas
+        .op(OpCode.STATICCALL);
+
+    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram();
+    calleeProgram.push(0).push("ff".repeat(32)).op(OpCode.RETURN);
+
+    final ToyAccount calleeAccount =
+        ToyAccount.builder()
+            .balance(Wei.fromEth(1))
+            .nonce(10)
+            .address(Address.fromHexString("ca11ee"))
+            .code(calleeProgram.compile())
+            .build();
+
+    BytecodeRunner.of(program.compile()).run(Wei.fromEth(1), 30000L, List.of(calleeAccount));
+  }
+}


### PR DESCRIPTION
- the `enter` method of `CallFrame` now uses a `CallDataInfo` object
- `CallSection`'s now produce the relevant `CallDataInfo` object, which the `enter(...)` method of the `CallFrame` re-uses
- a `CallSection`'s `callDataInfo` and `returnAtMemorySpan` now implement the logic whereby if the size is zero we discard the (meaningless) offset and set the span to `EMPTY`
- copy paste of the test in @lorenzogentile404 PR + some fixes to it (it likely be replaced by the analoguous parametric tests on the `HUB` issue)