### PR TITLE
fix: name for "Weekly Tests" workflow

### DIFF
--- a/.github/workflows/gradle-weekly-tests.yml
+++ b/.github/workflows/gradle-weekly-tests.yml
@@ -1,4 +1,4 @@
-name: Nightly Tests
+name: Weekly Tests
 
 on:
   schedule:


### PR DESCRIPTION
The name was previously "Nightly Tests" which was confusing, as these were actually the weekly tests.  Corrected now.