### PR TITLE
fix: `go-corset` running `test` in CI

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -8,8 +8,8 @@ runs:
       uses: ./.github/actions/setup-rust-corset
 
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5.1.0
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@latest
+      run: go install github.com/consensys/go-corset/cmd/go-corset@5cb0c28

--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -81,7 +81,6 @@ jobs:
       - name: Run General State Reference Tests
         run: GOMEMLIMIT=196GiB ./gradlew referenceGeneralStateTests
         env:
-          REFERENCE_TESTS_PARALLELISM: 10
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -wd --ansi-escapes=false --report --air
@@ -91,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ethereum-tests-go-corset-report
-          path: | 
+          path: |
             reference-tests/build/reports/tests/**/*
             tmp/local/*
 

--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           name: nightly-tests-report
           path: build/reports/tests/**/*
-          
+
       - name: Failure Notification
         if: ${{ failure() || cancelled() }}
         uses: slackapi/slack-github-action@v2.0.0

--- a/.github/workflows/gradle-weekly-tests.yml
+++ b/.github/workflows/gradle-weekly-tests.yml
@@ -64,8 +64,7 @@ jobs:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -wd --ansi-escapes=false --report --air
-          WEEKLY_TESTS_PARALLELISM: 4
-          
+
       - name: Failure Notification
         if: ${{ failure() || cancelled() }}
         uses: slackapi/slack-github-action@v2.0.0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -80,6 +80,7 @@ jobs:
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: trace-span=3,fields,expand,expand,expand
+          REPLAY_TESTS_PARALLELISM: 2
 
       - name: Run Replay tests
         run: ./gradlew :arithmetization:fastReplayTests --stacktrace

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-name: gradle
+name: "Unit & Fast Replay Tests"
 
 on:
   push:
@@ -80,7 +80,7 @@ jobs:
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: trace-span=3,fields,expand,expand,expand
-          REPLAY_TESTS_PARALLELISM: 2
+          UNIT_TESTS_PARALLELISM: 2
 
       - name: Run Replay tests
         run: ./gradlew :arithmetization:fastReplayTests --stacktrace

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           name: blockchain-refrence-tests-report
           path: reference-tests/build/reports/tests/**/*
-          
+
       - name: Failure Notification
         if: ${{ failure() || cancelled() }}
         uses: slackapi/slack-github-action@v2.0.0

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -118,13 +118,11 @@ tasks.withType(Test).configureEach {
 }
 
 tasks.test.configure {
-  if (System.getenv().containsKey("REPLAY_TESTS_PARALLELISM") ||
-      System.getenv().containsKey("WEEKLY_TESTS_PARALLELISM") ||
-      System.getenv().containsKey("REFERENCE_TESTS_PARALLELISM")) {
+  if (System.getenv().containsKey("UNIT_TESTS_PARALLELISM")) {
     // Only set this if parallelism is explicitly requested.
     // Specifically, because this option is not compatible with
     // go-corset.
-    maxParallelForks = Runtime.getRuntime().availableProcessors()
+    maxParallelForks = System.getenv().get("UNIT_TESTS_PARALLELISM").toInteger()
     println "Enabled parallel forks."
   }
   useJUnitPlatform {

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -118,7 +118,15 @@ tasks.withType(Test).configureEach {
 }
 
 tasks.test.configure {
-  maxParallelForks = Runtime.getRuntime().availableProcessors()
+  if (System.getenv().containsKey("REPLAY_TESTS_PARALLELISM") ||
+      System.getenv().containsKey("WEEKLY_TESTS_PARALLELISM") ||
+      System.getenv().containsKey("REFERENCE_TESTS_PARALLELISM")) {
+    // Only set this if parallelism is explicitly requested.
+    // Specifically, because this option is not compatible with
+    // go-corset.
+    maxParallelForks = Runtime.getRuntime().availableProcessors()
+    println "Enabled parallel forks."
+  }
   useJUnitPlatform {
     excludeTags("nightly")
     excludeTags("replay")


### PR DESCRIPTION
This disables the use of parallel forks in gradle unless this is
explicitly requested.  The issue is that parallel forks interferes with
go-corset which is highly concurrent.  Hence, running go-corset tasks in
parallel can (in some cases) lead to out-of-resource issues and workflow
tasks being cancelled unexpectedly.

However, since using parallel forks does improve the runtime for Rust
corset, this option is retained when specifically specified via the
UNIT_TESTS_PARALLELISM environment variable.