### PR TITLE
Slack Notification for Test Failures

### DIFF
--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -94,3 +94,13 @@ jobs:
           path: | 
             reference-tests/build/reports/tests/**/*
             tmp/local/*
+
+      - name: Failure Notification
+        if: ${{ failure() || cancelled() }}
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+             name: "Daily Reference Tests"
+             status: "${{ job.status }}"

--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -34,8 +34,18 @@ jobs:
           GOCORSET_FLAGS: -wd --ansi-escapes=false --report --air
 
       - name: Upload test report
-        if: always()
+        if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
           name: nightly-tests-report
           path: build/reports/tests/**/*
+          
+      - name: Failure Notification
+        if: ${{ failure() || cancelled() }}
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+             name: "Nightly"
+             status: "${{ job.status }}"

--- a/.github/workflows/gradle-weekly-tests.yml
+++ b/.github/workflows/gradle-weekly-tests.yml
@@ -65,3 +65,13 @@ jobs:
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -wd --ansi-escapes=false --report --air
           WEEKLY_TESTS_PARALLELISM: 4
+          
+      - name: Failure Notification
+        if: ${{ failure() || cancelled() }}
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+             name: "Weekly"
+             status: "${{ job.status }}"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -136,7 +136,7 @@ jobs:
           GOCORSET_FLAGS: -b1024 -wd --ansi-escapes=false --report --air
 
       - name: Upload test report
-        if: always()
+        if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
           name: go-corset-tests-report

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -88,3 +88,13 @@ jobs:
         with:
           name: blockchain-refrence-tests-report
           path: reference-tests/build/reports/tests/**/*
+          
+      - name: Failure Notification
+        if: ${{ failure() || cancelled() }}
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+             name: "Daily Reference Tests"
+             status: "${{ job.status }}"


### PR DESCRIPTION
The goal is to generate slack notifications when scheduled tests fail (e.g. "Nightly Tests", "Weekly Tests", etc).  This works by triggering a slack workflow webhook and including some minimal information.