### PR TITLE
Reenable TX Outcome Checks for Replay Tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 releaseVersion=0.8.0-rc5
-besuVersion=24.11-develop-139a0f1
+besuVersion=24.11-develop-660a354
 besuArtifactGroup=io.consensys.linea-besu
 distributionIdentifier=linea-tracer
 distributionBaseUrl=https://artifacts.consensys.net/public/linea-besu/raw/names/linea-besu.tar.gz/versions/


### PR DESCRIPTION
This updates the record TX outcomes in the replay test files to correctly follow mainnet.  This was done by playing the replays back through the ReplayExecutionEnvironment and the recording the outcomes using the BlockCapturer.

**NOTE**: this also updates `linea-besu` to `660a354` (as this includes the finalised fix for `traceEndTransaction()`).