### PR TITLE
fix: Daily Blockchain Reference Test Workflow Failures

### DIFF
--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -51,6 +51,15 @@ jobs:
             reference-tests/build/reports/tests/**/*
             tmp/local/*
 
+      - name: Failure Notification
+        if: ${{ failure() || cancelled() }}
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+             name: "Daily Reference Tests (Rust Corset)"
+             status: "${{ job.status }}"
 
   ethereum-tests-go-corset:
     runs-on: ubuntu-latest-128
@@ -73,7 +82,7 @@ jobs:
         run: cd ./linea-constraints; make zkevm_for_reference_tests.bin -B; cd ..
 
       - name: Generate General State Reference Tests
-        run: ./gradlew generateGeneralStateReferenceTests -Dorg.gradle.parallel=true -Dorg.gradle.caching=true
+        run: ./gradlew generateGeneralStateReferenceTests -Dorg.gradle.caching=true
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: fields,expand,expand,expand
@@ -101,5 +110,5 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: |
-             name: "Daily Reference Tests"
+             name: "Daily Reference Tests (Go Corset)"
              status: "${{ job.status }}"

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -65,7 +65,6 @@ jobs:
       - name: Run reference blockchain tests
         run: ./gradlew referenceBlockchainTests -x spotlessCheck
         timeout-minutes: 180
-        continue-on-error: true
         env:
           REFERENCE_TESTS_PARALLELISM: 7
           JAVA_OPTS: -Dorg.gradle.daemon=false

--- a/gradle/lint.gradle
+++ b/gradle/lint.gradle
@@ -49,7 +49,8 @@ spotless {
   }
   groovyGradle {
     target '*.gradle'
-    greclipse('4.21').configFile(rootProject.file('gradle/formatter.properties'))
+    // Temporarily disabled as was reporting XZFormatException
+    //    greclipse('4.21').configFile(rootProject.file('gradle/formatter.properties'))
     endWithNewline()
   }
   // Below this line are currently only license header tasks


### PR DESCRIPTION
Currently, workflow failures are being recorded as passing.  The reason for this is simply a flag within the yaml file that was presumably copied over from the original gradle tests.  This should now resolve the issus, and make sure that when the workflow fails --- we see that.