### PR TITLE
MmioPatterns optimisation

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
@@ -182,18 +182,6 @@ public class MmioPatterns {
 
   public static void updateTemporaryTargetRam(
       MmuData mmuData, final long targetLimbOffsetToUpdate, final Bytes16 newLimb) {
-
-    int limbStart = (int) (LLARGE * targetLimbOffsetToUpdate);
-    int limbEnd = limbStart + LLARGE;
-    byte[] originalRam = mmuData.targetRamBytes().toArray();
-    int sliceSize = Math.max(0, originalRam.length - limbEnd);
-
-    int size = limbStart + newLimb.size() + sliceSize;
-    byte[] updatedRam = new byte[size];
-    System.arraycopy(newLimb.toArray(), 0, updatedRam, limbStart, newLimb.size());
-    if (sliceSize > 0)
-      System.arraycopy(originalRam, limbEnd, updatedRam, limbStart + newLimb.size(), sliceSize);
-
-    mmuData.targetRamBytes(Bytes.wrap(updatedRam));
+    mmuData.targetRamBytes().set((int) targetLimbOffsetToUpdate, newLimb);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
@@ -181,7 +181,7 @@ public class MmioPatterns {
   }
 
   public static void updateTemporaryTargetRam(
-          MmuData mmuData, final long targetLimbOffsetToUpdate, final Bytes16 newLimb) {
+      MmuData mmuData, final long targetLimbOffsetToUpdate, final Bytes16 newLimb) {
     byte[] originalRam = mmuData.targetRamBytes().toArray();
 
     int limbStart = (int) (LLARGE * targetLimbOffsetToUpdate);
@@ -190,8 +190,8 @@ public class MmioPatterns {
     byte[] updatedRam = new byte[originalRam.length];
     System.arraycopy(originalRam, 0, updatedRam, 0, limbStart);
     System.arraycopy(newLimb.toArray(), 0, updatedRam, limbStart, newLimb.size());
-    System.arraycopy(originalRam, limbEnd, updatedRam, limbStart + newLimb.size(),
-            originalRam.length - limbEnd);
+    System.arraycopy(
+        originalRam, limbEnd, updatedRam, limbStart + newLimb.size(), originalRam.length - limbEnd);
     mmuData.targetRamBytes(Bytes.wrap(updatedRam));
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
@@ -187,13 +187,28 @@ public class MmioPatterns {
     int limbEnd = limbStart + LLARGE;
     byte[] originalRam = mmuData.targetRamBytes().toArray();
 
-    // The original formula below is limbStart + newLimb.size() + mmuData.targetRamBytes().size() - limbStart
-    int size = newLimb.size() + mmuData.targetRamBytes().size();
+    int size = limbStart + newLimb.size() + mmuData.targetRamBytes().size() - limbEnd;
     byte[] updatedRam = new byte[size];
     System.arraycopy(newLimb.toArray(), 0, updatedRam, limbStart, newLimb.size());
     System.arraycopy(
         originalRam, limbEnd, updatedRam, limbStart + newLimb.size(), originalRam.length - limbEnd);
 
     mmuData.targetRamBytes(Bytes.wrap(updatedRam));
+  }
+
+  public static void updateTemporaryTargetRam0(
+      MmuData mmuData, final long targetLimbOffsetToUpdate, final Bytes16 newLimb) {
+    final Bytes bytesPreLimb =
+        Bytes.repeat(
+            (byte) 0,
+            (int)
+                (LLARGE
+                    * targetLimbOffsetToUpdate)); // We won't access the preLimb again, so we don't
+    // care
+    // of its value
+    final Bytes bytesPostLimb =
+        mmuData.targetRamBytes().slice((int) ((targetLimbOffsetToUpdate + 1) * LLARGE));
+
+    mmuData.targetRamBytes(Bytes.concatenate(bytesPreLimb, newLimb, bytesPostLimb));
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
@@ -181,18 +181,17 @@ public class MmioPatterns {
   }
 
   public static void updateTemporaryTargetRam(
-      MmuData mmuData, final long targetLimbOffsetToUpdate, final Bytes16 newLimb) {
-    final Bytes bytesPreLimb =
-        Bytes.repeat(
-            (byte) 0,
-            (int)
-                (LLARGE
-                    * targetLimbOffsetToUpdate)); // We won't access the preLimb again, so we don't
-    // care
-    // of its value
-    final Bytes bytesPostLimb =
-        mmuData.targetRamBytes().slice((int) ((targetLimbOffsetToUpdate + 1) * LLARGE));
+          MmuData mmuData, final long targetLimbOffsetToUpdate, final Bytes16 newLimb) {
+    byte[] originalRam = mmuData.targetRamBytes().toArray();
 
-    mmuData.targetRamBytes(Bytes.concatenate(bytesPreLimb, newLimb, bytesPostLimb));
+    int limbStart = (int) (LLARGE * targetLimbOffsetToUpdate);
+    int limbEnd = limbStart + (int) LLARGE;
+
+    byte[] updatedRam = new byte[originalRam.length];
+    System.arraycopy(originalRam, 0, updatedRam, 0, limbStart);
+    System.arraycopy(newLimb.toArray(), 0, updatedRam, limbStart, newLimb.size());
+    System.arraycopy(originalRam, limbEnd, updatedRam, limbStart + newLimb.size(),
+            originalRam.length - limbEnd);
+    mmuData.targetRamBytes(Bytes.wrap(updatedRam));
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
@@ -196,20 +196,4 @@ public class MmioPatterns {
 
     mmuData.targetRamBytes(Bytes.wrap(updatedRam));
   }
-
-  public static void updateTemporaryTargetRam0(
-      MmuData mmuData, final long targetLimbOffsetToUpdate, final Bytes16 newLimb) {
-    final Bytes bytesPreLimb =
-        Bytes.repeat(
-            (byte) 0,
-            (int)
-                (LLARGE
-                    * targetLimbOffsetToUpdate)); // We won't access the preLimb again, so we don't
-    // care
-    // of its value
-    final Bytes bytesPostLimb =
-        mmuData.targetRamBytes().slice((int) ((targetLimbOffsetToUpdate + 1) * LLARGE));
-
-    mmuData.targetRamBytes(Bytes.concatenate(bytesPreLimb, newLimb, bytesPostLimb));
-  }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
@@ -186,12 +186,13 @@ public class MmioPatterns {
     int limbStart = (int) (LLARGE * targetLimbOffsetToUpdate);
     int limbEnd = limbStart + LLARGE;
     byte[] originalRam = mmuData.targetRamBytes().toArray();
+    int sliceSize = Math.max(0, originalRam.length - limbEnd);
 
-    int size = limbStart + newLimb.size() + originalRam.length - limbEnd;
+    int size = limbStart + newLimb.size() + sliceSize;
     byte[] updatedRam = new byte[size];
     System.arraycopy(newLimb.toArray(), 0, updatedRam, limbStart, newLimb.size());
-    System.arraycopy(
-        originalRam, limbEnd, updatedRam, limbStart + newLimb.size(), originalRam.length - limbEnd);
+    if (sliceSize > 0)
+      System.arraycopy(originalRam, limbEnd, updatedRam, limbStart + newLimb.size(), sliceSize);
 
     mmuData.targetRamBytes(Bytes.wrap(updatedRam));
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
@@ -187,7 +187,7 @@ public class MmioPatterns {
     int limbEnd = limbStart + LLARGE;
     byte[] originalRam = mmuData.targetRamBytes().toArray();
 
-    int size = limbStart + newLimb.size() + mmuData.targetRamBytes().size() - limbEnd;
+    int size = limbStart + newLimb.size() + originalRam.length - limbEnd;
     byte[] updatedRam = new byte[size];
     System.arraycopy(newLimb.toArray(), 0, updatedRam, limbStart, newLimb.size());
     System.arraycopy(

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
@@ -182,16 +182,18 @@ public class MmioPatterns {
 
   public static void updateTemporaryTargetRam(
       MmuData mmuData, final long targetLimbOffsetToUpdate, final Bytes16 newLimb) {
-    byte[] originalRam = mmuData.targetRamBytes().toArray();
 
     int limbStart = (int) (LLARGE * targetLimbOffsetToUpdate);
     int limbEnd = limbStart + LLARGE;
+    byte[] originalRam = mmuData.targetRamBytes().toArray();
 
-    byte[] updatedRam = new byte[originalRam.length];
-    System.arraycopy(originalRam, 0, updatedRam, 0, limbStart);
+    // The original formula below is limbStart + newLimb.size() + mmuData.targetRamBytes().size() - limbStart
+    int size = newLimb.size() + mmuData.targetRamBytes().size();
+    byte[] updatedRam = new byte[size];
     System.arraycopy(newLimb.toArray(), 0, updatedRam, limbStart, newLimb.size());
     System.arraycopy(
         originalRam, limbEnd, updatedRam, limbStart + newLimb.size(), originalRam.length - limbEnd);
+
     mmuData.targetRamBytes(Bytes.wrap(updatedRam));
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioPatterns.java
@@ -185,7 +185,7 @@ public class MmioPatterns {
     byte[] originalRam = mmuData.targetRamBytes().toArray();
 
     int limbStart = (int) (LLARGE * targetLimbOffsetToUpdate);
-    int limbEnd = limbStart + (int) LLARGE;
+    int limbEnd = limbStart + LLARGE;
 
     byte[] updatedRam = new byte[originalRam.length];
     System.arraycopy(originalRam, 0, updatedRam, 0, limbStart);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/MmuData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/MmuData.java
@@ -37,6 +37,7 @@ import net.consensys.linea.zktracer.module.mmu.values.MmuToMmioConstantValues;
 import net.consensys.linea.zktracer.module.mmu.values.MmuToMmioInstruction;
 import net.consensys.linea.zktracer.module.mmu.values.MmuWcpCallRecord;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.MutableBytes;
 
 @AllArgsConstructor
 @Getter
@@ -56,7 +57,7 @@ public class MmuData {
   private boolean mmuInstAnyToRamWithPaddingIsPurePadding;
   private Bytes exoBytes;
   private Bytes sourceRamBytes;
-  private Bytes targetRamBytes;
+  private MutableBytes targetRamBytes;
   private final boolean exoLimbIsSource;
   private final boolean exoLimbIsTarget;
   private static final List<Integer> MMU_INST_EXO_IS_SOURCE =
@@ -83,7 +84,7 @@ public class MmuData {
         false,
         Bytes.EMPTY,
         Bytes.EMPTY,
-        Bytes.EMPTY,
+        MutableBytes.EMPTY,
         MMU_INST_EXO_IS_SOURCE.contains(mmuCall.instruction()),
         MMU_INST_EXO_IS_TARGET.contains(mmuCall.instruction()));
 
@@ -112,7 +113,7 @@ public class MmuData {
 
   public void setTargetRamBytes() {
     if (mmuCall.targetRamBytes().isPresent()) {
-      targetRamBytes(mmuCall.targetRamBytes().get());
+      targetRamBytes(mmuCall.targetRamBytes().get().mutableCopy());
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/instructions/ExoToRamTransplants.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/instructions/ExoToRamTransplants.java
@@ -32,6 +32,7 @@ import net.consensys.linea.zktracer.module.mmu.values.MmuToMmioConstantValues;
 import net.consensys.linea.zktracer.module.mmu.values.MmuToMmioInstruction;
 import net.consensys.linea.zktracer.module.mmu.values.MmuWcpCallRecord;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.MutableBytes;
 
 public class ExoToRamTransplants implements MmuInstruction {
   private final Euc euc;
@@ -89,7 +90,7 @@ public class ExoToRamTransplants implements MmuInstruction {
     // Setting the target ram bytes
     // The target CN is ALWAYS a new, virgin, fictitious context, where is either write the call
     // data, or the result of a precompile
-    mmuData.targetRamBytes(Bytes.EMPTY);
+    mmuData.targetRamBytes(MutableBytes.EMPTY);
 
     // setting the MMIO instructions
     for (int i = 0; i < mmuData.totalNonTrivialInitials(); i++) {


### PR DESCRIPTION
Following an issue we faced recently on sepolia on linea_generateConflatedTracesToFileV2, where tracing the batch of blocks take more than 30 seconds we noticed that MmioPatterns.updateTemporaryTargetRam method takes more than 2.5 seconds to execute (see profiling below).

This PR improves this method by using Java native calls (System.arraycopy) to copy byte arrays instead of using Tuweni library.

**Before this PR**

<img width="1716" alt="image" src="https://github.com/user-attachments/assets/ea1a3715-f125-4c41-9022-9fc146125f0a">

<img width="1716" alt="image" src="https://github.com/user-attachments/assets/86495514-4fad-4987-9d8a-f86ef4cc024b">


**With this PR**
<img width="1716" alt="image" src="https://github.com/user-attachments/assets/4feeacfb-087c-4071-9c3c-6a2bc6db1ddb">

<img width="1716" alt="image" src="https://github.com/user-attachments/assets/0f0aed5f-175d-4772-98ca-8167355c3455">

Currently the test takes around 25 seconds instead of 30 seconds
```
[ec2-user@ip-10-40-43-134 besu]$ time curl --location --request POST 'localhost:8545' --header 'Content-Type: application/json' --data-raw '{"jsonrpc": "2.0", "method": "linea_generateConflatedTracesToFileV2", "params": [{"startBlockNumber":6488125,"endBlockNumber":6488189, "expectedTracesEngineVersion": "0.8.0-rc6"}], "id": 1}'
{"jsonrpc":"2.0","id":1,"result":{"tracesEngineVersion":"0.8.0-rc6","conflatedTracesFileName":"/data/besu/conflated/6488125-6488189.conflated.0.8.0-rc6.lt"}}
real	0m24.473s
user	0m0.005s
sys	0m0.000s
```