### PR TITLE
CHANGED - revert runner for blockchain tests to git-hosted

### DIFF
--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   blockchain-reference-tests:
-    runs-on: [gha-runner-scale-set-ubuntu-22.04-amd64-xxl]
+    runs-on: [ubuntu-latest-128]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Issue with Gradle, will science before re-introducing