### PR TITLE
`HUB -> ROM` lookup fix

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
@@ -20,7 +20,10 @@ import static net.consensys.linea.zktracer.opcode.InstructionFamily.*;
 import java.util.Objects;
 
 import net.consensys.linea.zktracer.opcode.gas.Billing;
+import net.consensys.linea.zktracer.opcode.gas.BillingRate;
+import net.consensys.linea.zktracer.opcode.gas.GasConstants;
 import net.consensys.linea.zktracer.opcode.gas.MxpType;
+import net.consensys.linea.zktracer.opcode.stack.Pattern;
 import net.consensys.linea.zktracer.opcode.stack.StackSettings;
 
 /**
@@ -46,6 +49,28 @@ public record OpCodeData(
     return Objects.requireNonNullElse(billing, Billing.DEFAULT);
   }
 
+  public static OpCodeData forNonOpCodes(int value){
+    return new OpCodeData(
+        OpCode.INVALID,
+        value,
+        INVALID,
+        new StackSettings(
+                Pattern.ZERO_ZERO,
+                0,
+                0,
+                GasConstants.G_ZERO,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false
+        ),
+        new RamSettings(DataLocation.NONE, DataLocation.NONE),
+        new Billing(GasConstants.G_ZERO, BillingRate.NONE, MxpType.NONE));
+  }
   /**
    * A method singling out <code>PUSHx</code> instructions.
    *

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
@@ -49,28 +49,28 @@ public record OpCodeData(
     return Objects.requireNonNullElse(billing, Billing.DEFAULT);
   }
 
-  public static OpCodeData forNonOpCodes(int value){
+  public static OpCodeData forNonOpCodes(int value) {
     return new OpCodeData(
         OpCode.INVALID,
         value,
         INVALID,
         new StackSettings(
-                Pattern.ZERO_ZERO,
-                0,
-                0,
-                GasConstants.G_ZERO,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-        ),
+            Pattern.ZERO_ZERO,
+            0,
+            0,
+            GasConstants.G_ZERO,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false),
         new RamSettings(DataLocation.NONE, DataLocation.NONE),
         new Billing(GasConstants.G_ZERO, BillingRate.NONE, MxpType.NONE));
   }
+
   /**
    * A method singling out <code>PUSHx</code> instructions.
    *

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodes.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodes.java
@@ -70,7 +70,7 @@ public class OpCodes {
       throw new IllegalArgumentException("No OpCode with value %s is defined.".formatted(value));
     }
 
-    return valueToOpCodeDataMap.getOrDefault(value, of(OpCode.INVALID));
+    return valueToOpCodeDataMap.getOrDefault(value, OpCodeData.forNonOpCodes(value));
   }
 
   /**


### PR DESCRIPTION
When Besu encounters a byte in the byte code that doesn't correspond to a known opcode it seems to default to the `INVALID` OpCode. This breaks the "instruction fetching" lookup

$$\texttt{HUB} \hookrightarrow \mathtt{ROM}$$

This PR fixes many of the reference tests (e.g. `BlockchainReferenceTest_53` tests à la `opcEFDiffPlaces_xxx`.)