### PR TITLE
`PUSHVALUE` fix for exceptional `PUSH`es

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/StackFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/StackFragment.java
@@ -46,8 +46,6 @@ import net.consensys.linea.zktracer.types.EWord;
 import net.consensys.linea.zktracer.types.UnsignedByte;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.evm.Code;
-import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.internal.Words;
 
 @Accessors(fluent = true)
@@ -159,8 +157,8 @@ public final class StackFragment implements TraceFragment {
     int nLeftoverBytes = byteCode.size() - (pc + 1);
     Bytes partialPushValue = byteCode.slice(pc + 1, min(nLeftoverBytes, nBytesToPush));
     return (nLeftoverBytes >= nBytesToPush)
-            ? partialPushValue
-            : rightPadTo(partialPushValue, nBytesToPush);
+        ? partialPushValue
+        : rightPadTo(partialPushValue, nBytesToPush);
   }
 
   public static StackFragment prepare(

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/StackFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/StackFragment.java
@@ -16,8 +16,10 @@
 package net.consensys.linea.zktracer.module.hub.fragment;
 
 import static com.google.common.base.Preconditions.*;
+import static com.google.common.primitives.Ints.min;
 import static net.consensys.linea.zktracer.module.hub.signals.TracedException.*;
 import static net.consensys.linea.zktracer.opcode.InstructionFamily.*;
+import static net.consensys.linea.zktracer.types.Utils.rightPadTo;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -44,6 +46,8 @@ import net.consensys.linea.zktracer.types.EWord;
 import net.consensys.linea.zktracer.types.UnsignedByte;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.evm.Code;
+import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.internal.Words;
 
 @Accessors(fluent = true)
@@ -61,6 +65,7 @@ public final class StackFragment implements TraceFragment {
   @Setter private boolean validJumpDestination;
   private final State.TxState.Stamps stamps;
   private final CommonFragmentValues commonFragmentValues;
+  private final EWord pushValue;
 
   private StackFragment(
       final Hub hub,
@@ -138,6 +143,24 @@ public final class StackFragment implements TraceFragment {
 
     this.stamps = hub.state().stamps();
     this.commonFragmentValues = commonFragmentValues;
+    this.pushValue = opCode.isPush() ? EWord.of(getPushValue(hub)) : EWord.ZERO;
+  }
+
+  private Bytes getPushValue(Hub hub) {
+    checkState(hub.opCode().isPush());
+
+    final int pc = hub.messageFrame().getPC();
+    if (pc + 1 >= hub.messageFrame().getCode().getSize()) {
+      return Bytes.EMPTY;
+    }
+
+    Bytes byteCode = hub.messageFrame().getCode().getBytes();
+    int nBytesToPush = (opCode.byteValue() & 0xff) - (OpCode.PUSH1.byteValue() & 0xff) + 1;
+    int nLeftoverBytes = byteCode.size() - (pc + 1);
+    Bytes partialPushValue = byteCode.slice(pc + 1, min(nLeftoverBytes, nBytesToPush));
+    return (nLeftoverBytes >= nBytesToPush)
+            ? partialPushValue
+            : rightPadTo(partialPushValue, nBytesToPush);
   }
 
   public static StackFragment prepare(
@@ -195,15 +218,11 @@ public final class StackFragment implements TraceFragment {
             trace::pStackStackItemStamp3,
             trace::pStackStackItemStamp4);
 
-    EWord pushValue = EWord.ZERO;
     var it = stackOps.listIterator();
     while (it.hasNext()) {
       var i = it.nextIndex();
       var op = it.next();
-      final EWord eValue = EWord.of(op.value());
-      if (stack.getCurrentOpcodeData().isPush()) {
-        pushValue = eValue;
-      }
+      final EWord eValue = (i == 3 && opCode().isPush()) ? pushValue : EWord.of(op.value());
 
       heightTracers.get(i).apply(op.height());
       valHiTracers.get(i).apply(eValue.hi());


### PR DESCRIPTION
Ugly hack. Can be optimized to
- use `getPushValue` if and only if there is an exception
- use the old approach if there is no exception