### PR TITLE
`EXTCODECOPY` requires the `CFI` as its `MMU_SRC_ID` only for addresses not currently under deployment

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/opcode/ExtCodeCopy.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/opcode/ExtCodeCopy.java
@@ -86,7 +86,7 @@ public class ExtCodeCopy extends MmuCall implements PostConflationDefer {
   @Override
   public void resolvePostConflation(Hub hub, WorldView world) {
     try {
-      sourceId(hub.romLex().getCodeFragmentIndexByMetadata(contract));
+      sourceId(contract.underDeployment() ? 0 : hub.romLex().getCodeFragmentIndexByMetadata(contract));
     } catch (Exception ignored) {
       // Can be 0 in case the ext account is empty. In this case, no associated CFI
       sourceId(0);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/opcode/ExtCodeCopy.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/opcode/ExtCodeCopy.java
@@ -86,7 +86,8 @@ public class ExtCodeCopy extends MmuCall implements PostConflationDefer {
   @Override
   public void resolvePostConflation(Hub hub, WorldView world) {
     try {
-      sourceId(contract.underDeployment() ? 0 : hub.romLex().getCodeFragmentIndexByMetadata(contract));
+      sourceId(
+          contract.underDeployment() ? 0 : hub.romLex().getCodeFragmentIndexByMetadata(contract));
     } catch (Exception ignored) {
       // Can be 0 in case the ext account is empty. In this case, no associated CFI
       sourceId(0);


### PR DESCRIPTION
Fix: providing the `CFI` to the `EXTCODECOPY` induced `MMU` instruction _iff_ the target address is not currently under deployment.

This echoes the implementation of `referenceSize()` in the same class.

Implements https://github.com/Consensys/linea-specification/pull/40