### PR TITLE
Fix typo

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -137,7 +137,7 @@ named `corset_output_$BLOCK_NUMBER_$BLOCK_HASH.txt`. After that an error message
 
 Tracer Readiness is a plugin that enables the existence of the `/tracer-readiness` REST endpoint that
 ensures that the given node is able to accept new requests. Under the hood it performs request limiting via an
-option configuring the number of allowed concurrent requests. Additionally in ensures that the your state is in sync.
+option configuring the number of allowed concurrent requests. Additionally, it ensures that your state is in sync.
 
 The plugin supports the following options in the TOML configuration:
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -86,7 +86,7 @@ ______________________________________________________________________
 NOTE
 
 > Please be aware if the reference test code generation tasks `blockchainReferenceTests` and
-> `generalStateReferenceTests` do not generate any java code, than probably you are missing the Ethereum tests
+> `generalStateReferenceTests` do not generate any java code, then probably you are missing the Ethereum tests
 > submodule which you can clone via `git submodule update --init --recursive`.
 
 ______________________________________________________________________


### PR DESCRIPTION
### Correction of punctuation and grammatical error in a sentence.

-option configuring the number of allowed concurrent requests. Additionally in ensures that the your state is in sync.
+option configuring the number of allowed concurrent requests. Additionally, it ensures that your state is in sync.

**Explanation:**
-The phrase "Additionally in ensures" was incorrect due to a missing comma and wrong word usage ("in" should be removed).
-"in" was replaced by a comma to properly separate the clauses and make the sentence grammatically correct.
-"the your state" is incorrect. The correct phrasing should be "your state", removing the unnecessary "the" before "your". This makes the sentence more fluent and accurate.

### Correction of a grammatical mistake regarding the word "than" in the following sentence.

-generalStateReferenceTests do not generate any java code, than probably you are missing the Ethereum tests
-generalStateReferenceTests do not generate any java code, then probably you are missing the Ethereum tests

**Explanation:**

-The word "than" was incorrectly used in place of "then". In this context, "then" is the correct word to indicate a sequence or result, i.e., "probably you are missing the Ethereum tests as a consequence."
-"Than" is used for comparisons, and using it in this context would be grammatically incorrect and confusing.