### PR TITLE
Feat/blockdata gas limit name refacto

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/BlockdataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/BlockdataOperation.java
@@ -172,10 +172,10 @@ public class BlockdataOperation extends ModuleOperation {
     data = EWord.of(blockHeader.getGasLimit());
 
     // row i
-    wcpCallToGEQ(0, data, EWord.of(LINEA_GAS_LIMIT_MINIMUM));
+    wcpCallToGEQ(0, data, EWord.of(GAS_LIMIT_MINIMUM));
 
     // row i + 1
-    wcpCallToLEQ(1, data, EWord.of(Bytes.ofUnsignedLong(LINEA_GAS_LIMIT_MAXIMUM)));
+    wcpCallToLEQ(1, data, EWord.of(Bytes.ofUnsignedLong(GAS_LIMIT_MAXIMUM)));
 
     if (!firstBlockInConflation) {
       EWord prevGasLimit = EWord.of(prevBlockHeader.getGasLimit());

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/Trace.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/Trace.java
@@ -31,6 +31,8 @@ import org.apache.tuweni.bytes.Bytes;
  * Please DO NOT ATTEMPT TO MODIFY this code directly.
  */
 public class Trace {
+  public static final int GAS_LIMIT_MAXIMUM = 0x77359400;
+  public static final int GAS_LIMIT_MINIMUM = 0x3a2c940;
   public static final int nROWS_BF = 0x1;
   public static final int nROWS_CB = 0x1;
   public static final int nROWS_DEPTH = 0xd;

--- a/buildSrc/src/main/groovy/TraceFilesTask.groovy
+++ b/buildSrc/src/main/groovy/TraceFilesTask.groovy
@@ -24,7 +24,7 @@ abstract class TraceFilesTask extends Exec {
   protected void exec() {
     def arguments = ["besu",
                      "-P", "${moduleDir.getOrElse(module.get()).replaceAll('/','.')}",
-                     "-o", "${project.projectDir}/src/main/java/net/consensys/linea/zktracer/module/${moduleDir.getOrElse(module.get())}"
+                     "-o", "${project.rootDir}/arithmetization/src/main/java/net/consensys/linea/zktracer/module/${moduleDir.getOrElse(module.get())}"
     ]
     if(project.hasProperty("className")) {
       arguments.add("-c")

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -21,7 +21,6 @@ jacoco {
 }
 
 apply plugin: 'com.adarshr.test-logger'
-
 /*
   * Pass some system properties provided on the gradle command line to test executions for
   * convenience.
@@ -133,6 +132,9 @@ tasks.test.configure {
 }
 
 tasks.register("fastReplayTests", Test) {
+
+  dependsOn blockdataLinea
+
   if (System.getenv().containsKey("REPLAY_TESTS_PARALLELISM")) {
     systemProperty("junit.jupiter.execution.parallel.enabled", true)
     systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")

--- a/gradle/trace-files.gradle
+++ b/gradle/trace-files.gradle
@@ -35,6 +35,23 @@ tasks.register("hub", TraceFilesTask) {
 }
 
 //
+// Special case: blockdata - trace file differ between Ethereum and Linea for gas limit purposes
+//
+tasks.register("blockdataEthereum", TraceFilesTask) {
+    group "Trace files generation"
+    dependsOn corsetExists
+    module = 'blockdata'
+    files = ['blockdata/constants.lisp', 'blockdata/columns.lisp', 'blockdata/constants-ethereum.lisp']
+}
+
+tasks.register("blockdataLinea", TraceFilesTask) {
+    group "Trace files generation"
+    dependsOn corsetExists
+    module = 'blockdata'
+    files = ['blockdata/constants.lisp', 'blockdata/columns.lisp', 'blockdata/constants-linea.lisp']
+}
+
+//
 // Reference table
 //
 tasks.register('instdecoder', TraceFilesTask) {
@@ -75,7 +92,7 @@ tasks.register('binreftable', TraceFilesTask) {
 //
 // Put here modules following the conventional MODULE/columns.lisp, MODULE/constants.lisp naming scheme.
 //
-['mmu', 'blake2fmodexpdata', 'blockdata', 'oob', 'exp', 'rlptxrcpt', 'rlpaddr', 'shakiradata', 'mxp', 'ecdata'].each {moduleName ->
+['mmu', 'blake2fmodexpdata', 'oob', 'exp', 'rlptxrcpt', 'rlpaddr', 'shakiradata', 'mxp', 'ecdata'].each {moduleName ->
     tasks.register(moduleName, TraceFilesTask) {
         group "Trace files generation"
         dependsOn corsetExists

--- a/reference-tests/build.gradle
+++ b/reference-tests/build.gradle
@@ -23,6 +23,7 @@ apply from: rootProject.file("gradle/tests.gradle")
 apply from: rootProject.file("gradle/dependency-management.gradle")
 apply from: rootProject.file('gradle/common-dependencies.gradle')
 apply from: rootProject.file("gradle/lint.gradle")
+apply from: rootProject.file("gradle/trace-files.gradle")
 
 configurations.configureEach {
   exclude module: 'log4j-api'
@@ -56,6 +57,7 @@ tasks.register("generateGeneralStateReferenceTests", RefTestGenerationTask) {
 
 tasks.register('referenceBlockchainTests', Test) {
   description = 'Runs ETH reference blockchain tests.'
+  dependsOn blockdataEthereum
   dependsOn generateBlockchainReferenceTests
   environment.put("REFERENCE_TEST_OUTCOME_OUTPUT_FILE", "BlockchainReferenceTestOutcome.json")
 
@@ -70,6 +72,7 @@ tasks.register('referenceBlockchainTests', Test) {
 
 tasks.register('referenceGeneralStateTests', Test) {
   description = 'Runs ETH reference general state tests.'
+  dependsOn blockdataEthereum
   dependsOn generateGeneralStateReferenceTests
 
   environment.put("REFERENCE_TEST_OUTCOME_OUTPUT_FILE", "GeneralStateReferenceTestOutcome.json")


### PR DESCRIPTION
Regenerate trace files on tests launch to dynamically account for a different Min and Max gas limit between Ethereum and Linea

Paired with `BLOCKHASH-redesign` /linea-constraints branch

TBC
With Ethereum Gas limits
- StateRefTests
- BlockchainRefTests

With Linea Gas limits
- fastReplayTests
