### PR TITLE
CHANGED - use github actions concurrency to reduce outdated runs

### DIFF
--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 23 * * 1-5"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   ethereum-tests:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl

--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 22 * * 1-5"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   nightly-tests:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl

--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -13,6 +13,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ==================================================================
   # Build

--- a/.github/workflows/gradle-weekly-tests.yml
+++ b/.github/workflows/gradle-weekly-tests.yml
@@ -5,6 +5,11 @@ on:
     - cron: "0 4 * * 1"
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   tests:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -23,6 +23,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   blockchain-reference-tests:
     runs-on: [ubuntu-latest-128]


### PR DESCRIPTION
Following best practice 
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs

for example if someone commits to a branch 3 times, 3 actions are run. This would cancel previous actions that are now stale. Saving Time and Money :)