### PR TITLE
fix: support default filter for cron job

### DIFF
--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -68,7 +68,7 @@ jobs:
         run: mv ${{ github.workspace }}/tmp/${{ steps.extract_branch.outputs.branch }}/failedBlockchainReferenceTests.json ${{ github.workspace }}/tmp/${{ steps.extract_branch.outputs.branch }}/failedBlockchainReferenceTests-input.json
 
       - name: Run reference blockchain tests
-        run: GOMEMLIMIT=32GiB ./gradlew referenceBlockchainTests -x spotlessCheck --tests "${{ inputs.test_filter }}"
+        run: GOMEMLIMIT=32GiB ./gradlew referenceBlockchainTests -x spotlessCheck --tests "${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}"
         timeout-minutes: 360
         env:
           REFERENCE_TESTS_PARALLELISM: 2


### PR DESCRIPTION
This corrects a typo related to the `test_filter` input parameter when scheduled via the `cron` job.  Specifically, in that case, the provided default value `BlockchainReferenceTest_*` is not used (surprisingly).  Therefore, instead, a default value is forced using the `||` operator at the point of use.