### PR TITLE
feat: update `release` action to install `corset`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,10 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
         with:
-          java-version: 21
-          distribution: temurin
-          cache: 'gradle'
+          rust-corset: true
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
This updates the release action so that it installs `corset`.  This is required now, since we use `corset` to rebuild the `Trace.java` files from scratch.