### PR TITLE
fix location of distribution for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./arithmetization/build/libs/linea-tracer-${{ steps.get_version.outputs.VERSION }}.jar
+          asset_path: ./plugins/build/libs/linea-tracer-${{ steps.get_version.outputs.VERSION }}.jar
           asset_name: linea-tracer-${{ steps.get_version.outputs.VERSION }}.jar
           asset_content_type: application/octet-stream
 
@@ -63,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./arithmetization/build/distributions/linea-tracer-${{ steps.get_version.outputs.VERSION }}.zip
+          asset_path: ./plugins/build/distributions/linea-tracer-${{ steps.get_version.outputs.VERSION }}.zip
           asset_name: linea-tracer-${{ steps.get_version.outputs.VERSION }}.zip
           asset_content_type: application/octet-stream
 


### PR DESCRIPTION
This fixes the location of the distribution for the release workflow. Specifically, since the plugins have been pulled out of arithmetization, the location has changed to be within the plugins/ directory.