### PR TITLE
fix: tweak publish task

### DIFF
--- a/arithmetization/build.gradle
+++ b/arithmetization/build.gradle
@@ -73,5 +73,3 @@ jar {
     )
   }
 }
-
-apply from: rootProject.file("gradle/publishing.gradle")


### PR DESCRIPTION
This tweaks the publish task so that it doesn't include the arithmetization project.  This is because the plugins/ project is where all the publishing action happens now.