### PR TITLE
Improve the copy local Besu distribution archive when the download fails

### DIFF
--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -23,6 +23,7 @@ jobs:
   # ==================================================================
   build:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    continue-on-error: true
     steps:
 
       - name: Checkout repository
@@ -39,9 +40,12 @@ jobs:
         uses: egor-tensin/setup-gcc@v1
 
       - name: Build without tests
-        run: ./gradlew build -x test -x spotlessCheck
+        run: ./gradlew build --info -x test -x spotlessCheck
         env:
           JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false
+
+      - name: Debug forlder
+        run: ls -lR plugins/build
 
       - name: Store distribution artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -23,7 +23,6 @@ jobs:
   # ==================================================================
   build:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
-    continue-on-error: true
     steps:
 
       - name: Checkout repository
@@ -40,12 +39,9 @@ jobs:
         uses: egor-tensin/setup-gcc@v1
 
       - name: Build without tests
-        run: ./gradlew build --info -x test -x spotlessCheck
+        run: ./gradlew build -x test -x spotlessCheck
         env:
           JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false
-
-      - name: Debug forlder
-        run: ls -lR plugins/build
 
       - name: Store distribution artifacts
         uses: actions/upload-artifact@v4

--- a/gradle/dist.gradle
+++ b/gradle/dist.gradle
@@ -15,35 +15,38 @@
 import de.undercouch.gradle.tasks.download.Download
 
 def lineaBesuDistTar = new File(new File(buildDir, "downloads"), rootProject.besuFilename)
-tasks.register('downloadLineaBesu', Download) {
-  src rootProject.besuUrl
-  dest lineaBesuDistTar
-  onlyIfModified true
-}
+task downloadLineaBesu {
+  doLast {
+    try {
+      download.run {
+        src rootProject.besuUrl
+        dest lineaBesuDistTar
+        onlyIfModified true
+      }
+    } catch (Exception e) {
+      def localLineaBesuDir =
+              project.hasProperty('useLocalLineaBesuDir')
+                      ? file("${findProperty('useLocalLineaBesuDir')}".replaceFirst('^~', System.getProperty('user.home')))
+                      : new File(projectDir, "../../linea-besu")
 
-tasks.register('copyLocalLineaBesu', Copy) {
-  onlyIf {
-    downloadLineaBesu.state.failure
-  }
-  def localLineaBesuDir =
-          project.hasProperty('useLocalLineaBesuDir')
-                  ? file("${findProperty('useLocalLineaBesuDir')}".replaceFirst('^~', System.getProperty('user.home')))
-                  : new File(projectDir, "../../linea-besu")
+      def localLineaBesuFile = new File("${localLineaBesuDir.canonicalPath}/build/distributions/${rootProject.besuFilename}")
 
-  def localLineaBesuFile = new File("${localLineaBesuDir.absoluteFile}/build/distributions/${rootProject.besuFilename}")
-  doFirst {
-    if (!file(localLineaBesuFile).exists()) {
-      throw new GradleException("Could not download Linea Besu distribution from: " + rootProject.besuUrl +
-              ", and could not find it locally at ${localLineaBesuFile} either")
+      logger.warn("Could not download " + rootProject.besuUrl + " trying local copy from " + localLineaBesuFile + " as fallback")
+      if (!file(localLineaBesuFile).exists()) {
+        throw new GradleException("Could not download Linea Besu distribution from: " + rootProject.besuUrl +
+                ", and could not find it locally at ${localLineaBesuFile} either")
+      }
+
+      copy {
+        from localLineaBesuFile
+        into lineaBesuDistTar.parentFile
+      }
     }
   }
-  from localLineaBesuFile
-  into lineaBesuDistTar.parentFile
 }
 
 task unTarLineaBesu(type: Copy) {
   dependsOn downloadLineaBesu
-  dependsOn copyLocalLineaBesu
 
   from tarTree(lineaBesuDistTar)
   into lineaBesuDistTar.parentFile

--- a/gradle/dist.gradle
+++ b/gradle/dist.gradle
@@ -16,6 +16,7 @@ import de.undercouch.gradle.tasks.download.Download
 
 def lineaBesuDistTar = new File(new File(buildDir, "downloads"), rootProject.besuFilename)
 task downloadLineaBesu {
+  outputs.file(lineaBesuDistTar)
   doLast {
     try {
       download.run {


### PR DESCRIPTION
Detect when the download of the Besu distribution archive fails and as fallback try to copy it from the local Besu folder if exists.

fixes #1719 