### PR TITLE
fix: update `go-corset` to latest

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -12,4 +12,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@f89cf145
+      run: go install github.com/consensys/go-corset/cmd/go-corset@77d304f


### PR DESCRIPTION
This updates `go-corset` to its latest commit to ensure a bug fix is incorporated into the CI pipeline for `linea-tracer`.