### PR TITLE
fix: daily blockchain tests

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -12,4 +12,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@77d304f
+      run: go install github.com/consensys/go-corset/cmd/go-corset@fe70003

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -71,7 +71,7 @@ jobs:
           REFERENCE_TESTS_PARALLELISM: 2
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
-          GOCORSET_FLAGS: -vw --ansi-escapes=false --report --air
+          GOCORSET_FLAGS: -b1024 -vw --ansi-escapes=false --report --air
           ZKEVM_BIN: "zkevm_for_reference_tests.go.bin"
           FAILED_TEST_JSON_DIRECTORY: ${{ github.workspace }}/tmp/${{ steps.extract_branch.outputs.branch }}/
           FAILED_MODULE: ${{ inputs.failed_module || '' }}


### PR DESCRIPTION
This fixes the issues running the daily blockchain tests, by doing two things:

1. Updating to the latest version of `go-corset`, which includes some minor optimisations that help reduce cost.
2. Adding a batching parameter for `go-corset` (`-b 1024`) which sets the batch size to max `1024`.  This throttles concurrency to some extent, and reduces memory pressure.

Overall, these changes appear to allow the [daily blockchain tests to pass](https://github.com/Consensys/linea-tracer/actions/runs/12922706274), and hopefully they will consistently pass going forward.