### PR TITLE
fix: Fix issues in binary_search.sh

### DIFF
--- a/scripts/binary_search.sh
+++ b/scripts/binary_search.sh
@@ -25,43 +25,44 @@ binary_search() {
     local end=$2
 
     # If start equals end, we are checking a single block
-    if [ $start -eq $end ]; then
-        echo -e "\nTesting block: $start" | tee -a $logfile
+    if [ "$start" -eq "$end" ]; then
+        echo -e "\nTesting block: $start" | tee -a "$logfile"
     else
-        echo -e "\nTesting range: $start - $end" | tee -a $logfile
+        echo -e "\nTesting range: $start - $end" | tee -a "$logfile"
     fi
 
     # Execute the curl command and capture the output
-    response=$(curl --silent --location --request POST "$url" --header 'Content-Type: application/json' --data-raw '{
-        "jsonrpc": "2.0",
-        "method": "linea_generateConflatedTracesToFileV2",
-        "params": [{"startBlockNumber": '$start',"endBlockNumber": '$end',"expectedTracesEngineVersion": "'$version'"}],
-        "id": 1
-    }')
+    response=$(jq -n --arg start "$start" --arg end "$end" --arg version "$version" \
+        '{jsonrpc: "2.0", method: "linea_generateConflatedTracesToFileV2", params: [{startBlockNumber: ($start|tonumber), endBlockNumber: ($end|tonumber), expectedTracesEngineVersion: $version}], id: 1}' |
+        curl --silent --location --request POST "$url" --header 'Content-Type: application/json' --data @-)
 
     # Log the response
-    echo "$response" | tee -a $logfile
+    echo "$response" | tee -a "$logfile"
 
     # Check if the response indicates a successful range
-    if echo "$response" | grep -q '"result"'; then
-        echo "Range $start - $end is successful, skipping further investigation in this range." | tee -a $logfile
+    if echo "$response" | jq -e '.result == true' >/dev/null 2>&1; then
+        echo "Range $start - $end is successful, skipping further investigation in this range." | tee -a "$logfile"
         return
     fi
 
     # If it's a single block, return after the check
-    if [ $start -eq $end ]; then
+    if [ "$start" -eq "$end" ]; then
         return
     fi
 
     # Calculate the middle block
-    local mid=$(( (start + end) / 2 ))
+    local mid=$(( (start + end + 1) / 2 ))
 
-    # Recursive binary search on the first half
-    binary_search $start $mid
+    # Recursive binary search on the first half (only if range is valid)
+    if [ "$mid" -gt "$start" ]; then
+        binary_search "$start" "$mid"
+    fi
 
-    # Recursive binary search on the second half
-    binary_search $((mid + 1)) $end
+    # Recursive binary search on the second half (only if range is valid)
+    if [ "$mid" -lt "$end" ]; then
+        binary_search "$((mid + 1))" "$end"
+    fi
 }
 
 # Start the binary search with the provided arguments
-binary_search $startBlock $endBlock
+binary_search "$startBlock" "$endBlock"


### PR DESCRIPTION
This update improves the JSON generation process by using `jq`, ensuring proper handling of quotes and spaces.

I've also fixed the issue with `mid` rounding, where it now correctly rounds up, preventing infinite recursion.

Additionally, checks have been added before recursion to ensure that we don't repeatedly call the same range:  
`if [ "$mid" -gt "$start" ]` and `if [ "$mid" -lt "$end" ]`.

This should prevent unnecessary loops and improve performance.