### PR TITLE
chore: update `go-corset` to `301d5c4`

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -12,4 +12,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@e5e0938
+      run: go install github.com/consensys/go-corset/cmd/go-corset@301d5c4

--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
-          GOCORSET_FLAGS: -vw --ansi-escapes=false --report --hir
+          GOCORSET_FLAGS: -vw --ansi-escapes=false --report --mir
           ZKEVM_BIN: "zkevm.go.bin"
           NIGHTLY_TESTS_PARALLELISM: 2
 


### PR DESCRIPTION
This updates `go-corset` as it include some performance improvements which might be beneficial for the CI testing pipeline.