### PR TITLE
chore: update `go-corset` to latest commit

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -12,4 +12,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@latest
+      run: go install github.com/consensys/go-corset/cmd/go-corset@75a88c5


### PR DESCRIPTION
This updates `go-corset` to `75a88c5` as this contains some performance optimisations of interest.  Specifically, simplification of inverse columns.