### PR TITLE
chore: increase parallelism to unit/replay tests

### DIFF
--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -77,7 +77,7 @@ jobs:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -b1024 -vw --ansi-escapes=false --report --air
-          UNIT_TESTS_PARALLELISM: 1
+          UNIT_TESTS_PARALLELISM: 4
 
       - name: Upload test report
         if: ${{ always() }}
@@ -109,6 +109,7 @@ jobs:
         run: GOMEMLIMIT=26GiB ./gradlew :arithmetization:fastReplayTests
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
+          REPLAY_TESTS_PARALLELISM: 4
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -b1024 -vw --ansi-escapes=false --report --air
 

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -68,7 +68,7 @@ jobs:
         run: GOMEMLIMIT=32GiB ./gradlew -Dblockchain=Ethereum referenceBlockchainTests -x spotlessCheck --tests "${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}"
         timeout-minutes: 360
         env:
-          REFERENCE_TESTS_PARALLELISM: 2
+          REFERENCE_TESTS_PARALLELISM: 4
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -b1024 -vw --ansi-escapes=false --report --air


### PR DESCRIPTION
This increases the use of parallelism in the unit / replay tests to reduce the time taken to complete in the CI pipeline.