### PR TITLE
chore: update weekly and nightly tests

### DIFF
--- a/.github/workflows/gradle-weekly-tests.yml
+++ b/.github/workflows/gradle-weekly-tests.yml
@@ -11,43 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - name: Setup Test Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          rust-corset: true
-
-      - name: Run Weekly tests
-        run: ./gradlew weeklyTests
-        env:
-          JAVA_OPTS: -Dorg.gradle.daemon=false
-          CORSET_FLAGS: fields,expand,expand,expand
-          WEEKLY_TESTS_PARALLELISM: 4
-
-      - name: Upload test report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: nightly-tests-report
-          path: build/reports/tests/**/*
-
-      - name: Failure Notification
-        if: ${{ failure() || cancelled() }}
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: webhook-trigger
-          payload: |
-             name: "Weekly (Go-Corset)"
-             status: "${{ job.status }}"
-
   weekly-tests:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     continue-on-error: true
@@ -66,6 +29,7 @@ jobs:
         run: GOMEMLIMIT=96GiB ./gradlew weeklyTests
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
+          WEEKLY_TESTS_PARALLELISM: 4
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -vw -b1024 --ansi-escapes=false --report --air
 

--- a/arithmetization/src/test/java/net/consensys/linea/replaytests/Issue1124Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/replaytests/Issue1124Tests.java
@@ -18,7 +18,6 @@ import static net.consensys.linea.replaytests.ReplayTestTools.replay;
 import static net.consensys.linea.testing.ReplayExecutionEnvironment.LINEA_MAINNET;
 
 import net.consensys.linea.UnitTestWatcher;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /** STP constraints were failing for these ranges */
 @Tag("replay")
 @Tag("nightly")
-@Disabled
 @ExtendWith(UnitTestWatcher.class)
 public class Issue1124Tests {
 

--- a/arithmetization/src/test/java/net/consensys/linea/replaytests/Issue1126Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/replaytests/Issue1126Tests.java
@@ -18,7 +18,6 @@ import static net.consensys.linea.replaytests.ReplayTestTools.replay;
 import static net.consensys.linea.testing.ReplayExecutionEnvironment.LINEA_MAINNET;
 
 import net.consensys.linea.UnitTestWatcher;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +38,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>See https://github.com/Consensys/linea-tracer/issues/1121
  */
 @Tag("nightly")
-@Disabled
 @ExtendWith(UnitTestWatcher.class)
 public class Issue1126Tests {
   @Test

--- a/arithmetization/src/test/java/net/consensys/linea/replaytests/Issue1126Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/replaytests/Issue1126Tests.java
@@ -18,6 +18,7 @@ import static net.consensys.linea.replaytests.ReplayTestTools.replay;
 import static net.consensys.linea.testing.ReplayExecutionEnvironment.LINEA_MAINNET;
 
 import net.consensys.linea.UnitTestWatcher;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,107 +42,114 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(UnitTestWatcher.class)
 public class Issue1126Tests {
   @Test
-  void issue_1126_3108622_3108633() {
+  void issue_1126_3108622_3108633() { // 11 blocks
     replay(LINEA_MAINNET, "3108622-3108633.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_3175608_3175636() {
+  void issue_1126_3175608_3175636() { // 28 blocks
     replay(LINEA_MAINNET, "3175608-3175636.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_3432730_3432768() {
+  void issue_1126_3432730_3432768() { // 38 blocks
     replay(LINEA_MAINNET, "3432730-3432768.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_4392225_4392280() {
+  @Disabled
+  void issue_1126_4392225_4392280() { // 55 blocks
     replay(LINEA_MAINNET, "4392225-4392280.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_4477086_4477226() {
+  @Disabled
+  void issue_1126_4477086_4477226() { // 140 blocks
     replay(LINEA_MAINNET, "4477086-4477226.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_3290673_3290679() {
+  void issue_1126_3290673_3290679() { // 6 blocks
     replay(LINEA_MAINNET, "3290673-3290679.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_3290746_3290752() {
+  void issue_1126_3290746_3290752() { // 6 blocks
     replay(LINEA_MAINNET, "3290746-3290752.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_3315684_3315690() {
+  void issue_1126_3315684_3315690() { // 6 blocks
     replay(LINEA_MAINNET, "3315684-3315690.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_3374278_3374284() {
+  void issue_1126_3374278_3374284() { // 6 blocks
     replay(LINEA_MAINNET, "3374278-3374284.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_3385404_3385411() {
+  void issue_1126_3385404_3385411() { // 7 blocks
     replay(LINEA_MAINNET, "3385404-3385411.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_3410170_3410240() {
+  @Disabled
+  void issue_1126_3410170_3410240() { // 70 blocks
     replay(LINEA_MAINNET, "3410170-3410240.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_3423488_3423521() {
+  void issue_1126_3423488_3423521() { // 33 blocks
     replay(LINEA_MAINNET, "3423488-3423521.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_3424829_3424864() {
+  void issue_1126_3424829_3424864() { // 35 blocks
     replay(LINEA_MAINNET, "3424829-3424864.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_3429701_3429735() {
+  void issue_1126_3429701_3429735() { // 34 blocks
     replay(LINEA_MAINNET, "3429701-3429735.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_3431193_3431232() {
+  void issue_1126_3431193_3431232() { // 39 blocks
     replay(LINEA_MAINNET, "3431193-3431232.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_3431567_3431601() {
+  void issue_1126_3431567_3431601() { // 34 blocks
     replay(LINEA_MAINNET, "3431567-3431601.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_4323962_4324012() {
+  @Disabled
+  void issue_1126_4323962_4324012() { // 50 blocks
     replay(LINEA_MAINNET, "4323962-4324012.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_4343434_4343473() {
+  void issue_1126_4343434_4343473() { // 39 blocks
     replay(LINEA_MAINNET, "4343434-4343473.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_4519246_4519309() {
+  @Disabled
+  void issue_1126_4519246_4519309() { // 63 blocks
     replay(LINEA_MAINNET, "4519246-4519309.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_4556007_4556115() {
+  @Disabled
+  void issue_1126_4556007_4556115() { // 108 blocks
     replay(LINEA_MAINNET, "4556007-4556115.mainnet.json.gz");
   }
 
   @Test
-  void issue_1126_4583379_4583463() {
+  @Disabled
+  void issue_1126_4583379_4583463() { // 84 blocks
     replay(LINEA_MAINNET, "4583379-4583463.mainnet.json.gz");
   }
 }


### PR DESCRIPTION
This updates the weekly tests by removing the workflow using the original Rust corset tool (since this is now incompatible with the latest set of constraitns).  This also updates the nightly tests by enabling some long-running tests which were previously disabled. Various performance improvements over the last few weeks should mean that these tests can run again in reasonable time.