### PR TITLE
hotfix: temp dependency conflict

### DIFF
--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -32,6 +32,14 @@ repositories {
 
 apply plugin: 'io.spring.dependency-management'
 
+
+dependencies {
+  constraints {
+    // Temporarily locking in to avoid https://github.com/netplex/json-smart-v2/issues/240
+    api 'net.minidev:json-smart:2.4.2'
+  }
+}
+
 dependencyManagement {
   applyMavenExclusions = false
   generatedPomCustomization {


### PR DESCRIPTION
Hotfix for gradle compile issue by locking in json-smart version 

Inspired by hotfix on Besu https://github.com/hyperledger/besu/pull/8282

To revert when issue is closed https://github.com/netplex/json-smart-v2/issues/240