### PR TITLE
`MODEXP_lead_log` OOB instruction tracing type error fix

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/ModexpLeadOobCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/ModexpLeadOobCall.java
@@ -52,9 +52,9 @@ public class ModexpLeadOobCall extends OobCall {
         .data3(bigIntegerToBytes(ebs))
         .data4(booleanToBytes(loadLead))
         .data5(ZERO)
-        .data6(Bytes.of(cdsCutoff))
-        .data7(Bytes.of(ebsCutoff))
-        .data8(Bytes.of(subEbs32))
+        .data6(Bytes.ofUnsignedInt(cdsCutoff))
+        .data7(Bytes.ofUnsignedInt(ebsCutoff))
+        .data8(Bytes.ofUnsignedInt(subEbs32))
         .data9(ZERO);
   }
 
@@ -68,9 +68,9 @@ public class ModexpLeadOobCall extends OobCall {
         .pMiscOobData3(bigIntegerToBytes(ebs))
         .pMiscOobData4(booleanToBytes(loadLead))
         .pMiscOobData5(ZERO)
-        .pMiscOobData6(Bytes.of(cdsCutoff))
-        .pMiscOobData7(Bytes.of(ebsCutoff))
-        .pMiscOobData8(Bytes.of(subEbs32))
+        .pMiscOobData6(Bytes.ofUnsignedInt(cdsCutoff))
+        .pMiscOobData7(Bytes.ofUnsignedInt(ebsCutoff))
+        .pMiscOobData8(Bytes.ofUnsignedInt(subEbs32))
         .pMiscOobData9(ZERO);
   }
 }


### PR DESCRIPTION
This fix was originally done on a PRC testing branch. Extracted for the upcoming release.