### PR TITLE
chore: update `go-corset` to commit ab7f2d5

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -12,4 +12,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@75a88c5
+      run: go install github.com/consensys/go-corset/cmd/go-corset@ab7f2d5


### PR DESCRIPTION
This updates `go-corset` to the latest commit for testing.