### PR TITLE
Improve MMIO line counting performance

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Mmio.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Mmio.java
@@ -141,7 +141,7 @@ public class Mmio implements Module {
     final boolean isRamToRamTwoTarget = (mmioData.instruction() == MMIO_INST_RAM_TO_RAM_TWO_TARGET);
     final boolean isRamVanishes = (mmioData.instruction() == MMIO_INST_RAM_VANISHES);
     int mmioLineCountingInstruction = lineCountOfMmioInstruction(mmioData.instruction());
-    for (short ct = 0; ct < mmioLineCountingInstruction ; ct++) {
+    for (short ct = 0; ct < mmioLineCountingInstruction; ct++) {
       trace
           .cnA(Bytes.minimalBytes(mmioData.cnA()))
           .cnB(Bytes.minimalBytes(mmioData.cnB()))

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Mmio.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Mmio.java
@@ -140,8 +140,8 @@ public class Mmio implements Module {
     final boolean isRamToRamTwoSource = (mmioData.instruction() == MMIO_INST_RAM_TO_RAM_TWO_SOURCE);
     final boolean isRamToRamTwoTarget = (mmioData.instruction() == MMIO_INST_RAM_TO_RAM_TWO_TARGET);
     final boolean isRamVanishes = (mmioData.instruction() == MMIO_INST_RAM_VANISHES);
-
-    for (short ct = 0; ct < lineCountOfMmioInstruction(mmioData.instruction()); ct++) {
+    int mmioLineCountingInstruction = lineCountOfMmioInstruction(mmioData.instruction());
+    for (short ct = 0; ct < mmioLineCountingInstruction ; ct++) {
       trace
           .cnA(Bytes.minimalBytes(mmioData.cnA()))
           .cnB(Bytes.minimalBytes(mmioData.cnB()))

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioData.java
@@ -164,8 +164,12 @@ public class MmioData {
   }
 
   public static boolean isFastOperation(final int mmioInstruction) {
-      return (mmioInstruction == MMIO_INST_LIMB_VANISHES || mmioInstruction == MMIO_INST_LIMB_TO_RAM_TRANSPLANT || mmioInstruction == MMIO_INST_RAM_TO_LIMB_TRANSPLANT ||  mmioInstruction == MMIO_INST_RAM_TO_RAM_TRANSPLANT ||  mmioInstruction == MMIO_INST_RAM_VANISHES);
-    }
+    return (mmioInstruction == MMIO_INST_LIMB_VANISHES
+        || mmioInstruction == MMIO_INST_LIMB_TO_RAM_TRANSPLANT
+        || mmioInstruction == MMIO_INST_RAM_TO_LIMB_TRANSPLANT
+        || mmioInstruction == MMIO_INST_RAM_TO_RAM_TRANSPLANT
+        || mmioInstruction == MMIO_INST_RAM_VANISHES);
+  }
 
   public static int lineCountOfMmioInstruction(final int mmioInstruction) {
     return isFastOperation(mmioInstruction) ? 1 : LLARGE;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/MmioData.java
@@ -164,14 +164,8 @@ public class MmioData {
   }
 
   public static boolean isFastOperation(final int mmioInstruction) {
-    return List.of(
-            MMIO_INST_LIMB_VANISHES,
-            MMIO_INST_LIMB_TO_RAM_TRANSPLANT,
-            MMIO_INST_RAM_TO_LIMB_TRANSPLANT,
-            MMIO_INST_RAM_TO_RAM_TRANSPLANT,
-            MMIO_INST_RAM_VANISHES)
-        .contains(mmioInstruction);
-  }
+      return (mmioInstruction == MMIO_INST_LIMB_VANISHES || mmioInstruction == MMIO_INST_LIMB_TO_RAM_TRANSPLANT || mmioInstruction == MMIO_INST_RAM_TO_LIMB_TRANSPLANT ||  mmioInstruction == MMIO_INST_RAM_TO_RAM_TRANSPLANT ||  mmioInstruction == MMIO_INST_RAM_VANISHES);
+    }
 
   public static int lineCountOfMmioInstruction(final int mmioInstruction) {
     return isFastOperation(mmioInstruction) ? 1 : LLARGE;


### PR DESCRIPTION
CPU profiling on ERC20 and ERC721 transactions during performance load testing showed that `isFastOperation` method in `MmioData` class, takes up to 25% of the block selection time.

**ERC20 transactions**

<img width="1379" alt="image" src="https://github.com/user-attachments/assets/25ffb57f-6114-4459-9587-589f175fc0cb" />


**ERC721 transactions**

<img width="1379" alt="image" src="https://github.com/user-attachments/assets/5620ce48-5948-4671-89e0-a24a8b1a3257" />

