### PR TITLE
Feat/jacoco reporting on all tests

### DIFF
--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   ethereum-tests:
-    runs-on: [ubuntu-latest-128]
+    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -31,6 +31,7 @@ jobs:
       - name: Run General State Reference Tests
         run: GOMEMLIMIT=64GiB ./gradlew -Dblockchain=Ethereum referenceGeneralStateTests
         env:
+          REFERENCE_TESTS_PARALLELISM: 2
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -vw -b1024 --ansi-escapes=false --report --air
@@ -43,6 +44,20 @@ jobs:
           path: |
             reference-tests/build/reports/tests/**/*
             tmp/local/*
+
+      - name: Upload jacoco state tests coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-state-tests-coverage-report
+          path: reference-tests/build/reports/jacoco/jacocoReferenceGeneralStateTestsReport/**/*
+
+      - name: Upload jacoco state tests exec file
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-state-tests-exec-file
+          path: reference-tests/build/jacoco/referenceGeneralStateTests.exec
 
       - name: Failure Notification
         if: ${{ failure() || cancelled() }}

--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   ethereum-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: [ubuntu-latest-128]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -39,6 +39,20 @@ jobs:
           name: nightly-tests-report
           path: build/reports/tests/**/*
 
+      - name: Upload jacoco nightly tests coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-nightly-tests-coverage-report
+          path: arithmetization/build/reports/jacoco/jacocoNightlyTestsReport/**/*
+
+      - name: Upload jacoco nightly tests exec file
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-nightly-tests-exec-file
+          path: arithmetization/build/jacoco/nightlyTests.exec
+
       - name: Failure Notification
         if: ${{ failure() || cancelled() }}
         uses: slackapi/slack-github-action@v2.0.0

--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -86,14 +86,14 @@ jobs:
           name: unit-tests-report
           path: arithmetization/build/reports/tests/**/*
 
-      - name: Upload jacoco test coverage report
+      - name: Upload jacoco unit tests coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-unit-tests-coverage-report
           path: arithmetization/build/reports/jacoco/test/**/*
 
-      - name: Upload jacoco exec test
+      - name: Upload jacoco unit tests exec file
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -133,3 +133,17 @@ jobs:
         with:
           name: replay-tests-report
           path: arithmetization/build/reports/tests/**/*
+
+      - name: Upload jacoco fast replay tests coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-fast-replay-tests-coverage-report
+          path: arithmetization/build/reports/jacoco/fastReplayTestsReport/**/*
+
+      - name: Upload jacoco fast replay tests exec file
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-fast-replay-tests-exec-file
+          path: arithmetization/build/jacoco/fastReplayTests.exec

--- a/.github/workflows/gradle-weekly-tests.yml
+++ b/.github/workflows/gradle-weekly-tests.yml
@@ -33,6 +33,20 @@ jobs:
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -vw -b1024 --ansi-escapes=false --report --air
 
+      - name: Upload jacoco weekly tests coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-weekly-tests-coverage-report
+          path: arithmetization/build/reports/jacoco/jacocoWeeklyTestsReport/**/*
+
+      - name: Upload jacoco weekly tests exec file
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-weekly-tests-exec-file
+          path: arithmetization/build/jacoco/weeklyTests.exec
+
       - name: Failure Notification
         if: ${{ failure() || cancelled() }}
         uses: slackapi/slack-github-action@v2.0.0

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -91,18 +91,18 @@ jobs:
           name: blockchain-refrence-tests-report
           path: reference-tests/build/reports/tests/**/*
 
-      - name: Upload jacoco test coverage report
+      - name: Upload jacoco blockchain tests coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jacoco-reference-tests-coverage-report
+          name: jacoco-blockchain-tests-coverage-report
           path: reference-tests/build/reports/jacoco/jacocoReferenceBlockchainTestsReport/**/*
 
-      - name: Upload jacoco exec test
+      - name: Upload jacoco blockchain tests exec file
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jacoco-reference-tests-exec-file
+          name: jacoco-blockchain-tests-exec-file
           path: reference-tests/build/jacoco/referenceBlockchainTests.exec
 
       - name: Extract Metrics

--- a/SETUP.md
+++ b/SETUP.md
@@ -77,8 +77,8 @@ ______________________________________________________________________
 # Run all EVM test suite reference tests
 ./gradlew clean referenceTests
 
-# Run single reference test via gradle, e.g for net.consensys.linea.generated.blockchain.BlockchainReferenceTest_583
-./gradlew :reference-tests:referenceTests --tests "net.consensys.linea.generated.blockchain.BlockchainReferenceTest_583"
+# Run single reference test via gradle, e.g for net.consensys.linea.generated.blockchain.BlockchainReferenceTest_339
+./gradlew referenceBlockchainTests -Dblockchain=Ethereum --tests "net.consensys.linea.generated.blockchain.BlockchainReferenceTest_339"
 ```
 
 ______________________________________________________________________
@@ -160,10 +160,12 @@ corset check -T <JSON_FILE> -v zkevm-constraints/zkevm.bin
 Plugins are documented [here](PLUGINS.md).
 
 ## Release Process
-Here are the steps for releasing a new version of the plugins:
-  1. Create a tag with the release version number in the format vX.Y.Z (e.g., v0.2.0 creates a release version 0.2.0).
-  2. Push the tag to the repository.
-  3. GitHub Actions will automatically create a draft release for the release tag.
-  4. Once the release workflow completes, update the release notes, uncheck "Draft", and publish the release.
 
-Note: Release tags (of the form v*) are protected and can only be pushed by organization and/or repository owners.
+Here are the steps for releasing a new version of the plugins:
+
+1. Create a tag with the release version number in the format vX.Y.Z (e.g., v0.2.0 creates a release version 0.2.0).
+1. Push the tag to the repository.
+1. GitHub Actions will automatically create a draft release for the release tag.
+1. Once the release workflow completes, update the release notes, uncheck "Draft", and publish the release.
+
+Note: Release tags (of the form v\*) are protected and can only be pushed by organization and/or repository owners.

--- a/build.gradle
+++ b/build.gradle
@@ -22,16 +22,32 @@ sonar {
   if(tests == null || tests=="Unit") {
     print("Executing Sonarqube scanner Unit tests coverage report...\n")
     xmlTestReport = "${project.projectDir}/arithmetization/build/reports/jacoco/test/jacocoTestReport.xml"
-    // If set to Reference, we account only for the Reference tests coverage report
-  } else if(tests == "Reference") {
-    print("Executing Sonarqube scanner for Reference tests coverage report...\n")
+    // If set to FastReplay, we account only for the Nightly tests coverage report
+  } else if(tests == "FastReplay") {
+    print("Executing Sonarqube scanner for FastReplay tests coverage report...\n")
+    xmlTestReport  =  "${project.projectDir}/arithmetization/build/reports/jacoco/jacocoFastReplayTestsReport/jacocoFastReplayTestsReport.xml"
+    // If set to Nightly, we account only for the Nightly tests coverage report
+  } else if(tests == "Nightly") {
+    print("Executing Sonarqube scanner for Nightly tests coverage report...\n")
+    xmlTestReport  =  "${project.projectDir}/arithmetization/build/reports/jacoco/jacocoNightlyTestsReport/jacocoNightlyTestsReport.xml"
+    // If set to Weekly, we account only for the Weekly tests coverage report
+  } else if(tests == "Weekly") {
+    print("Executing Sonarqube scanner for Weekly tests coverage report...\n")
+    xmlTestReport  =  "${project.projectDir}/arithmetization/build/reports/jacoco/jacocoWeeklyTestsReport/jacocoWeeklyTestsReport.xml"
+    // If set to ReferenceBlockchain, we account only for the Reference Blockchain tests coverage report
+  } else if(tests == "ReferenceBlockchain") {
+    print("Executing Sonarqube scanner for Reference Blockchain tests coverage report...\n")
     xmlTestReport  =  "${project.projectDir}/reference-tests/build/reports/jacoco/jacocoReferenceBlockchainTestsReport/jacocoReferenceBlockchainTestsReport.xml"
-  } else if(tests == "Both") {
-    print("Executing Sonarqube scanner for Unit and Reference tests coverage report...\n")
+    // If set to ReferenceState, we account only for the Reference State tests coverage report
+  } else if(tests == "ReferenceState") {
+    print("Executing Sonarqube scanner for Reference State tests coverage report...\n")
+    xmlTestReport  =  "${project.projectDir}/reference-tests/build/reports/jacoco/jacocoReferenceGeneralStateTestsReport/jacocoReferenceGeneralStateTestsReport.xml"
+  } else if(tests == "All") {
+    print("Executing Sonarqube scanner for Unit, FastReplay, Nightly, Weekly, Reference Blockchain and State tests coverage report...\n")
     xmlTestReport  =  "${project.projectDir}/arithmetization/build/reports/jacocoConcatenate/test/jacocoTestReport.xml"
   } else {
     // Force build failure if unknown concatenate value.
-    println("*** unknown tests property.  Try '-Dconcatenate=Unit' or '-Dconcatenate=Reference' or '-Dconcatenate=Both'\n\n")
+    println("*** unknown tests property.  Try '-Dconcatenate=Unit', '-Dconcatenate=FastReplay', '-Dconcatenate=Nightly', '-Dconcatenate=Weekly', '-Dconcatenate=ReferenceBlockchain','-Dconcatenate=ReferenceState' or '-Dconcatenate=All'\n\n")
     assert false
   }
 

--- a/docs/Local-test-coverage.md
+++ b/docs/Local-test-coverage.md
@@ -30,39 +30,59 @@ Sonarqube server needs a third party test coverage report to display a coverage 
 
 To produce a report, you can either
 
-- Run unit or reference tests tasks locally with
+- Run tests tasks locally with
 
 ```
-GOMEMLIMIT=26GiB ./gradlew :arithmetization:test
+GOMEMLIMIT=26GiB ./gradlew test
+GOMEMLIMIT=26GiB ./gradlew fastReplayTests
+GOMEMLIMIT=26GiB ./gradlew nightlyTests
+GOMEMLIMIT=26GiB ./gradlew weeklyTests
 GOMEMLIMIT=26GiB ./gradlew -Dblockchain=Ethereum referenceBlockchainTests
+GOMEMLIMIT=26GiB ./gradlew -Dblockchain=Ethereum referenceGeneralStateTests
 ```
 
 These tasks are finalized by Jacoco test reports
 
-- Or get xml report from the CI pipeline in unit or reference tests actions
+- Or get xml report from the CI pipeline in tests actions
 
 Paste the xml report in the following paths :
 
 - for unit tests
   `/arithmetization/build/reports/jacoco/test/jacocoTestReport.xml`
-- or for reference tests
-  `/reference-tests/build/reports/jacoco/jacocoReferenceBlockchainTestsReport/jacocoReferenceBlockchainTestsReport.xml`
+- for fast replay tests
+  `/arithmetization/build/reports/jacoco/jacocoFastReplayTestsReport/jacocoFastReplayTestsReport.xml`
+- for nightly tests
+  `/arithmetization/build/reports/jacoco/jacocoNightlyTestsReport/jacocoNightlyTestsReport.xml`
+- for weekly tests
+  `/arithmetization/build/reports/jacoco/jacocoWeeklyTestsReport/jacocoWeeklyTestsReport.xml`
+- for reference blockchain tests
+  `/referenceBlockchainTests/build/reports/jacoco/jacocoReferenceBlockchainTestsReport/jacocoReferenceBlockchainTestsReport.xml`
+- for reference state tests
+  `/referenceBlockchainTests/build/reports/jacoco/jacocoReferenceGeneralStateTestsReport/jacocoReferenceGeneralStateTestsReport.xml`
 
-### Concatenate two Jacoco reports
+### Concatenate Jacoco reports
 
-Get jacoco exec files from the CI pipeline in unit and reference tests actions
+Get jacoco exec files from the CI pipeline in the uploaded artifacts tests actions
 
 Paste the exec files in the following paths :
 
 - for unit tests
   `/arithmetization/build/jacoco/test.exec`
-- for reference tests
+- for fast replay tests
+  `/arithmetization/build/jacoco/jacocoFastReplayTests.exec`
+- for nightly tests
+  `/arithmetization/build/jacoco/jacocoNightlyTests.exec`
+- for weekly tests
+  `/arithmetization/build/jacoco/jacocoWeeklyTests.exec`
+- for reference blockchain tests
   `/reference-tests/build/jacoco/referenceBlockchainTests.exec`
+- for reference state tests
+  `/reference-tests/build/jacoco/referenceGeneralStateTests.exec`
 
-Run the jacocoUnitAndReferenceTestsReport task
+Execute and concatenate the results with the `jacocoUnitFastReplayWeeklyNightlyReferenceBlockchainAndStateTestsReport` task
 
 ```
-./gradlew jacocoUnitAndReferenceTestsReport
+./gradlew jacocoUnitFastReplayWeeklyNightlyReferenceBlockchainAndStateTestsReport
 ```
 
 Note: if an xml report already exists, delete it to generate it again, else the task will be marked as Skipped.
@@ -85,17 +105,25 @@ curl -u admin:admin -X POST "http://localhost:80/api/users/change_password?login
 
 Go to `localhost:80` in your browser and login with the credentials `admin/Adminadmin123*`
 
-## Launch Sonar task with gradle
+## Coverage score with Sonarqube
 
-Then run `sonar` gradle task in verification group with the corresponding property depending on the coverage score you want to display
+Launch `sonar` gradle task in verification group with the corresponding property depending on the coverage score you want to display
 
 ```
 ./gradlew sonar -Dtests=Unit
-./gradlew sonar -Dtests=Reference
-./gradlew sonar -Dtests=Both
+./gradlew sonar -Dtests=FastReplay
+./gradlew sonar -Dtests=Nightly
+./gradlew sonar -Dtests=Weekly
+./gradlew sonar -Dtests=ReferenceBlockchain
+./gradlew sonar -Dtests=ReferenceState
+./gradlew sonar -Dtests=All
 ```
 
-Go to `localhost:80/projects` in your browser and check the results
+Go to `localhost:80/projects` in your browser and check the results :
+
+- overall score
+- line coverage (absolute and %)
+- condition coverage (absolute and %)
 
 ## Exit Sonarqube server
 

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -155,6 +155,15 @@ tasks.register("fastReplayTests", Test) {
     excludeTags("nightly")
     excludeTags("weekly")
   }
+  finalizedBy(jacocoFastReplayTestsReport)
+}
+
+tasks.register("jacocoFastReplayTestsReport", JacocoReport) {
+  reports {
+    xml.required = true
+  }
+
+  executionData(fastReplayTests)
 }
 
 tasks.register("nightlyReplayTests", Test) {
@@ -194,6 +203,15 @@ tasks.register("nightlyTests", Test) {
   useJUnitPlatform {
     includeTags("nightly")
   }
+  finalizedBy(jacocoNightlyTestsReport)
+}
+
+tasks.register("jacocoNightlyTestsReport", JacocoReport) {
+  reports {
+    xml.required = true
+  }
+
+  executionData(nightlyTests)
 }
 
 tasks.register("weeklyTests", Test) {
@@ -211,10 +229,19 @@ tasks.register("weeklyTests", Test) {
     excludeTags("replay")
     includeTags("weekly")
   }
+  finalizedBy(jacocoWeeklyTestsReport)
 }
 
-// Gradle task to concatenate Unit and Reference tests exec files
-tasks.register("jacocoUnitAndReferenceTestsReport", JacocoReport) {
+tasks.register("jacocoWeeklyTestsReport", JacocoReport) {
+  reports {
+    xml.required = true
+  }
+
+  executionData(weeklyTests)
+}
+
+// Gradle task to concatenate Unit, FastReplay, Nightly, Weekly and Reference Blockchain and State tests exec files
+tasks.register("jacocoUnitFastReplayWeeklyNightlyReferenceBlockchainAndStateTestsReport", JacocoReport) {
   reports {
     xml.required = true
     html.outputLocation = layout.buildDirectory.dir('reports/jacocoConcatenate/html')

--- a/reference-tests/build.gradle
+++ b/reference-tests/build.gradle
@@ -84,6 +84,7 @@ tasks.register("jacocoReferenceBlockchainTestsReport", JacocoReport) {
 
 tasks.register('referenceGeneralStateTests', Test) {
   dependsOn(buildReferenceTestsZkevmBin)
+  finalizedBy(jacocoReferenceGeneralStateTestsReport)
   description = 'Runs ETH reference general state tests.'
   dependsOn generateGeneralStateReferenceTests
   // Record zkevm.bin for CorsetValidator
@@ -96,6 +97,15 @@ tasks.register('referenceGeneralStateTests', Test) {
   boolean isCiServer = System.getenv().containsKey("CI")
   minHeapSize = "4g"
   maxHeapSize = isCiServer ? "32g" : "8g"
+}
+
+tasks.register("jacocoReferenceGeneralStateTestsReport", JacocoReport) {
+  reports {
+    xml.required = true
+  }
+
+  sourceSets project(":arithmetization").sourceSets.main
+  executionData(referenceGeneralStateTests)
 }
 
 [


### PR DESCRIPTION
For Fast Replay, Nightly, Weekly, and State Ref tests
- add jacoco test report gradle tasks
- update the concatenate jacoco gradle task
- update sonar gradle task
- update doc `Local-test-coverage`
- upload jacoco coverage report and exec files with github workflow