### PR TITLE
release beta-v2.0-rc1: updated `gradle.properties` + `CHANGELOG`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## beta-v2.0-rc1
+* Low gas stipend precompile calls (#1754)
+* Tweak GOMEMLIMIT (#1830)
+* Improve MMIO line counting performance (#1831)
+* constraints commit update
+
 ## beta-v1.3-rc3
 * constraints commit update
 * update `go-corset` to commit ab7f2d5 (#1822)

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/RipemdBlocks.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/RipemdBlocks.java
@@ -26,8 +26,6 @@ import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 @Accessors(fluent = true)
 public final class RipemdBlocks implements CountingOnlyModule {
   private final CountOnlyOperation counts = new CountOnlyOperation();
-  private static final int PRECOMPILE_BASE_GAS_FEE = 600;
-  private static final int PRECOMPILE_GAS_FEE_PER_EWORD = 120;
   private static final int RIPEMD160_BLOCKSIZE = 64 * 8;
   // If the length is > 2⁶4, we just use the lower 64 bits.
   private static final int RIPEMD160_LENGTH_APPEND = 64;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-releaseVersion=beta-v1.3-rc2
+releaseVersion=beta-v2.0-rc1
 besuVersion=25.2-delivery50
 besuArtifactGroup=io.consensys.linea-besu
 distributionIdentifier=linea-tracer


### PR DESCRIPTION
This is 100% proven save for
- the lexicographic ordering argument of `ROMLEX`
- hardcoding the `BLOCK_GAS_LIMIT` to 2B
- removing redundant columns from the `HUB` (e.g. the `_INFTY` stuff)