### PR TITLE
chore: update `go-corset` to commit 5d32de6

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -12,4 +12,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@ab7f2d5
+      run: go install github.com/consensys/go-corset/cmd/go-corset@5d32de6


### PR DESCRIPTION
Aims to address the issue whereby we can't build the `zkevm.bin` using the latest `Makefile` of the constraints repo (https://github.com/Consensys/linea-constraints/blob/12c234e8c844069571c7cd197cbe608db5b37678/Makefile#L109) on this PR https://github.com/Consensys/linea-tracer/pull/1840

mimicks https://github.com/Consensys/linea-tracer/pull/1841/files