### PR TITLE
fix(statetests): lower go mem limit

### DIFF
--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -29,7 +29,7 @@ jobs:
           JAVA_OPTS: -Dorg.gradle.daemon=false
 
       - name: Run General State Reference Tests
-        run: GOMEMLIMIT=64GiB ./gradlew -Dblockchain=Ethereum referenceGeneralStateTests
+        run: GOMEMLIMIT=20GiB ./gradlew -Dblockchain=Ethereum referenceGeneralStateTests
         env:
           REFERENCE_TESTS_PARALLELISM: 2
           JAVA_OPTS: -Dorg.gradle.daemon=false


### PR DESCRIPTION
Testing to make general state tests pass with lower go mem limit (set like blockchain ref tests)