### PR TITLE
feat: support embedded metadata in trace files

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -9,4 +9,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@db318ec
+      run: go install github.com/consensys/go-corset/cmd/go-corset@12a62d2

--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -9,4 +9,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@v0.9.4
+      run: go install github.com/consensys/go-corset/cmd/go-corset@db318ec

--- a/arithmetization/src/main/java/net/consensys/linea/blockcapture/snapshots/ConflationSnapshot.java
+++ b/arithmetization/src/main/java/net/consensys/linea/blockcapture/snapshots/ConflationSnapshot.java
@@ -37,6 +37,22 @@ public record ConflationSnapshot(
     List<StorageSnapshot> storage,
     List<BlockHashSnapshot> blockHashes) {
 
+  public long firstBlockNumber() {
+    if (blocks.isEmpty()) {
+      return Long.MAX_VALUE;
+    }
+    // Extract number of first block
+    return blocks.getFirst().header().number();
+  }
+
+  public long lastBlockNumber() {
+    if (blocks.isEmpty()) {
+      return Long.MAX_VALUE;
+    }
+    // Extract number of last block
+    return blocks.getLast().header().number();
+  }
+
   /**
    * Construct a block hash map for any block hashes embedded in this conflation.
    *

--- a/arithmetization/src/main/java/net/consensys/linea/tracewriter/TraceWriter.java
+++ b/arithmetization/src/main/java/net/consensys/linea/tracewriter/TraceWriter.java
@@ -54,7 +54,12 @@ public class TraceWriter {
     // Write the trace at the original and final trace file path, but with the suffix .tmp at the
     // end of the file.
     final Path tmpTraceFilePath =
-        writeToTmpFile(tracesOutputDirPath, origTraceFileName + ".", TRACE_TEMP_FILE_EXTENSION);
+        writeToTmpFile(
+            tracesOutputDirPath,
+            origTraceFileName + ".",
+            TRACE_TEMP_FILE_EXTENSION,
+            startBlockNumber,
+            endBlockNumber);
     // After trace writing is complete, rename the file by removing the .tmp prefix, indicating
     // the file is complete and should not be corrupted due to trace writing issues.
     final Path finalizedTraceFilePath =
@@ -63,7 +68,12 @@ public class TraceWriter {
     return finalizedTraceFilePath.toAbsolutePath();
   }
 
-  public Path writeToTmpFile(final Path rootDir, final String prefix, final String suffix) {
+  public Path writeToTmpFile(
+      final Path rootDir,
+      final String prefix,
+      final String suffix,
+      final long startBlockNumber,
+      final long endBlockNumber) {
     Path traceFile;
     try {
       FileAttribute<Set<PosixFilePermission>> perms =
@@ -83,7 +93,7 @@ public class TraceWriter {
       }
     }
 
-    tracer.writeToFile(traceFile);
+    tracer.writeToFile(traceFile, startBlockNumber, endBlockNumber);
 
     return traceFile;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
@@ -73,6 +75,11 @@ public class ZkTracer implements ConflationAwareOperationTracer {
   /** Accumulate all the exceptions that happened at tracing time. */
   @Getter private final List<Exception> tracingExceptions = new FiniteList<>(50);
 
+  // Fields for metadata
+  private long startBlock = Long.MAX_VALUE;
+  private long endBlock = 0;
+  private BigInteger chainId;
+
   public ZkTracer() {
     this(
         LineaL1L2BridgeSharedConfiguration.TEST_DEFAULT,
@@ -85,6 +92,7 @@ public class ZkTracer implements ConflationAwareOperationTracer {
 
   public ZkTracer(
       final LineaL1L2BridgeSharedConfiguration bridgeConfiguration, BigInteger chainId) {
+    this.chainId = chainId;
     this.hub = new Hub(bridgeConfiguration.contract(), bridgeConfiguration.topic(), chainId);
     for (Module m : this.hub.getModulesToCount()) {
       if (!spillings.containsKey(m.moduleKey())) {
@@ -109,9 +117,15 @@ public class ZkTracer implements ConflationAwareOperationTracer {
     final List<Module> modules = hub.getModulesToTrace();
     final List<Trace.ColumnHeader> headers =
         modules.stream().flatMap(m -> m.columnHeaders().stream()).toList();
-
+    // Configure metadata
+    final Map<String,String> metadata = Trace.metadata();
+    metadata.put("chainId",this.chainId.toString());
+    metadata.put("startBlock",Long.toString(this.startBlock));
+    metadata.put("endBlock",Long.toString(this.endBlock));
+    metadata.put("releaseVersion",ZkTracer.class.getPackage().getSpecificationVersion());
+    //
     try (RandomAccessFile file = new RandomAccessFile(filename.toString(), "rw")) {
-      Trace trace = Trace.of(file, headers, new byte[0]);
+      Trace trace = Trace.of(file, headers, getMetadataBytes(metadata));
       // Commit each module
       for (Module m : modules) {
         m.commit(trace);
@@ -157,6 +171,9 @@ public class ZkTracer implements ConflationAwareOperationTracer {
     } catch (final Exception e) {
       this.tracingExceptions.add(e);
     }
+    // Update block information for trace file metadata
+    this.startBlock = Math.min(this.startBlock, processableBlockHeader.getNumber());
+    this.endBlock = Math.max(this.endBlock, processableBlockHeader.getNumber());
   }
 
   @Override
@@ -168,6 +185,9 @@ public class ZkTracer implements ConflationAwareOperationTracer {
     } catch (final Exception e) {
       this.tracingExceptions.add(e);
     }
+    // Update block information for trace file metadata
+    this.startBlock = Math.min(this.startBlock, blockHeader.getNumber());
+    this.endBlock = Math.max(this.endBlock, blockHeader.getNumber());
   }
 
   @Override
@@ -316,5 +336,10 @@ public class ZkTracer implements ConflationAwareOperationTracer {
                                             + " not found in spillings.toml"))));
     modulesLineCount.put("BLOCK_TRANSACTIONS", hub.cumulatedTxCount());
     return modulesLineCount;
+  }
+
+  public static byte[] getMetadataBytes(Map<String,String> metadata) throws IOException {
+    ObjectWriter mapper = new ObjectMapper().writer();
+    return mapper.writeValueAsBytes(metadata);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -112,29 +112,29 @@ public class ZkTracer implements ConflationAwareOperationTracer {
   public void writeToFile(final Path filename, long startBlock, long endBlock) {
     maybeThrowTracingExceptions();
 
-    final List<Module> modules = hub.getModulesToTrace();
+    final List<Module> modulesToTrace = hub.getModulesToTrace();
     final List<Trace.ColumnHeader> headers =
-        modules.stream().flatMap(m -> m.columnHeaders().stream()).toList();
+        modulesToTrace.stream().flatMap(m -> m.columnHeaders().stream()).toList();
     // Configure metadata
     final Map<String, Object> metadata = Trace.metadata();
     metadata.put("chainId", this.chainId.toString());
     metadata.put("releaseVersion", ZkTracer.class.getPackage().getSpecificationVersion());
     // include block range
-    Map<String, String> range = new HashMap<>();
+    final Map<String, String> range = new HashMap<>();
     range.put("start", Long.toString(startBlock));
     range.put("end", Long.toString(endBlock));
     metadata.put("conflation", range);
     // include line counts
-    Map<String, String> lineCounts = new HashMap<>();
-    for (Module m : modules) {
+    final Map<String, String> lineCounts = new HashMap<>();
+    for (Module m : hub.getModulesToCount()) {
       lineCounts.put(m.moduleKey(), Integer.toString(m.lineCount()));
     }
     metadata.put("lineCounts", lineCounts);
     //
     try (RandomAccessFile file = new RandomAccessFile(filename.toString(), "rw")) {
-      Trace trace = Trace.of(file, headers, getMetadataBytes(metadata));
+      final Trace trace = Trace.of(file, headers, getMetadataBytes(metadata));
       // Commit each module
-      for (Module m : modules) {
+      for (Module m : modulesToTrace) {
         m.commit(trace);
       }
       // Close the file

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -118,11 +118,11 @@ public class ZkTracer implements ConflationAwareOperationTracer {
     final List<Trace.ColumnHeader> headers =
         modules.stream().flatMap(m -> m.columnHeaders().stream()).toList();
     // Configure metadata
-    final Map<String,String> metadata = Trace.metadata();
-    metadata.put("chainId",this.chainId.toString());
-    metadata.put("startBlock",Long.toString(this.startBlock));
-    metadata.put("endBlock",Long.toString(this.endBlock));
-    metadata.put("releaseVersion",ZkTracer.class.getPackage().getSpecificationVersion());
+    final Map<String, String> metadata = Trace.metadata();
+    metadata.put("chainId", this.chainId.toString());
+    metadata.put("startBlock", Long.toString(this.startBlock));
+    metadata.put("endBlock", Long.toString(this.endBlock));
+    metadata.put("releaseVersion", ZkTracer.class.getPackage().getSpecificationVersion());
     //
     try (RandomAccessFile file = new RandomAccessFile(filename.toString(), "rw")) {
       Trace trace = Trace.of(file, headers, getMetadataBytes(metadata));
@@ -338,7 +338,7 @@ public class ZkTracer implements ConflationAwareOperationTracer {
     return modulesLineCount;
   }
 
-  public static byte[] getMetadataBytes(Map<String,String> metadata) throws IOException {
+  public static byte[] getMetadataBytes(Map<String, String> metadata) throws IOException {
     ObjectWriter mapper = new ObjectMapper().writer();
     return mapper.writeValueAsBytes(metadata);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -76,9 +76,7 @@ public class ZkTracer implements ConflationAwareOperationTracer {
   @Getter private final List<Exception> tracingExceptions = new FiniteList<>(50);
 
   // Fields for metadata
-  private long startBlock = Long.MAX_VALUE;
-  private long endBlock = 0;
-  private BigInteger chainId;
+  private final BigInteger chainId;
 
   public ZkTracer() {
     this(
@@ -111,18 +109,27 @@ public class ZkTracer implements ConflationAwareOperationTracer {
         debugLevel.none() ? Optional.empty() : Optional.of(new DebugMode(debugLevel, this.hub));
   }
 
-  public void writeToFile(final Path filename) {
+  public void writeToFile(final Path filename, long startBlock, long endBlock) {
     maybeThrowTracingExceptions();
 
     final List<Module> modules = hub.getModulesToTrace();
     final List<Trace.ColumnHeader> headers =
         modules.stream().flatMap(m -> m.columnHeaders().stream()).toList();
     // Configure metadata
-    final Map<String, String> metadata = Trace.metadata();
+    final Map<String, Object> metadata = Trace.metadata();
     metadata.put("chainId", this.chainId.toString());
-    metadata.put("startBlock", Long.toString(this.startBlock));
-    metadata.put("endBlock", Long.toString(this.endBlock));
     metadata.put("releaseVersion", ZkTracer.class.getPackage().getSpecificationVersion());
+    // include block range
+    Map<String,String> range = new HashMap<>();
+    range.put("start", Long.toString(startBlock));
+    range.put("end", Long.toString(endBlock));
+    metadata.put("conflation", range);
+    // include line counts
+    Map<String, String> lineCounts = new HashMap<>();
+    for (Module m : modules) {
+      lineCounts.put(m.moduleKey(), Integer.toString(m.lineCount()));
+    }
+    metadata.put("lineCounts", lineCounts);
     //
     try (RandomAccessFile file = new RandomAccessFile(filename.toString(), "rw")) {
       Trace trace = Trace.of(file, headers, getMetadataBytes(metadata));
@@ -171,9 +178,6 @@ public class ZkTracer implements ConflationAwareOperationTracer {
     } catch (final Exception e) {
       this.tracingExceptions.add(e);
     }
-    // Update block information for trace file metadata
-    this.startBlock = Math.min(this.startBlock, processableBlockHeader.getNumber());
-    this.endBlock = Math.max(this.endBlock, processableBlockHeader.getNumber());
   }
 
   @Override
@@ -185,9 +189,6 @@ public class ZkTracer implements ConflationAwareOperationTracer {
     } catch (final Exception e) {
       this.tracingExceptions.add(e);
     }
-    // Update block information for trace file metadata
-    this.startBlock = Math.min(this.startBlock, blockHeader.getNumber());
-    this.endBlock = Math.max(this.endBlock, blockHeader.getNumber());
   }
 
   @Override
@@ -338,8 +339,10 @@ public class ZkTracer implements ConflationAwareOperationTracer {
     return modulesLineCount;
   }
 
-  public static byte[] getMetadataBytes(Map<String, String> metadata) throws IOException {
-    ObjectWriter mapper = new ObjectMapper().writer();
-    return mapper.writeValueAsBytes(metadata);
+  /** Object writer is used for generating JSON byte strings. */
+  private static final ObjectWriter objectWriter = new ObjectMapper().writer();
+
+  public static byte[] getMetadataBytes(Map<String, Object> metadata) throws IOException {
+    return objectWriter.writeValueAsBytes(metadata);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -120,7 +120,7 @@ public class ZkTracer implements ConflationAwareOperationTracer {
     metadata.put("chainId", this.chainId.toString());
     metadata.put("releaseVersion", ZkTracer.class.getPackage().getSpecificationVersion());
     // include block range
-    Map<String,String> range = new HashMap<>();
+    Map<String, String> range = new HashMap<>();
     range.put("start", Long.toString(startBlock));
     range.put("end", Long.toString(endBlock));
     metadata.put("conflation", range);

--- a/reference-tests/src/test/java/net/consensys/linea/GeneralStateReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/GeneralStateReferenceTestTools.java
@@ -232,7 +232,14 @@ public class GeneralStateReferenceTestTools {
                   .isEqualTo(expected);
             });
 
-    ExecutionEnvironment.checkTracer(zkTracer, CORSET_VALIDATOR, Optional.of(log));
+    ExecutionEnvironment.checkTracer(
+        zkTracer,
+        CORSET_VALIDATOR,
+        Optional.of(log),
+        // block number for first block
+        blockHeader.getNumber(),
+        // block number for last block
+        blockHeader.getNumber());
   }
 
   private static boolean shouldClearEmptyAccounts(final String eip) {

--- a/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
@@ -70,13 +70,17 @@ public class ExecutionEnvironment {
           .blockHeaderFunctions(new CliqueBlockHeaderFunctions());
 
   public static void checkTracer(
-      ZkTracer zkTracer, CorsetValidator corsetValidator, Optional<Logger> logger) {
+      ZkTracer zkTracer,
+      CorsetValidator corsetValidator,
+      Optional<Logger> logger,
+      long startBlock,
+      long endBlock) {
     Path traceFilePath = null;
     boolean traceValidated = false;
     try {
       String prefix = constructTestPrefix();
       traceFilePath = Files.createTempFile(prefix, ".lt");
-      zkTracer.writeToFile(traceFilePath);
+      zkTracer.writeToFile(traceFilePath, startBlock, endBlock);
       final Path finalTraceFilePath = traceFilePath;
       logger.ifPresent(log -> log.debug("trace written to {}", finalTraceFilePath));
       CorsetValidator.Result corsetValidationResult = corsetValidator.validate(traceFilePath);

--- a/testing/src/main/java/net/consensys/linea/testing/GeneralStateReferenceTestTools.java
+++ b/testing/src/main/java/net/consensys/linea/testing/GeneralStateReferenceTestTools.java
@@ -171,7 +171,14 @@ public class GeneralStateReferenceTestTools {
                   .isEqualTo(expected);
             });
 
-    ExecutionEnvironment.checkTracer(tracer, CORSET_VALIDATOR, Optional.of(log));
+    ExecutionEnvironment.checkTracer(
+        tracer,
+        CORSET_VALIDATOR,
+        Optional.of(log),
+        // block number for first block
+        blockHeader.getNumber(),
+        // block number for last block
+        blockHeader.getNumber());
   }
 
   @SneakyThrows

--- a/testing/src/main/java/net/consensys/linea/testing/ReplayExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ReplayExecutionEnvironment.java
@@ -98,12 +98,12 @@ public class ReplayExecutionEnvironment {
 
   private ZkTracer zkTracer;
 
-  public void checkTracer(String inputFilePath) {
+  public void checkTracer(String inputFilePath, long startBlock, long endBlock) {
     // Generate the output file path based on the input file path
     Path inputPath = Paths.get(inputFilePath);
     String outputFileName = inputPath.getFileName().toString().replace(".json.gz", ".lt");
     Path outputPath = inputPath.getParent().resolve(outputFileName);
-    this.zkTracer.writeToFile(outputPath);
+    this.zkTracer.writeToFile(outputPath, startBlock, endBlock);
     log.info("trace written to `{}`", outputPath);
     // validation is disabled by default for replayBulk
     // assertThat(CORSET_VALIDATOR.validate(outputPath).isValid()).isTrue();
@@ -125,7 +125,12 @@ public class ReplayExecutionEnvironment {
       return;
     }
     this.executeFrom(chainId, conflation);
-    ExecutionEnvironment.checkTracer(zkTracer, CORSET_VALIDATOR, Optional.of(log));
+    ExecutionEnvironment.checkTracer(
+        zkTracer,
+        CORSET_VALIDATOR,
+        Optional.of(log),
+        conflation.firstBlockNumber(),
+        conflation.lastBlockNumber());
   }
 
   public void replay(BigInteger chainId, final Reader replayFile, String inputFilePath) {
@@ -138,12 +143,14 @@ public class ReplayExecutionEnvironment {
       return;
     }
     this.executeFrom(chainId, conflation);
-    this.checkTracer(inputFilePath);
+    this.checkTracer(inputFilePath, conflation.firstBlockNumber(), conflation.lastBlockNumber());
   }
 
   public void replay(BigInteger chainId, ConflationSnapshot conflation) {
     this.executeFrom(chainId, conflation);
-    ExecutionEnvironment.checkTracer(zkTracer, CORSET_VALIDATOR, Optional.of(log));
+    ExecutionEnvironment.checkTracer(zkTracer, CORSET_VALIDATOR, Optional.of(log),
+      conflation.firstBlockNumber(),
+      conflation.lastBlockNumber());
   }
 
   /**

--- a/testing/src/main/java/net/consensys/linea/testing/ReplayExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ReplayExecutionEnvironment.java
@@ -148,9 +148,12 @@ public class ReplayExecutionEnvironment {
 
   public void replay(BigInteger chainId, ConflationSnapshot conflation) {
     this.executeFrom(chainId, conflation);
-    ExecutionEnvironment.checkTracer(zkTracer, CORSET_VALIDATOR, Optional.of(log),
-      conflation.firstBlockNumber(),
-      conflation.lastBlockNumber());
+    ExecutionEnvironment.checkTracer(
+        zkTracer,
+        CORSET_VALIDATOR,
+        Optional.of(log),
+        conflation.firstBlockNumber(),
+        conflation.lastBlockNumber());
   }
 
   /**


### PR DESCRIPTION
This adds support for embedding metadata into the generated trace file.  The metadata is sourced from two places: the `zkevm.bin` file, and also some information gathered by the tracer (e.g. block range, etc).