### PR TITLE
fix: l2l1Log count

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaL1L2BridgeSharedConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaL1L2BridgeSharedConfiguration.java
@@ -28,9 +28,12 @@ public record LineaL1L2BridgeSharedConfiguration(Address contract, Bytes topic)
   private static Bytes LINEA_L2L1TOPIC =
       Bytes.fromHexString("0xe856c2b8bd4eb0027ce32eeaf595c21b0b6b4644b326e5b7bd80a1cf8db72e6c");
 
-  public static final LineaL1L2BridgeSharedConfiguration SEPOLIA_DEFAULT =
+  private static final Address SEPOLIA_L2L1LOGS_SMC =
+      Address.fromHexString("0x971e727e956690b9957be6d51Ec16E73AcAC83A7");
+
+  public static final LineaL1L2BridgeSharedConfiguration TEST_DEFAULT =
       LineaL1L2BridgeSharedConfiguration.builder()
-          .contract(Address.fromHexString("0x971e727e956690b9957be6d51Ec16E73AcAC83A7"))
+          .contract(Address.fromHexString("0x7e577e577e577e577e577e577e577e577e577e57"))
           .topic(LINEA_L2L1TOPIC)
           .build();
 

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaL1L2BridgeSharedConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaL1L2BridgeSharedConfiguration.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.datatypes.Address;
 public record LineaL1L2BridgeSharedConfiguration(Address contract, Bytes topic)
     implements LineaOptionsConfiguration {
 
+  // = Hash(MessageSent(address,address,uint256,uint256,uint256,bytes,bytes32))
   private static Bytes LINEA_L2L1TOPIC =
       Bytes.fromHexString("0xe856c2b8bd4eb0027ce32eeaf595c21b0b6b4644b326e5b7bd80a1cf8db72e6c");
 

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaL1L2BridgeSharedConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaL1L2BridgeSharedConfiguration.java
@@ -24,6 +24,16 @@ import org.hyperledger.besu.datatypes.Address;
 @Builder(toBuilder = true)
 public record LineaL1L2BridgeSharedConfiguration(Address contract, Bytes topic)
     implements LineaOptionsConfiguration {
+
+  private static Bytes LINEA_L2L1TOPIC =
+      Bytes.fromHexString("0xe856c2b8bd4eb0027ce32eeaf595c21b0b6b4644b326e5b7bd80a1cf8db72e6c");
+
+  public static final LineaL1L2BridgeSharedConfiguration SEPOLIA_DEFAULT =
+      LineaL1L2BridgeSharedConfiguration.builder()
+          .contract(Address.fromHexString("0x971e727e956690b9957be6d51Ec16E73AcAC83A7"))
+          .topic(LINEA_L2L1TOPIC)
+          .build();
+
   public static final LineaL1L2BridgeSharedConfiguration EMPTY =
       LineaL1L2BridgeSharedConfiguration.builder()
           .contract(Address.ZERO)

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaL1L2BridgeSharedConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaL1L2BridgeSharedConfiguration.java
@@ -36,14 +36,4 @@ public record LineaL1L2BridgeSharedConfiguration(Address contract, Bytes topic)
           .contract(Address.fromHexString("0x7e577e577e577e577e577e577e577e577e577e57"))
           .topic(LINEA_L2L1TOPIC)
           .build();
-
-  public static final LineaL1L2BridgeSharedConfiguration EMPTY =
-      LineaL1L2BridgeSharedConfiguration.builder()
-          .contract(Address.ZERO)
-          .topic(Bytes.EMPTY)
-          .build();
-
-  public boolean isEmpty() {
-    return this.contract.equals(Address.ZERO) || this.topic.isEmpty();
-  }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -75,12 +75,12 @@ public class ZkTracer implements ConflationAwareOperationTracer {
 
   public ZkTracer() {
     this(
-        LineaL1L2BridgeSharedConfiguration.SEPOLIA_DEFAULT,
+        LineaL1L2BridgeSharedConfiguration.TEST_DEFAULT,
         Bytes.fromHexString("c0ffee").toUnsignedBigInteger());
   }
 
   public ZkTracer(BigInteger nonnegativeChainId) {
-    this(LineaL1L2BridgeSharedConfiguration.SEPOLIA_DEFAULT, nonnegativeChainId);
+    this(LineaL1L2BridgeSharedConfiguration.TEST_DEFAULT, nonnegativeChainId);
   }
 
   public ZkTracer(

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -75,12 +75,12 @@ public class ZkTracer implements ConflationAwareOperationTracer {
 
   public ZkTracer() {
     this(
-        LineaL1L2BridgeSharedConfiguration.EMPTY,
+        LineaL1L2BridgeSharedConfiguration.SEPOLIA_DEFAULT,
         Bytes.fromHexString("c0ffee").toUnsignedBigInteger());
   }
 
   public ZkTracer(BigInteger nonnegativeChainId) {
-    this(LineaL1L2BridgeSharedConfiguration.EMPTY, nonnegativeChainId);
+    this(LineaL1L2BridgeSharedConfiguration.SEPOLIA_DEFAULT, nonnegativeChainId);
   }
 
   public ZkTracer(

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -85,7 +85,6 @@ public class ZkTracer implements ConflationAwareOperationTracer {
 
   public ZkTracer(
       final LineaL1L2BridgeSharedConfiguration bridgeConfiguration, BigInteger chainId) {
-    ;
     this.hub = new Hub(bridgeConfiguration.contract(), bridgeConfiguration.topic(), chainId);
     for (Module m : this.hub.getModulesToCount()) {
       if (!spillings.containsKey(m.moduleKey())) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/CountingOnlyModule.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/CountingOnlyModule.java
@@ -40,7 +40,7 @@ public interface CountingOnlyModule extends Module {
     return counts().lineCount();
   }
 
-  default void addPrecompileLimit(final int count) {
+  default void addLimit(final int count) {
     Preconditions.checkArgument(count >= 0, "Must be positive");
     counts().add(count);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/CountingOnlyModule.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/CountingOnlyModule.java
@@ -40,8 +40,8 @@ public interface CountingOnlyModule extends Module {
     return counts().lineCount();
   }
 
-  default void addLimit(final int count) {
-    Preconditions.checkArgument(count >= 0, "Must be positive");
+  default void updateTally(final int count) {
+    Preconditions.checkArgument(count >= 0, "Must be non-negative");
     counts().add(count);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/BlakeModexpData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/BlakeModexpData.java
@@ -50,13 +50,13 @@ public class BlakeModexpData implements OperationListModule<BlakeModexpDataOpera
 
   public void callModexp(final ModexpMetadata modexpMetaData, final int operationID) {
     operations.add(new BlakeModexpDataOperation(modexpMetaData, operationID));
-    modexpEffectiveCall.addPrecompileLimit(1);
+    modexpEffectiveCall.addLimit(1);
     callWcpForIdCheck(operationID);
   }
 
   public void callBlake(final BlakeComponents blakeComponents, final int operationID) {
     operations.add(new BlakeModexpDataOperation(blakeComponents, operationID));
-    blakeEffectiveCall.addPrecompileLimit(1);
+    blakeEffectiveCall.addLimit(1);
     blakeRounds.addPrecompileLimit(blakeComponents.r());
     callWcpForIdCheck(operationID);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/BlakeModexpData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/BlakeModexpData.java
@@ -50,13 +50,13 @@ public class BlakeModexpData implements OperationListModule<BlakeModexpDataOpera
 
   public void callModexp(final ModexpMetadata modexpMetaData, final int operationID) {
     operations.add(new BlakeModexpDataOperation(modexpMetaData, operationID));
-    modexpEffectiveCall.addLimit(1);
+    modexpEffectiveCall.updateTally(1);
     callWcpForIdCheck(operationID);
   }
 
   public void callBlake(final BlakeComponents blakeComponents, final int operationID) {
     operations.add(new BlakeModexpDataOperation(blakeComponents, operationID));
-    blakeEffectiveCall.addLimit(1);
+    blakeEffectiveCall.updateTally(1);
     blakeRounds.addPrecompileLimit(blakeComponents.r());
     callWcpForIdCheck(operationID);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/EcData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/EcData.java
@@ -89,18 +89,16 @@ public class EcData implements OperationListModule<EcDataOperation> {
     operations.add(ecDataOperation);
 
     switch (ecDataOperation.precompileFlag()) {
-      case PRC_ECADD -> ecAddEffectiveCall.addPrecompileLimit(
-          ecDataOperation.internalChecksPassed() ? 1 : 0);
-      case PRC_ECMUL -> ecMulEffectiveCall.addPrecompileLimit(
-          ecDataOperation.internalChecksPassed() ? 1 : 0);
-      case PRC_ECRECOVER -> ecRecoverEffectiveCall.addPrecompileLimit(
+      case PRC_ECADD -> ecAddEffectiveCall.addLimit(ecDataOperation.internalChecksPassed() ? 1 : 0);
+      case PRC_ECMUL -> ecMulEffectiveCall.addLimit(ecDataOperation.internalChecksPassed() ? 1 : 0);
+      case PRC_ECRECOVER -> ecRecoverEffectiveCall.addLimit(
           ecDataOperation.internalChecksPassed() ? 1 : 0);
       case PRC_ECPAIRING -> {
         // ecPairingG2MembershipCalls case
         // NOTE: the other precompile limits are managed below
         // NOTE: see EC_DATA specs Figure 3.5 for a graphical representation of this case analysis
         if (!ecDataOperation.internalChecksPassed()) {
-          ecPairingG2MembershipCalls.addPrecompileLimit(0);
+          ecPairingG2MembershipCalls.addLimit(0);
           // The circuit is never invoked in the case of internal checks failing
         }
         // NOTE: the && of the conditions may seem not necessary since in the specs
@@ -110,21 +108,20 @@ public class EcData implements OperationListModule<EcDataOperation> {
         // , and it has to be && with internalChecksPassed to compute the actual
         // NOT_ON_G2_ACC_MAX to trace
         if (ecDataOperation.internalChecksPassed() && ecDataOperation.notOnG2AccMax()) {
-          ecPairingG2MembershipCalls.addPrecompileLimit(1);
+          ecPairingG2MembershipCalls.addLimit(1);
           // The circuit is invoked only once if there is at least one point predicted to be not on
           // G2
         }
         if (ecDataOperation.internalChecksPassed()
             && !ecDataOperation.notOnG2AccMax()
             && ecDataOperation.overallTrivialPairing().getLast()) {
-          ecPairingG2MembershipCalls.addPrecompileLimit(0);
+          ecPairingG2MembershipCalls.addLimit(0);
           // The circuit is never invoked in the case of a trivial pairing
         }
         if (ecDataOperation.internalChecksPassed()
             && !ecDataOperation.notOnG2AccMax()
             && !ecDataOperation.overallTrivialPairing().getLast()) {
-          ecPairingG2MembershipCalls.addPrecompileLimit(
-              ecDataOperation.circuitSelectorG2MembershipCounter());
+          ecPairingG2MembershipCalls.addLimit(ecDataOperation.circuitSelectorG2MembershipCounter());
           // The circuit is invoked as many times as there are points predicted to be on G2
         }
 
@@ -137,11 +134,11 @@ public class EcData implements OperationListModule<EcDataOperation> {
         // the small point is on C_1, the large point is on G_2, and they are not
         // points at infinity (valid trivial pairings and valid pairings with the
         // small point at infinity are excluded from this counting)
-        ecPairingMillerLoops.addPrecompileLimit(ecDataOperation.circuitSelectorEcPairingCounter());
+        ecPairingMillerLoops.addLimit(ecDataOperation.circuitSelectorEcPairingCounter());
 
         // ecPairingFinalExponentiation case
         // NOTE: if at least one Miller Loop is computed, the final exponentiation is 1
-        ecPairingFinalExponentiations.addPrecompileLimit(
+        ecPairingFinalExponentiations.addLimit(
             ecDataOperation.circuitSelectorEcPairingCounter() > 0
                 ? 1
                 : 0); // See https://eprint.iacr.org/2008/490.pdf

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/EcData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/EcData.java
@@ -89,16 +89,18 @@ public class EcData implements OperationListModule<EcDataOperation> {
     operations.add(ecDataOperation);
 
     switch (ecDataOperation.precompileFlag()) {
-      case PRC_ECADD -> ecAddEffectiveCall.addLimit(ecDataOperation.internalChecksPassed() ? 1 : 0);
-      case PRC_ECMUL -> ecMulEffectiveCall.addLimit(ecDataOperation.internalChecksPassed() ? 1 : 0);
-      case PRC_ECRECOVER -> ecRecoverEffectiveCall.addLimit(
+      case PRC_ECADD -> ecAddEffectiveCall.updateTally(
+          ecDataOperation.internalChecksPassed() ? 1 : 0);
+      case PRC_ECMUL -> ecMulEffectiveCall.updateTally(
+          ecDataOperation.internalChecksPassed() ? 1 : 0);
+      case PRC_ECRECOVER -> ecRecoverEffectiveCall.updateTally(
           ecDataOperation.internalChecksPassed() ? 1 : 0);
       case PRC_ECPAIRING -> {
         // ecPairingG2MembershipCalls case
         // NOTE: the other precompile limits are managed below
         // NOTE: see EC_DATA specs Figure 3.5 for a graphical representation of this case analysis
         if (!ecDataOperation.internalChecksPassed()) {
-          ecPairingG2MembershipCalls.addLimit(0);
+          ecPairingG2MembershipCalls.updateTally(0);
           // The circuit is never invoked in the case of internal checks failing
         }
         // NOTE: the && of the conditions may seem not necessary since in the specs
@@ -108,20 +110,21 @@ public class EcData implements OperationListModule<EcDataOperation> {
         // , and it has to be && with internalChecksPassed to compute the actual
         // NOT_ON_G2_ACC_MAX to trace
         if (ecDataOperation.internalChecksPassed() && ecDataOperation.notOnG2AccMax()) {
-          ecPairingG2MembershipCalls.addLimit(1);
+          ecPairingG2MembershipCalls.updateTally(1);
           // The circuit is invoked only once if there is at least one point predicted to be not on
           // G2
         }
         if (ecDataOperation.internalChecksPassed()
             && !ecDataOperation.notOnG2AccMax()
             && ecDataOperation.overallTrivialPairing().getLast()) {
-          ecPairingG2MembershipCalls.addLimit(0);
+          ecPairingG2MembershipCalls.updateTally(0);
           // The circuit is never invoked in the case of a trivial pairing
         }
         if (ecDataOperation.internalChecksPassed()
             && !ecDataOperation.notOnG2AccMax()
             && !ecDataOperation.overallTrivialPairing().getLast()) {
-          ecPairingG2MembershipCalls.addLimit(ecDataOperation.circuitSelectorG2MembershipCounter());
+          ecPairingG2MembershipCalls.updateTally(
+              ecDataOperation.circuitSelectorG2MembershipCounter());
           // The circuit is invoked as many times as there are points predicted to be on G2
         }
 
@@ -134,11 +137,11 @@ public class EcData implements OperationListModule<EcDataOperation> {
         // the small point is on C_1, the large point is on G_2, and they are not
         // points at infinity (valid trivial pairings and valid pairings with the
         // small point at infinity are excluded from this counting)
-        ecPairingMillerLoops.addLimit(ecDataOperation.circuitSelectorEcPairingCounter());
+        ecPairingMillerLoops.updateTally(ecDataOperation.circuitSelectorEcPairingCounter());
 
         // ecPairingFinalExponentiation case
         // NOTE: if at least one Miller Loop is computed, the final exponentiation is 1
-        ecPairingFinalExponentiations.addLimit(
+        ecPairingFinalExponentiations.updateTally(
             ecDataOperation.circuitSelectorEcPairingCounter() > 0
                 ? 1
                 : 0); // See https://eprint.iacr.org/2008/490.pdf

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -255,7 +255,9 @@ public class Hub implements Module {
         modexpEffectiveCall,
         ripemdBlocks,
         blakeEffectiveCall,
-        blakeRounds);
+        blakeRounds,
+        l2Block,
+        l2L1Logs);
   }
 
   /*
@@ -281,7 +283,7 @@ public class Hub implements Module {
           ecPairingFinalExponentiations);
 
   private final L2Block l2Block;
-  private final L2L1Logs l2L1Logs;
+  @Getter private final L2L1Logs l2L1Logs;
 
   /** list of module than can be modified during execution */
   private final List<Module> modules;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -207,7 +207,7 @@ public class Hub implements Module {
   private final RlpTxnRcpt rlpTxnRcpt = new RlpTxnRcpt();
   private final LogInfo logInfo = new LogInfo(rlpTxnRcpt);
   private final LogData logData = new LogData(rlpTxnRcpt);
-  @Getter private final RlpAddr rlpAddr = new RlpAddr(this, trm);
+  @Getter private final RlpAddr rlpAddr;
 
   // modules triggered by sub-fragments of the MISCELLANEOUS / IMC perspective
   @Getter private final Mxp mxp = new Mxp();
@@ -221,7 +221,6 @@ public class Hub implements Module {
    * precompile to meet the prover limits
    */
   private final Keccak keccak;
-
   private final Sha256Blocks sha256Blocks = new Sha256Blocks();
 
   private final EcAddEffectiveCall ecAddEffectiveCall = new EcAddEffectiveCall();
@@ -385,6 +384,7 @@ public class Hub implements Module {
     l2Block = new L2Block(l2L1Logs, l2l1ContractAddress, LogTopic.of(l2l1Topic));
     keccak = new Keccak(ecRecoverEffectiveCall, l2Block);
     shakiraData = new ShakiraData(wcp, sha256Blocks, keccak, ripemdBlocks);
+    rlpAddr = new RlpAddr(this, trm, keccak);
     blockdata = new Blockdata(wcp, euc, txnData, EWord.of(chainId));
     mmu = new Mmu(euc, wcp);
     mmio = new Mmio(mmu);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -16,6 +16,7 @@
 package net.consensys.linea.zktracer.module.hub;
 
 import static com.google.common.base.Preconditions.*;
+import static net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration.TEST_DEFAULT;
 import static net.consensys.linea.zktracer.Trace.Hub.MULTIPLIER___STACK_STAMP;
 import static net.consensys.linea.zktracer.module.hub.HubProcessingPhase.TX_EXEC;
 import static net.consensys.linea.zktracer.module.hub.HubProcessingPhase.TX_FINL;
@@ -380,6 +381,9 @@ public class Hub implements Module {
 
   public Hub(final Address l2l1ContractAddress, final Bytes l2l1Topic, final BigInteger chainId) {
     checkState(chainId.signum() >= 0);
+    if (l2l1ContractAddress.equals(TEST_DEFAULT.contract())) {
+      log.info("WARN: Using default testing L2L1 contract address");
+    }
     l2L1Logs = new L2L1Logs();
     l2Block = new L2Block(l2L1Logs, l2l1ContractAddress, LogTopic.of(l2l1Topic));
     keccak = new Keccak(ecRecoverEffectiveCall, l2Block);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -220,7 +220,7 @@ public class Hub implements Module {
    * Those modules are not traced, we just compute the number of calls to those
    * precompile to meet the prover limits
    */
-  private final Keccak keccak;
+  @Getter private final Keccak keccak;
   private final Sha256Blocks sha256Blocks = new Sha256Blocks();
 
   private final EcAddEffectiveCall ecAddEffectiveCall = new EcAddEffectiveCall();
@@ -281,7 +281,7 @@ public class Hub implements Module {
           ecPairingMillerLoops,
           ecPairingFinalExponentiations);
 
-  private final L2Block l2Block;
+  @Getter private final L2Block l2Block;
   @Getter private final L2L1Logs l2L1Logs;
 
   /** list of module than can be modified during execution */

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -379,8 +379,8 @@ public class Hub implements Module {
 
   public Hub(final Address l2l1ContractAddress, final Bytes l2l1Topic, final BigInteger chainId) {
     checkState(chainId.signum() >= 0);
-    l2Block = new L2Block(l2l1ContractAddress, LogTopic.of(l2l1Topic));
-    l2L1Logs = new L2L1Logs(l2Block);
+    l2L1Logs = new L2L1Logs();
+    l2Block = new L2Block(l2L1Logs, l2l1ContractAddress, LogTopic.of(l2l1Topic));
     keccak = new Keccak(ecRecoverEffectiveCall, l2Block);
     shakiraData = new ShakiraData(wcp, sha256Blocks, keccak, ripemdBlocks);
     blockdata = new Blockdata(wcp, euc, txnData, EWord.of(chainId));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/ModexpSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/ModexpSubsection.java
@@ -74,7 +74,7 @@ public class ModexpSubsection extends PrecompileSubsection {
                 .toUnsignedBigInteger()
                 .compareTo(BigInteger.valueOf(MODEXP_COMPONENT_BYTE_SIZE))
             > 0) {
-      hub.modexpEffectiveCall().addLimit(Integer.MAX_VALUE);
+      hub.modexpEffectiveCall().updateTally(Integer.MAX_VALUE);
       hub.defers().unscheduleForContextReEntry(this, hub.currentFrame());
       transactionWillBePopped = true;
       return;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/ModexpSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/ModexpSubsection.java
@@ -74,7 +74,7 @@ public class ModexpSubsection extends PrecompileSubsection {
                 .toUnsignedBigInteger()
                 .compareTo(BigInteger.valueOf(MODEXP_COMPONENT_BYTE_SIZE))
             > 0) {
-      hub.modexpEffectiveCall().addPrecompileLimit(Integer.MAX_VALUE);
+      hub.modexpEffectiveCall().addLimit(Integer.MAX_VALUE);
       hub.defers().unscheduleForContextReEntry(this, hub.currentFrame());
       transactionWillBePopped = true;
       return;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
@@ -41,7 +41,7 @@ public class Keccak implements CountingOnlyModule {
   }
 
   @Override
-  public void addLimit(final int count) {
+  public void updateTally(final int count) {
     final int blockCount = numberOfKeccakBloc(count);
     counts.add(blockCount);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
@@ -59,9 +59,10 @@ public class Keccak implements CountingOnlyModule {
     final int ecRecoverCount = ecRecoverEffectiveCall.lineCount();
 
     // From tx RLPs, used both for both the signature verification and the
-    // public input computation.
-    return numberOfKeccakBloc(l2Block.sizesRlpEncodedTxs().lineCount())
-        + txCount
+    // public input computation. As l2Block.sizesRlpEncodedTxs().lineCount() gives the size of the
+    // concatenation of all
+    // the RLP-encoded transactions, we add txCount to not miss keccak blocks.
+    return (numberOfKeccakBloc(l2Block.sizesRlpEncodedTxs().lineCount()) + txCount)
         // From ecRecover precompiles,
         // This accounts for the keccak of the recovered public keys to derive the
         // addresses. This also accounts for the transactions signatures

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
@@ -49,7 +49,7 @@ public class Keccak implements CountingOnlyModule {
   }
 
   @Override
-  public void addPrecompileLimit(final int count) {
+  public void addLimit(final int count) {
     final int blockCount = numberOfKeccakBloc(count);
     counts.add(blockCount);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
@@ -64,7 +64,6 @@ public class Keccak implements CountingOnlyModule {
         + (txCount + ecRecoverCount) * numberOfKeccakBloc(PUBKEY_BYTES)
 
         // From deployed contracts, number of Keccak block for SHA3 and CREATE2, and from RLP_ADDR
-        // TODO:
         + counts.lineCount();
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
@@ -67,7 +67,7 @@ public class Keccak implements CountingOnlyModule {
         + counts.lineCount();
   }
 
-  private static int numberOfKeccakBloc(final long dataByteLength) {
+  public static int numberOfKeccakBloc(final long dataByteLength) {
     final long r = (dataByteLength + KECCAK_BYTE_RATE - 1) / KECCAK_BYTE_RATE;
     Preconditions.checkState(r < Integer.MAX_VALUE, "demented KECCAK");
     return (int) r;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
@@ -22,18 +22,12 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 import net.consensys.linea.zktracer.module.limits.precompiles.EcRecoverEffectiveCall;
-import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.Hash;
 
 @RequiredArgsConstructor
 @Getter
 @Accessors(fluent = true)
 public class Keccak implements CountingOnlyModule {
   private final CountOnlyOperation counts = new CountOnlyOperation();
-  private static final int ADDRESS_BYTES = Address.SIZE;
-  private static final int HASH_BYTES = Hash.SIZE;
-  private static final int L1_MSG_INDICES_BYTES = 8;
-  private static final int L1_TIMESTAMPS_BYTES = 8;
   private static final int PUBKEY_BYTES = 64;
   private static final int KECCAK_BIT_RATE = 1088;
   private static final int KECCAK_BYTE_RATE = KECCAK_BIT_RATE / 8; // TODO: find correct name
@@ -54,65 +48,24 @@ public class Keccak implements CountingOnlyModule {
 
   @Override
   public int lineCount() {
-    final int l2L1LogsCount = l2Block.l2l1LogSizes().lineCount();
     final int txCount = l2Block.numberOfTransactions().lineCount();
     final int ecRecoverCount = ecRecoverEffectiveCall.lineCount();
 
+    return
     // From tx RLPs, used both for both the signature verification and the
     // public input computation. As l2Block.sizesRlpEncodedTxs().lineCount() gives the size of the
     // concatenation of all
     // the RLP-encoded transactions, we add txCount to not miss keccak blocks.
-    return (numberOfKeccakBloc(l2Block.sizesRlpEncodedTxs().lineCount()) + txCount)
+    (numberOfKeccakBloc(l2Block.sizesRlpEncodedTxs().lineCount()) + txCount)
         // From ecRecover precompiles,
         // This accounts for the keccak of the recovered public keys to derive the
         // addresses. This also accounts for the transactions signatures
         // verifications.
         + (txCount + ecRecoverCount) * numberOfKeccakBloc(PUBKEY_BYTES)
 
-        // From deployed contracts, SHA3 opcode, and CREATE2
-        + counts.lineCount()
-
-        /**
-         * TODO: previous implem was missing CREATE2 and was the following: // From deployed
-         * contracts, // @alex, this formula suggests that the same data is hashed twice. Is this //
-         * accurate? If this is actually the same data then we should not need to // prove it twice.
-         * If the second time the data is hashed with a few extra // bytes this should be accounted
-         * for : numKeccak(l) + numKeccak(l + extra) +
-         * this.deployedCodeSizes.stream().flatMap(List::stream).mapToInt(Keccak::numKeccak).sum()
-         * // From SHA3 opcode +
-         * this.sha3Sizes.stream().flatMap(List::stream).mapToInt(Keccak::numKeccak).sum()
-         */
-
-        // From public input computation. This accounts for the hashing of:
-        // - The block data hash:
-        // 		- hashing the list of the transaction hashes
-        //		- hashing the list of the L2L1 messages hashes
-        // 		- hashing the list of the from addresses of the transactions
-        // 		- hashing the list of the batch reception indices
-        //		- hashing the above resulting hashes together to obtain the hash
-        //			for the current block data
-        + txCount
-            * (numberOfKeccakBloc(HASH_BYTES)
-                + numberOfKeccakBloc(ADDRESS_BYTES)
-                + numberOfKeccakBloc(L1_MSG_INDICES_BYTES))
-        + l2L1LogsCount * numberOfKeccakBloc(HASH_BYTES)
-        + numberOfKeccakBloc(4 * HASH_BYTES) // 4 because there are 4 fields above
-
-        // - The top-level structure (with the worst-case assumption, the
-        // 	  current block is alone in the conflation). This includes:
-        // 		- hashing concatenation of the state-root hashes for all blocks +1
-        //			for the parent state-root hash.
-        //		- hashing the list of the timestamps including the last finalized
-        //			timestamp.
-        //		- hashing the list of the block data hashes.
-        //		- the first block number in the conflation list (formatted over 32
-        // 			bytes). Note: it does not need to be hashed. It will just be
-        //			included directly in the final hash.
-        //		- the hash of the above fields, to obtain the final public input
-        + 2 * numberOfKeccakBloc(HASH_BYTES) // one for the parent, one for the current block
-        + 2 * numberOfKeccakBloc(L1_TIMESTAMPS_BYTES)
-        + numberOfKeccakBloc(HASH_BYTES) // for the block data hash
-        + numberOfKeccakBloc(4 * HASH_BYTES);
+        // From deployed contracts, number of Keccak block for SHA3 and CREATE2, and from RLP_ADDR
+        // TODO:
+        + counts.lineCount();
   }
 
   private static int numberOfKeccakBloc(final long dataByteLength) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/Keccak.java
@@ -15,8 +15,6 @@
 
 package net.consensys.linea.zktracer.module.limits;
 
-import java.util.List;
-
 import com.google.common.base.Preconditions;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -56,13 +54,14 @@ public class Keccak implements CountingOnlyModule {
 
   @Override
   public int lineCount() {
-    final int l2L1LogsCount = this.l2Block.l2l1LogSizes().stream().mapToInt(List::size).sum();
-    final int txCount = this.l2Block.sizesRlpEncodedTxs().size();
+    final int l2L1LogsCount = l2Block.l2l1LogSizes().lineCount();
+    final int txCount = l2Block.numberOfTransactions().lineCount();
     final int ecRecoverCount = ecRecoverEffectiveCall.lineCount();
 
     // From tx RLPs, used both for both the signature verification and the
     // public input computation.
-    return this.l2Block.sizesRlpEncodedTxs().stream().mapToInt(Keccak::numberOfKeccakBloc).sum()
+    return numberOfKeccakBloc(l2Block.sizesRlpEncodedTxs().lineCount())
+        + txCount
         // From ecRecover precompiles,
         // This accounts for the keccak of the recovered public keys to derive the
         // addresses. This also accounts for the transactions signatures

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2Block.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2Block.java
@@ -92,6 +92,8 @@ public class L2Block implements Module {
 
   @Override
   public void traceEndTx(TransactionProcessingMetadata tx) {
+    numberOfTransactions.add(1);
+
     for (Log log : tx.getLogs()) {
       if (isL2L1Log(log)) {
         l2l1LogSizes.add(log.getData().size());

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2Block.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2Block.java
@@ -98,7 +98,7 @@ public class L2Block implements Module {
       if (isL2L1Log(log)) {
         l2l1LogSizes.add(log.getData().size());
         // The L2L1Logs module counts only the number of L2->L1 logs
-        l2l1Logs.addLimit(1);
+        l2l1Logs.updateTally(1);
       }
     }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2Block.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2Block.java
@@ -15,9 +15,6 @@
 
 package net.consensys.linea.zktracer.module.limits;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
 import java.util.List;
 
 import lombok.Getter;
@@ -25,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.Module;
+import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
@@ -32,6 +30,7 @@ import org.hyperledger.besu.evm.log.Log;
 import org.hyperledger.besu.evm.log.LogTopic;
 
 @Accessors(fluent = true)
+@Getter
 @RequiredArgsConstructor
 public class L2Block implements Module {
   private final L2L1Logs l2l1Logs;
@@ -43,11 +42,14 @@ public class L2Block implements Module {
   private static final int ABI_OFFSET_BYTES = 32;
   private static final int ABI_LEN_BYTES = 32;
 
+  /** The number of transaction */
+  private final CountOnlyOperation numberOfTransactions = new CountOnlyOperation();
+
   /** The byte size of the RLP-encoded transaction of the conflation */
-  @Getter private final Deque<Integer> sizesRlpEncodedTxs = new ArrayDeque<>();
+  private final CountOnlyOperation sizesRlpEncodedTxs = new CountOnlyOperation();
 
   /** The byte size of the L2->L1 logs messages of the conflation */
-  @Getter private final Deque<List<Integer>> l2l1LogSizes = new ArrayDeque<>();
+  private final CountOnlyOperation l2l1LogSizes = new CountOnlyOperation();
 
   @Override
   public String moduleKey() {
@@ -56,69 +58,60 @@ public class L2Block implements Module {
 
   @Override
   public void commitTransactionBundle() {
-    this.sizesRlpEncodedTxs.push(0);
-    this.l2l1LogSizes.push(new ArrayList<>());
+    numberOfTransactions.commitTransactionBundle();
+    sizesRlpEncodedTxs.commitTransactionBundle();
+    l2l1LogSizes.commitTransactionBundle();
   }
 
   @Override
   public void popTransactionBundle() {
-    this.sizesRlpEncodedTxs.pop();
-    this.l2l1LogSizes.pop();
+    numberOfTransactions.popTransactionBundle();
+    sizesRlpEncodedTxs.popTransactionBundle();
+    l2l1LogSizes.popTransactionBundle();
   }
 
   @Override
   public int lineCount() {
-    final int txCount = this.sizesRlpEncodedTxs.size();
-    final int l2L1LogsCount = this.l2l1LogSizes.stream().mapToInt(List::size).sum();
 
-    // This calculates the data size related to the transaction field of the
-    // data sent on L1. This field is a double array of byte. Each subarray
-    // corresponds to an RLP encoded transaction. The abi encoding incurs an
-    // overhead for each transaction (32 bytes for an offset, and 32 bytes for
-    // to encode the length of each sub bytes array). This overhead is also
-    // incurred by the top-level array, hence the +1.
-    int totalTxsRlpSize = (txCount + 1) * (ABI_OFFSET_BYTES + ABI_LEN_BYTES);
-    for (int txRlpSize : this.sizesRlpEncodedTxs) {
-      totalTxsRlpSize += txRlpSize;
-    }
+    return sizesRlpEncodedTxs.lineCount()
+        + l2l1LogSizes.lineCount()
 
-    // Calculates the data size related to the abi encoding of the list of the
-    // from addresses. The field is a simple array of bytes20. We need to take
-    // into account the offset and the length in the ABI encoding.
-    final int totalFromSize = txCount * Address.SIZE + ABI_OFFSET_BYTES + ABI_LEN_BYTES;
+        // Calculates the data size related to the abi encoding of the list of the
+        // from addresses. The field is a simple array of bytes20. We need to take
+        // into account the offset and the length in the ABI encoding.
+        + numberOfTransactions.lineCount() * Address.SIZE
+        + ABI_OFFSET_BYTES
+        + ABI_LEN_BYTES
 
-    // Accumulates the data occupied for the hashes of the L2 to L1 messages
-    // hashes each of them occupies 32 bytes. Also accounts for the overheads
-    // of L2 and L1 messages encoding.
-    final int totalL2L1Logs = Hash.SIZE * l2L1LogsCount + ABI_OFFSET_BYTES + ABI_LEN_BYTES;
+        // Accumulates the data occupied for the hashes of the L2 to L1 messages
+        // hashes each of them occupies 32 bytes. Also accounts for the overheads
+        // of L2 and L1 messages encoding.
+        + Hash.SIZE * l2l1LogSizes.lineCount()
+        + ABI_OFFSET_BYTES
+        + ABI_LEN_BYTES
 
-    int l1Size = totalTxsRlpSize + totalL2L1Logs + totalFromSize;
-
-    // Account for the overheads of sending the resulting root hash, the
-    // timestamp and the L1 msg reception. For a sequence of conflated L2 blocks
-    // , we will need to also need to send the initial timestamp and the parent
-    // state root hash. Since we cannot forsee, at this point, the number of
-    // blocks that will be conflated together with this block we make the worst
-    // assumption that the block will be conflated alone. This corresponds to
-    // counting twice the root hash and the timestamps. For the L1 messages, we
-    // unfortunately do not have the data in the tracer yet. For that reason,
-    // we also make a worst-case assumption that that every transaction is a
-    // batch reception on layer 2. Finally, since what is sent on L1 is an array
-    // of L2BlockData, we also make a worst-case assumption that the block will
-    // be alone in the structure and account for the ABI encoding.
-    l1Size +=
-        2 * L1_TIMESTAMPS_BYTES
-            + // the timestamp
-            2 * Hash.SIZE
-            + // the root hash
-            L1_MSG_INDICES_BYTES * txCount
-            + ABI_LEN_BYTES
-            + ABI_OFFSET_BYTES
-            + // the L1 messages
-            ABI_LEN_BYTES
-            + ABI_OFFSET_BYTES; // abi overheads for the blockdata struct.
-
-    return l1Size;
+        // Account for the overheads of sending the resulting root hash, the
+        // timestamp and the L1 msg reception. For a sequence of conflated L2 blocks
+        // , we will need to also need to send the initial timestamp and the parent
+        // state root hash. Since we cannot forsee, at this point, the number of
+        // blocks that will be conflated together with this block we make the worst
+        // assumption that the block will be conflated alone. This corresponds to
+        // counting twice the root hash and the timestamps. For the L1 messages, we
+        // unfortunately do not have the data in the tracer yet. For that reason,
+        // we also make a worst-case assumption that that every transaction is a
+        // batch reception on layer 2. Finally, since what is sent on L1 is an array
+        // of L2BlockData, we also make a worst-case assumption that the block will
+        // be alone in the structure and account for the ABI encoding.
+        + 2 * L1_TIMESTAMPS_BYTES
+        + // the timestamp
+        2 * Hash.SIZE
+        + // the root hash
+        L1_MSG_INDICES_BYTES * numberOfTransactions.lineCount()
+        + ABI_LEN_BYTES
+        + ABI_OFFSET_BYTES
+        + // the L1 messages
+        ABI_LEN_BYTES
+        + ABI_OFFSET_BYTES; // abi overheads for the blockdata struct.
   }
 
   @Override
@@ -130,13 +123,19 @@ public class L2Block implements Module {
   public void traceEndTx(TransactionProcessingMetadata tx) {
     for (Log log : tx.getLogs()) {
       if (isL2L1Log(log)) {
-        l2l1LogSizes.peek().add(log.getData().size());
+        l2l1LogSizes.add(log.getData().size());
         // The L2L1Logs module counts only the number of L2->L1 logs
         l2l1Logs.addLimit(1);
       }
     }
 
-    sizesRlpEncodedTxs.push(sizesRlpEncodedTxs.pop() + tx.getBesuTransaction().encoded().size());
+    // This calculates the data size related to the transaction field of the
+    // data sent on L1. This field is a double array of byte. Each subarray
+    // corresponds to an RLP encoded transaction. The abi encoding incurs an
+    // overhead for each transaction (32 bytes for an offset, and 32 bytes for
+    // to encode the length of each sub bytes array). This overhead is also
+    // incurred by the top-level array, hence the +1.
+    sizesRlpEncodedTxs.add(tx.getBesuTransaction().encoded().size());
   }
 
   private boolean isL2L1Log(Log log) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2Block.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2Block.java
@@ -34,6 +34,7 @@ import org.hyperledger.besu.evm.log.LogTopic;
 @Accessors(fluent = true)
 @RequiredArgsConstructor
 public class L2Block implements Module {
+  private final L2L1Logs l2l1Logs;
   private final Address l2l1Address;
   private final LogTopic l2l1Topic;
 
@@ -128,16 +129,19 @@ public class L2Block implements Module {
   @Override
   public void traceEndTx(TransactionProcessingMetadata tx) {
     for (Log log : tx.getLogs()) {
-      if (log.getLogger().equals(l2l1Address) && log.getTopics().contains(l2l1Topic)) {
-        this.l2l1LogSizes.peek().add(log.getData().size());
+      if (isL2L1Log(log)) {
+        l2l1LogSizes.peek().add(log.getData().size());
+        // The L2L1Logs module counts only the number of L2->L1 logs
+        l2l1Logs.addLimit(1);
       }
     }
 
-    this.sizesRlpEncodedTxs.push(
-        this.sizesRlpEncodedTxs.pop() + tx.getBesuTransaction().encoded().size());
+    sizesRlpEncodedTxs.push(sizesRlpEncodedTxs.pop() + tx.getBesuTransaction().encoded().size());
   }
 
-  public int l2l1LogsCount() {
-    return this.l2l1LogSizes.stream().mapToInt(List::size).sum();
+  private boolean isL2L1Log(Log log) {
+    return log.getLogger().equals(l2l1Address)
+        && !log.getTopics().isEmpty()
+        && log.getTopics().getFirst().equals(l2l1Topic);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2Block.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2Block.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.log.Log;
 import org.hyperledger.besu.evm.log.LogTopic;
+import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 
 @Accessors(fluent = true)
 @Getter
@@ -37,10 +38,8 @@ public class L2Block implements Module {
   private final Address l2l1Address;
   private final LogTopic l2l1Topic;
 
-  private static final int L1_MSG_INDICES_BYTES = 8;
-  private static final int L1_TIMESTAMPS_BYTES = 8;
-  private static final int ABI_OFFSET_BYTES = 32;
-  private static final int ABI_LEN_BYTES = 32;
+  private final short TIMESTAMP_BYTESIZE = 32 / 8;
+  private final short NB_TX_IN_BLOCK_BYTESIZE = 16 / 8;
 
   /** The number of transaction */
   private final CountOnlyOperation numberOfTransactions = new CountOnlyOperation();
@@ -50,6 +49,9 @@ public class L2Block implements Module {
 
   /** The byte size of the L2->L1 logs messages of the conflation */
   private final CountOnlyOperation l2l1LogSizes = new CountOnlyOperation();
+
+  /** The number of block of the current conflation */
+  private short nbBlock = 0;
 
   @Override
   public String moduleKey() {
@@ -74,44 +76,13 @@ public class L2Block implements Module {
   public int lineCount() {
 
     return sizesRlpEncodedTxs.lineCount()
-        + l2l1LogSizes.lineCount()
 
         // Calculates the data size related to the abi encoding of the list of the
-        // from addresses. The field is a simple array of bytes20. We need to take
-        // into account the offset and the length in the ABI encoding.
+        // from addresses. The field is a simple array of bytes20.
         + numberOfTransactions.lineCount() * Address.SIZE
-        + ABI_OFFSET_BYTES
-        + ABI_LEN_BYTES
 
-        // Accumulates the data occupied for the hashes of the L2 to L1 messages
-        // hashes each of them occupies 32 bytes. Also accounts for the overheads
-        // of L2 and L1 messages encoding.
-        + Hash.SIZE * l2l1LogSizes.lineCount()
-        + ABI_OFFSET_BYTES
-        + ABI_LEN_BYTES
-
-        // Account for the overheads of sending the resulting root hash, the
-        // timestamp and the L1 msg reception. For a sequence of conflated L2 blocks
-        // , we will need to also need to send the initial timestamp and the parent
-        // state root hash. Since we cannot forsee, at this point, the number of
-        // blocks that will be conflated together with this block we make the worst
-        // assumption that the block will be conflated alone. This corresponds to
-        // counting twice the root hash and the timestamps. For the L1 messages, we
-        // unfortunately do not have the data in the tracer yet. For that reason,
-        // we also make a worst-case assumption that that every transaction is a
-        // batch reception on layer 2. Finally, since what is sent on L1 is an array
-        // of L2BlockData, we also make a worst-case assumption that the block will
-        // be alone in the structure and account for the ABI encoding.
-        + 2 * L1_TIMESTAMPS_BYTES
-        + // the timestamp
-        2 * Hash.SIZE
-        + // the root hash
-        L1_MSG_INDICES_BYTES * numberOfTransactions.lineCount()
-        + ABI_LEN_BYTES
-        + ABI_OFFSET_BYTES
-        + // the L1 messages
-        ABI_LEN_BYTES
-        + ABI_OFFSET_BYTES; // abi overheads for the blockdata struct.
+        // Calculates the data size related to the block
+        + nbBlock * (TIMESTAMP_BYTESIZE + Hash.SIZE + NB_TX_IN_BLOCK_BYTESIZE);
   }
 
   @Override
@@ -136,6 +107,12 @@ public class L2Block implements Module {
     // to encode the length of each sub bytes array). This overhead is also
     // incurred by the top-level array, hence the +1.
     sizesRlpEncodedTxs.add(tx.getBesuTransaction().encoded().size());
+  }
+
+  @Override
+  public void traceStartBlock(
+      final ProcessableBlockHeader processableBlockHeader, final Address miningBeneficiary) {
+    nbBlock++;
   }
 
   private boolean isL2L1Log(Log log) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2L1Logs.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2L1Logs.java
@@ -15,15 +15,18 @@
 
 package net.consensys.linea.zktracer.module.limits;
 
-import java.util.List;
+import static com.google.common.base.Preconditions.checkArgument;
 
-import lombok.RequiredArgsConstructor;
-import net.consensys.linea.zktracer.Trace;
-import net.consensys.linea.zktracer.container.module.Module;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
+import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 
-@RequiredArgsConstructor
-public class L2L1Logs implements Module {
-  private final L2Block l2Block;
+public final class L2L1Logs implements CountingOnlyModule {
+
+  @Getter
+  @Accessors(fluent = true)
+  private final CountOnlyOperation counts = new CountOnlyOperation();
 
   @Override
   public String moduleKey() {
@@ -31,18 +34,8 @@ public class L2L1Logs implements Module {
   }
 
   @Override
-  public void commitTransactionBundle() {}
-
-  @Override
-  public void popTransactionBundle() {}
-
-  @Override
-  public int lineCount() {
-    return l2Block.l2l1LogsCount();
-  }
-
-  @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return null;
+  public void addLimit(final int numberEffectiveCall) {
+    checkArgument(numberEffectiveCall == 1, "can't add more than one l2l1Log event at a time");
+    counts.add(numberEffectiveCall);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2L1Logs.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2L1Logs.java
@@ -34,7 +34,7 @@ public final class L2L1Logs implements CountingOnlyModule {
   }
 
   @Override
-  public void addLimit(final int numberEffectiveCall) {
+  public void updateTally(final int numberEffectiveCall) {
     checkArgument(numberEffectiveCall == 1, "can't add more than one l2l1Log event at a time");
     counts.add(numberEffectiveCall);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeEffectiveCall.java
@@ -33,7 +33,7 @@ public final class BlakeEffectiveCall implements CountingOnlyModule {
   }
 
   @Override
-  public void addPrecompileLimit(final int numberEffectiveCall) {
+  public void addLimit(final int numberEffectiveCall) {
     checkArgument(
         numberEffectiveCall == 1, "can't add more than one effective precompile call at a time");
     counts.add(numberEffectiveCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeEffectiveCall.java
@@ -33,7 +33,7 @@ public final class BlakeEffectiveCall implements CountingOnlyModule {
   }
 
   @Override
-  public void addLimit(final int numberEffectiveCall) {
+  public void updateTally(final int numberEffectiveCall) {
     checkArgument(
         numberEffectiveCall == 1, "can't add more than one effective precompile call at a time");
     counts.add(numberEffectiveCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeRounds.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeRounds.java
@@ -42,7 +42,7 @@ public final class BlakeRounds implements CountingOnlyModule {
   }
 
   @Override
-  public void addPrecompileLimit(final int count) {
+  public void addLimit(final int count) {
     throw new UnsupportedOperationException("Not implemented");
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeRounds.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/BlakeRounds.java
@@ -42,7 +42,7 @@ public final class BlakeRounds implements CountingOnlyModule {
   }
 
   @Override
-  public void addLimit(final int count) {
+  public void updateTally(final int count) {
     throw new UnsupportedOperationException("Not implemented");
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcAddEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcAddEffectiveCall.java
@@ -33,7 +33,7 @@ public final class EcAddEffectiveCall implements CountingOnlyModule {
   }
 
   @Override
-  public void addLimit(final int numberEffectiveCall) {
+  public void updateTally(final int numberEffectiveCall) {
     checkArgument(
         numberEffectiveCall <= 1, "can't add more than one effective precompile call at a time");
     counts.add(numberEffectiveCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcAddEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcAddEffectiveCall.java
@@ -33,7 +33,7 @@ public final class EcAddEffectiveCall implements CountingOnlyModule {
   }
 
   @Override
-  public void addPrecompileLimit(final int numberEffectiveCall) {
+  public void addLimit(final int numberEffectiveCall) {
     checkArgument(
         numberEffectiveCall <= 1, "can't add more than one effective precompile call at a time");
     counts.add(numberEffectiveCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcMulEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcMulEffectiveCall.java
@@ -35,7 +35,7 @@ public final class EcMulEffectiveCall implements CountingOnlyModule {
   }
 
   @Override
-  public void addLimit(final int numberEffectiveCall) {
+  public void updateTally(final int numberEffectiveCall) {
     checkArgument(
         numberEffectiveCall <= 1, "can't add more than one effective precompile call at a time");
     counts.add(numberEffectiveCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcMulEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcMulEffectiveCall.java
@@ -35,7 +35,7 @@ public final class EcMulEffectiveCall implements CountingOnlyModule {
   }
 
   @Override
-  public void addPrecompileLimit(final int numberEffectiveCall) {
+  public void addLimit(final int numberEffectiveCall) {
     checkArgument(
         numberEffectiveCall <= 1, "can't add more than one effective precompile call at a time");
     counts.add(numberEffectiveCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingFinalExponentiations.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingFinalExponentiations.java
@@ -43,7 +43,7 @@ public final class EcPairingFinalExponentiations implements CountingOnlyModule {
   }
 
   @Override
-  public void addLimit(final int numberEffectiveCall) {
+  public void updateTally(final int numberEffectiveCall) {
     Preconditions.checkArgument(
         numberEffectiveCall <= 1, "can't add more than one effective precompile call at a time");
     counts.add(numberEffectiveCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingFinalExponentiations.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingFinalExponentiations.java
@@ -43,7 +43,7 @@ public final class EcPairingFinalExponentiations implements CountingOnlyModule {
   }
 
   @Override
-  public void addPrecompileLimit(final int numberEffectiveCall) {
+  public void addLimit(final int numberEffectiveCall) {
     Preconditions.checkArgument(
         numberEffectiveCall <= 1, "can't add more than one effective precompile call at a time");
     counts.add(numberEffectiveCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingG2MembershipCalls.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingG2MembershipCalls.java
@@ -30,7 +30,7 @@ public class EcPairingG2MembershipCalls implements CountingOnlyModule {
   }
 
   @Override
-  public void addLimit(final int numberEffectiveCall) {
+  public void updateTally(final int numberEffectiveCall) {
     // Preconditions.checkArgument(numberEffectiveCall <= ?, "can't add more than ? effective
     // precompile call at a time");
     counts.add(numberEffectiveCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingG2MembershipCalls.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingG2MembershipCalls.java
@@ -30,7 +30,7 @@ public class EcPairingG2MembershipCalls implements CountingOnlyModule {
   }
 
   @Override
-  public void addPrecompileLimit(final int numberEffectiveCall) {
+  public void addLimit(final int numberEffectiveCall) {
     // Preconditions.checkArgument(numberEffectiveCall <= ?, "can't add more than ? effective
     // precompile call at a time");
     counts.add(numberEffectiveCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingMillerLoops.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingMillerLoops.java
@@ -31,7 +31,7 @@ public final class EcPairingMillerLoops implements CountingOnlyModule {
   }
 
   @Override
-  public void addLimit(final int numberEffectiveCall) {
+  public void updateTally(final int numberEffectiveCall) {
     // Preconditions.checkArgument(numberEffectiveCall <= ?, "can't add more than ? effective
     // precompile call at a time");
     counts.add(numberEffectiveCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingMillerLoops.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcPairingMillerLoops.java
@@ -31,7 +31,7 @@ public final class EcPairingMillerLoops implements CountingOnlyModule {
   }
 
   @Override
-  public void addPrecompileLimit(final int numberEffectiveCall) {
+  public void addLimit(final int numberEffectiveCall) {
     // Preconditions.checkArgument(numberEffectiveCall <= ?, "can't add more than ? effective
     // precompile call at a time");
     counts.add(numberEffectiveCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcRecoverEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcRecoverEffectiveCall.java
@@ -35,7 +35,7 @@ public final class EcRecoverEffectiveCall implements CountingOnlyModule {
   }
 
   @Override
-  public void addPrecompileLimit(final int numberEffectiveCall) {
+  public void addLimit(final int numberEffectiveCall) {
     checkArgument(
         numberEffectiveCall <= 1, "can't add more than one effective precompile call at a time");
     counts.add(numberEffectiveCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcRecoverEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/EcRecoverEffectiveCall.java
@@ -35,7 +35,7 @@ public final class EcRecoverEffectiveCall implements CountingOnlyModule {
   }
 
   @Override
-  public void addLimit(final int numberEffectiveCall) {
+  public void updateTally(final int numberEffectiveCall) {
     checkArgument(
         numberEffectiveCall <= 1, "can't add more than one effective precompile call at a time");
     counts.add(numberEffectiveCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/ModexpEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/ModexpEffectiveCall.java
@@ -40,7 +40,7 @@ public class ModexpEffectiveCall implements CountingOnlyModule {
   }
 
   @Override
-  public void addPrecompileLimit(final int count) {
+  public void addLimit(final int count) {
     Preconditions.checkArgument(
         count == 1 || count == MAX_VALUE,
         "Either use 1 for one effective precompile call at a time or use Integer.MAX_VALUE");

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/ModexpEffectiveCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/ModexpEffectiveCall.java
@@ -40,7 +40,7 @@ public class ModexpEffectiveCall implements CountingOnlyModule {
   }
 
   @Override
-  public void addLimit(final int count) {
+  public void updateTally(final int count) {
     Preconditions.checkArgument(
         count == 1 || count == MAX_VALUE,
         "Either use 1 for one effective precompile call at a time or use Integer.MAX_VALUE");

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/RipemdBlocks.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/RipemdBlocks.java
@@ -37,7 +37,7 @@ public final class RipemdBlocks implements CountingOnlyModule {
   }
 
   @Override
-  public void addLimit(final int count) {
+  public void updateTally(final int count) {
     final int blockCount = numberOfRipemd160locks(count);
     counts.add(blockCount);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/RipemdBlocks.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/RipemdBlocks.java
@@ -37,7 +37,7 @@ public final class RipemdBlocks implements CountingOnlyModule {
   }
 
   @Override
-  public void addPrecompileLimit(final int count) {
+  public void addLimit(final int count) {
     final int blockCount = numberOfRipemd160locks(count);
     counts.add(blockCount);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/Sha256Blocks.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/Sha256Blocks.java
@@ -37,7 +37,7 @@ public final class Sha256Blocks implements CountingOnlyModule {
   }
 
   @Override
-  public void addPrecompileLimit(final int count) {
+  public void addLimit(final int count) {
     final int blockCount = numberOfSha256Blocks(count);
     counts.add(blockCount);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/Sha256Blocks.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/Sha256Blocks.java
@@ -37,7 +37,7 @@ public final class Sha256Blocks implements CountingOnlyModule {
   }
 
   @Override
-  public void addLimit(final int count) {
+  public void updateTally(final int count) {
     final int blockCount = numberOfSha256Blocks(count);
     counts.add(blockCount);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpaddr/RlpAddrOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpaddr/RlpAddrOperation.java
@@ -47,7 +47,7 @@ public final class RlpAddrOperation extends ModuleOperation {
       Keccak keccak, Bytes32 rawDepAddress, OpCode opCode, BigInteger nonce, Address address) {
     this(rawDepAddress, opCode, nonce, address, Bytes32.ZERO, Bytes32.ZERO);
     // We hash RLP (Address + nonce) which is at most 1 + (1+20) + (1+8) = 31 bytes
-    keccak.addLimit(31);
+    keccak.updateTally(31);
   }
 
   // CREATE2 operation
@@ -61,7 +61,7 @@ public final class RlpAddrOperation extends ModuleOperation {
       BigInteger nonce) {
     this(rawHash, opCode, nonce, address, salt, kec);
     // We hash (0xFF + Address + SALT + KECCAK256(initcode)) which is 1+20+32+32 = 85 bytes
-    keccak.addLimit(85);
+    keccak.updateTally(85);
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpaddr/RlpAddrOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpaddr/RlpAddrOperation.java
@@ -25,6 +25,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.container.ModuleOperation;
+import net.consensys.linea.zktracer.module.limits.Keccak;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Address;
@@ -42,12 +43,16 @@ public final class RlpAddrOperation extends ModuleOperation {
   private final Bytes32 keccak;
 
   // CREATE operation
-  public RlpAddrOperation(Bytes32 rawDepAddress, OpCode opCode, BigInteger nonce, Address address) {
+  public RlpAddrOperation(
+      Keccak keccak, Bytes32 rawDepAddress, OpCode opCode, BigInteger nonce, Address address) {
     this(rawDepAddress, opCode, nonce, address, Bytes32.ZERO, Bytes32.ZERO);
+    // We hash RLP (Address + nonce) which is at most 1 + (1+20) + (1+8) = 31 bytes
+    keccak.addLimit(31);
   }
 
   // CREATE2 operation
   public RlpAddrOperation(
+      Keccak keccak,
       Bytes32 rawHash,
       OpCode opCode,
       Address address,
@@ -55,6 +60,8 @@ public final class RlpAddrOperation extends ModuleOperation {
       Bytes32 kec,
       BigInteger nonce) {
     this(rawHash, opCode, nonce, address, salt, kec);
+    // We hash (0xFF + Address + SALT + KECCAK256(initcode)) which is 1+20+32+32 = 85 bytes
+    keccak.addLimit(85);
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shakiradata/ShakiraData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shakiradata/ShakiraData.java
@@ -64,9 +64,9 @@ public class ShakiraData implements OperationListModule<ShakiraDataOperation> {
     wcp.callLEQ(operation.lastNBytes(), LLARGE);
 
     switch (operation.hashType()) {
-      case SHA256 -> sha256Blocks.addPrecompileLimit(operation.inputSize());
-      case KECCAK -> keccak.addPrecompileLimit(operation.inputSize());
-      case RIPEMD -> ripemdBlocks.addPrecompileLimit(operation.inputSize());
+      case SHA256 -> sha256Blocks.addLimit(operation.inputSize());
+      case KECCAK -> keccak.addLimit(operation.inputSize());
+      case RIPEMD -> ripemdBlocks.addLimit(operation.inputSize());
       default -> throw new IllegalArgumentException("Precompile type not supported by SHAKIRA");
     }
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shakiradata/ShakiraData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shakiradata/ShakiraData.java
@@ -64,9 +64,9 @@ public class ShakiraData implements OperationListModule<ShakiraDataOperation> {
     wcp.callLEQ(operation.lastNBytes(), LLARGE);
 
     switch (operation.hashType()) {
-      case SHA256 -> sha256Blocks.addLimit(operation.inputSize());
-      case KECCAK -> keccak.addLimit(operation.inputSize());
-      case RIPEMD -> ripemdBlocks.addLimit(operation.inputSize());
+      case SHA256 -> sha256Blocks.updateTally(operation.inputSize());
+      case KECCAK -> keccak.updateTally(operation.inputSize());
+      case RIPEMD -> ripemdBlocks.updateTally(operation.inputSize());
       default -> throw new IllegalArgumentException("Precompile type not supported by SHAKIRA");
     }
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/Utils.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/Utils.java
@@ -45,4 +45,18 @@ public class Utils {
         .op(staticCall ? OpCode.STATICCALL : OpCode.CALL)
         .compile();
   }
+
+  public static Bytes delegateCall(Address address) {
+    return newProgram()
+        .immediate(POPULATE_MEMORY)
+        .push(0) // retSize
+        .push(0) // retOffset
+        .op(OpCode.MSIZE) // arg size
+        .push(0) // argOffset
+        .push(1) // value
+        .push(address) // address
+        .push(100000) // gas
+        .op(OpCode.DELEGATECALL)
+        .compile();
+  }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/containers/CountOnlyModuleTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/containers/CountOnlyModuleTest.java
@@ -30,18 +30,18 @@ public class CountOnlyModuleTest {
     ZkTracer state = new ZkTracer();
     final ModexpEffectiveCall countingOnlyModule = state.getHub().modexpEffectiveCall();
 
-    countingOnlyModule.addPrecompileLimit(1);
+    countingOnlyModule.addLimit(1);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(1);
 
-    countingOnlyModule.addPrecompileLimit(1);
+    countingOnlyModule.addLimit(1);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(2);
 
     countingOnlyModule.popTransactionBundle();
     assertThat(countingOnlyModule.lineCount()).isEqualTo(0);
 
-    countingOnlyModule.addPrecompileLimit(1);
+    countingOnlyModule.addLimit(1);
     countingOnlyModule.commitTransactionBundle();
-    countingOnlyModule.addPrecompileLimit(1);
+    countingOnlyModule.addLimit(1);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(2);
     countingOnlyModule.popTransactionBundle();
     assertThat(countingOnlyModule.lineCount()).isEqualTo(1);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/containers/CountOnlyModuleTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/containers/CountOnlyModuleTest.java
@@ -30,18 +30,18 @@ public class CountOnlyModuleTest {
     ZkTracer state = new ZkTracer();
     final ModexpEffectiveCall countingOnlyModule = state.getHub().modexpEffectiveCall();
 
-    countingOnlyModule.addLimit(1);
+    countingOnlyModule.updateTally(1);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(1);
 
-    countingOnlyModule.addLimit(1);
+    countingOnlyModule.updateTally(1);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(2);
 
     countingOnlyModule.popTransactionBundle();
     assertThat(countingOnlyModule.lineCount()).isEqualTo(0);
 
-    countingOnlyModule.addLimit(1);
+    countingOnlyModule.updateTally(1);
     countingOnlyModule.commitTransactionBundle();
-    countingOnlyModule.addLimit(1);
+    countingOnlyModule.updateTally(1);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(2);
     countingOnlyModule.popTransactionBundle();
     assertThat(countingOnlyModule.lineCount()).isEqualTo(1);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/KeccakBlocksTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/KeccakBlocksTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright ConsenSys Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.zktracer.module.limits;
+
+import static net.consensys.linea.zktracer.module.limits.Keccak.numberOfKeccakBloc;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import net.consensys.linea.testing.BytecodeCompiler;
+import net.consensys.linea.testing.ToyAccount;
+import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
+import net.consensys.linea.testing.ToyTransaction;
+import net.consensys.linea.zktracer.opcode.OpCode;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.crypto.KeyPair;
+import org.hyperledger.besu.crypto.SECP256K1;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.junit.jupiter.api.Test;
+
+public class KeccakBlocksTests {
+
+  @Test
+  void twoSuccessfullL2l1Logs() {
+
+    // sender account
+    final KeyPair senderKeyPair = new SECP256K1().generateKeyPair();
+    final Address senderAddress =
+        Address.extract(Hash.hash(senderKeyPair.getPublicKey().getEncodedBytes()));
+    final ToyAccount senderAccount =
+        ToyAccount.builder().balance(Wei.fromEth(123)).nonce(12).address(senderAddress).build();
+
+    // receiver account
+    final ToyAccount recipient =
+        ToyAccount.builder()
+            .balance(Wei.fromEth(1))
+            .address(Address.wrap(Bytes.repeat((byte) 1, Address.SIZE)))
+            .code(
+                BytecodeCompiler.newProgram()
+                    // CREATE
+                    .push(0) // size
+                    .push(0) // offset
+                    .push(0) // value
+                    .op(OpCode.CREATE)
+                    // CREATE 2
+                    .push(0) // salt
+                    .push(0) // size
+                    .push(0) // offset
+                    .push(0) // value
+                    .op(OpCode.CREATE2)
+                    .compile())
+            .build();
+
+    final Transaction tx =
+        ToyTransaction.builder()
+            .sender(senderAccount)
+            .to(recipient)
+            .keyPair(senderKeyPair)
+            .gasLimit(300000L)
+            .value(Wei.of(1000))
+            .build();
+
+    final ToyExecutionEnvironmentV2 toyWorld =
+        ToyExecutionEnvironmentV2.builder()
+            .accounts(List.of(senderAccount, recipient))
+            .transaction(tx)
+            .zkTracerValidator(zkTracer -> {})
+            .build();
+
+    toyWorld.run();
+
+    final Keccak keccak = toyWorld.getHub().keccak();
+    final L2Block l2Block = toyWorld.getHub().l2Block();
+
+    // check lineCount of Keccak
+    final int txRlpSize = tx.encoded().size();
+    final int txKeccak =
+        numberOfKeccakBloc(txRlpSize)
+            + 1
+            + 1; // numberOfKeccakBloc(txRlpSize) + 1 for the tx + 2 for EcRecover
+    final int rlpAddrKeccak = 1 + 1; // 1 for CREATE, 1 for CRETAE2
+    assertEquals(txKeccak + rlpAddrKeccak, keccak.lineCount());
+
+    // check lineCount of l2Block
+    assertEquals(txRlpSize + 20 + 38, l2Block.lineCount());
+  }
+}

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/KeccakBlocksTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/KeccakBlocksTests.java
@@ -98,6 +98,12 @@ public class KeccakBlocksTests {
     assertEquals(txKeccak + rlpAddrKeccak, keccak.lineCount());
 
     // check lineCount of l2Block
-    assertEquals(txRlpSize + 20 + 38, l2Block.lineCount());
+    assertEquals(
+        txRlpSize
+            // nbTransaction * Address.SIZE
+            + Address.SIZE
+            // nbBlock * (TIMESTAMP_BYTESIZE + Hash.SIZE + NB_TX_IN_BLOCK_BYTESIZE)
+            + 38,
+        l2Block.lineCount());
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/KeccakBlocksTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/KeccakBlocksTests.java
@@ -93,7 +93,7 @@ public class KeccakBlocksTests {
     final int txKeccak =
         numberOfKeccakBloc(txRlpSize)
             + 1
-            + 1; // numberOfKeccakBloc(txRlpSize) + 1 for the tx + 2 for EcRecover
+            + 1; // numberOfKeccakBloc(txRlpSize) + 1 for the tx + 1 for EcRecover
     final int rlpAddrKeccak = 1 + 1; // 1 for CREATE, 1 for CRETAE2
     assertEquals(txKeccak + rlpAddrKeccak, keccak.lineCount());
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/L2L1LogsTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/L2L1LogsTests.java
@@ -15,7 +15,7 @@
 
 package net.consensys.linea.zktracer.module.limits;
 
-import static net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration.SEPOLIA_DEFAULT;
+import static net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration.TEST_DEFAULT;
 import static net.consensys.linea.zktracer.Utils.call;
 import static net.consensys.linea.zktracer.Utils.delegateCall;
 import static org.junit.jupiter.api.Assertions.*;
@@ -48,11 +48,11 @@ public class L2L1LogsTests {
     final ToyAccount l2l1LogSMC =
         ToyAccount.builder()
             .balance(Wei.fromEth(1))
-            .address(SEPOLIA_DEFAULT.contract())
+            .address(TEST_DEFAULT.contract())
             .code(
                 BytecodeCompiler.newProgram()
                     // LOG1 with right topic, and no data
-                    .push(SEPOLIA_DEFAULT.topic()) // topic
+                    .push(TEST_DEFAULT.topic()) // topic
                     .push(0) //  size
                     .push(0) // offset
                     .op(OpCode.LOG1)
@@ -63,7 +63,7 @@ public class L2L1LogsTests {
                     .push(Bytes.of(4)) // topic 4
                     .push(Bytes.of(3)) // topic 3
                     .push(Bytes.of(2)) // topic 2
-                    .push(SEPOLIA_DEFAULT.topic()) // topic 1
+                    .push(TEST_DEFAULT.topic()) // topic 1
                     .push(15) //  size
                     .push(0) // offset
                     .op(OpCode.LOG1)
@@ -110,7 +110,7 @@ public class L2L1LogsTests {
             .code(
                 BytecodeCompiler.newProgram()
                     // LOG1 with right topic, and no data
-                    .push(SEPOLIA_DEFAULT.topic()) // topic
+                    .push(TEST_DEFAULT.topic()) // topic
                     .push(0) //  size
                     .push(0) // offset
                     .op(OpCode.LOG1)
@@ -124,7 +124,7 @@ public class L2L1LogsTests {
             .code(
                 BytecodeCompiler.newProgram()
                     // LOG1 with right topic, and no data
-                    .push(SEPOLIA_DEFAULT.topic()) // topic
+                    .push(TEST_DEFAULT.topic()) // topic
                     .push(0) //  size
                     .push(0) // offset
                     .op(OpCode.LOG1)
@@ -138,11 +138,11 @@ public class L2L1LogsTests {
     final ToyAccount l2l1LogSMC =
         ToyAccount.builder()
             .balance(Wei.fromEth(1))
-            .address(SEPOLIA_DEFAULT.contract())
+            .address(TEST_DEFAULT.contract())
             .code(
                 BytecodeCompiler.newProgram()
                     // LOG2 with right topic, not at the right place
-                    .push(SEPOLIA_DEFAULT.topic()) // topic 2
+                    .push(TEST_DEFAULT.topic()) // topic 2
                     .push(Bytes.of(1)) // topic 1
                     .push(0) //  size
                     .push(0) // offset

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/L2L1LogsTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/L2L1LogsTests.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright ConsenSys Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.zktracer.module.limits;
+
+import static net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration.SEPOLIA_DEFAULT;
+import static net.consensys.linea.zktracer.Utils.call;
+import static net.consensys.linea.zktracer.Utils.delegateCall;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import net.consensys.linea.testing.*;
+import net.consensys.linea.zktracer.opcode.OpCode;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.crypto.KeyPair;
+import org.hyperledger.besu.crypto.SECP256K1;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.junit.jupiter.api.Test;
+
+public class L2L1LogsTests {
+
+  @Test
+  void twoSuccessfullL2l1Logs() {
+    // sender account
+    final KeyPair senderKeyPair = new SECP256K1().generateKeyPair();
+    final Address senderAddress =
+        Address.extract(Hash.hash(senderKeyPair.getPublicKey().getEncodedBytes()));
+    final ToyAccount senderAccount =
+        ToyAccount.builder().balance(Wei.fromEth(123)).nonce(12).address(senderAddress).build();
+
+    // receiver account: L2L1Logs account
+    final ToyAccount l2l1LogSMC =
+        ToyAccount.builder()
+            .balance(Wei.fromEth(1))
+            .address(SEPOLIA_DEFAULT.contract())
+            .code(
+                BytecodeCompiler.newProgram()
+                    // LOG1 with right topic, and no data
+                    .push(SEPOLIA_DEFAULT.topic()) // topic
+                    .push(0) //  size
+                    .push(0) // offset
+                    .op(OpCode.LOG1)
+                    // LOG4 with right first topic, and useless data
+                    .push(2) // value
+                    .push(2) // offset
+                    .op(OpCode.MSTORE)
+                    .push(Bytes.of(4)) // topic 4
+                    .push(Bytes.of(3)) // topic 3
+                    .push(Bytes.of(2)) // topic 2
+                    .push(SEPOLIA_DEFAULT.topic()) // topic 1
+                    .push(15) //  size
+                    .push(0) // offset
+                    .op(OpCode.LOG1)
+                    .compile())
+            .build();
+
+    final Transaction tx =
+        ToyTransaction.builder()
+            .sender(senderAccount)
+            .to(l2l1LogSMC)
+            .keyPair(senderKeyPair)
+            .gasLimit(300000L)
+            .value(Wei.of(1000))
+            .build();
+
+    final ToyExecutionEnvironmentV2 toyWorld =
+        ToyExecutionEnvironmentV2.builder()
+            .accounts(List.of(senderAccount, l2l1LogSMC))
+            .transaction(tx)
+            .zkTracerValidator(zkTracer -> {})
+            .build();
+
+    toyWorld.run();
+
+    final L2L1Logs l2l1Logs = toyWorld.getHub().l2L1Logs();
+
+    // We made two LOGs, one with 1 topic, and one with 4 topics and data
+    assertEquals(2, l2l1Logs.lineCount());
+  }
+
+  @Test
+  void unsuccessfullL2l1Logs() {
+    // sender account
+    final KeyPair senderKeyPair = new SECP256K1().generateKeyPair();
+    final Address senderAddress =
+        Address.extract(Hash.hash(senderKeyPair.getPublicKey().getEncodedBytes()));
+    final ToyAccount senderAccount =
+        ToyAccount.builder().balance(Wei.fromEth(123)).nonce(12).address(senderAddress).build();
+
+    final ToyAccount LOG_ACCOUNT =
+        ToyAccount.builder()
+            .balance(Wei.fromEth(1))
+            .address(Address.wrap(Bytes.repeat((byte) 1, Address.SIZE)))
+            .code(
+                BytecodeCompiler.newProgram()
+                    // LOG1 with right topic, and no data
+                    .push(SEPOLIA_DEFAULT.topic()) // topic
+                    .push(0) //  size
+                    .push(0) // offset
+                    .op(OpCode.LOG1)
+                    .compile())
+            .build();
+
+    final ToyAccount LOG_ACCOUNT_AND_REVERT =
+        ToyAccount.builder()
+            .balance(Wei.fromEth(1))
+            .address(Address.wrap(Bytes.repeat((byte) 2, Address.SIZE)))
+            .code(
+                BytecodeCompiler.newProgram()
+                    // LOG1 with right topic, and no data
+                    .push(SEPOLIA_DEFAULT.topic()) // topic
+                    .push(0) //  size
+                    .push(0) // offset
+                    .op(OpCode.LOG1)
+                    .push(0)
+                    .push(0)
+                    .op(OpCode.REVERT)
+                    .compile())
+            .build();
+
+    // receiver account: L2L1Logs account
+    final ToyAccount l2l1LogSMC =
+        ToyAccount.builder()
+            .balance(Wei.fromEth(1))
+            .address(SEPOLIA_DEFAULT.contract())
+            .code(
+                BytecodeCompiler.newProgram()
+                    // LOG2 with right topic, not at the right place
+                    .push(SEPOLIA_DEFAULT.topic()) // topic 2
+                    .push(Bytes.of(1)) // topic 1
+                    .push(0) //  size
+                    .push(0) // offset
+                    .op(OpCode.LOG2)
+                    // DELEGATE CALL to a contract that will LOG1 then revert
+                    .immediate(delegateCall(LOG_ACCOUNT_AND_REVERT.getAddress()))
+                    // LOG1 with right topic, but not right address
+                    .immediate(call(LOG_ACCOUNT.getAddress(), false))
+                    .compile())
+            .build();
+
+    final Transaction tx =
+        ToyTransaction.builder()
+            .sender(senderAccount)
+            .to(l2l1LogSMC)
+            .keyPair(senderKeyPair)
+            .gasLimit(300000L)
+            .value(Wei.of(1000))
+            .build();
+
+    final ToyExecutionEnvironmentV2 toyWorld =
+        ToyExecutionEnvironmentV2.builder()
+            .accounts(List.of(senderAccount, l2l1LogSMC, LOG_ACCOUNT_AND_REVERT, LOG_ACCOUNT))
+            .transaction(tx)
+            .zkTracerValidator(zkTracer -> {})
+            .build();
+
+    toyWorld.run();
+
+    final L2L1Logs l2l1Logs = toyWorld.getHub().l2L1Logs();
+
+    // We made two LOGs, one with 1 topic, and one with 4 topics and data
+    assertEquals(0, l2l1Logs.lineCount());
+  }
+}

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/precompileLimits/BlakeRoundsTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/precompileLimits/BlakeRoundsTests.java
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.zktracer.module.precompileLimits;
+package net.consensys.linea.zktracer.module.limits.precompileLimits;
 
 import static java.lang.Integer.MAX_VALUE;
 import static net.consensys.linea.zktracer.module.blake2fmodexpdata.BlakeModexpDataOperation.BLAKE2f_R_SIZE;

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/precompileLimits/ModexpIllegalOperationTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/precompileLimits/ModexpIllegalOperationTests.java
@@ -28,12 +28,12 @@ public class ModexpIllegalOperationTests {
     final ZkTracer state = new ZkTracer();
     final ModexpEffectiveCall countingOnlyModule = state.getHub().modexpEffectiveCall();
 
-    countingOnlyModule.addLimit(1);
+    countingOnlyModule.updateTally(1);
 
-    countingOnlyModule.addLimit(MAX_VALUE);
+    countingOnlyModule.updateTally(MAX_VALUE);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(MAX_VALUE);
 
-    countingOnlyModule.addLimit(MAX_VALUE);
+    countingOnlyModule.updateTally(MAX_VALUE);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(MAX_VALUE);
 
     countingOnlyModule.popTransactionBundle();
@@ -45,12 +45,12 @@ public class ModexpIllegalOperationTests {
     final ZkTracer state = new ZkTracer();
     final ModexpEffectiveCall countingOnlyModule = state.getHub().modexpEffectiveCall();
 
-    countingOnlyModule.addLimit(1);
+    countingOnlyModule.updateTally(1);
 
-    countingOnlyModule.addLimit(MAX_VALUE);
+    countingOnlyModule.updateTally(MAX_VALUE);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(MAX_VALUE);
 
-    countingOnlyModule.addLimit(1);
+    countingOnlyModule.updateTally(1);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(MAX_VALUE);
 
     countingOnlyModule.popTransactionBundle();
@@ -62,10 +62,10 @@ public class ModexpIllegalOperationTests {
     final ZkTracer state = new ZkTracer();
     final ModexpEffectiveCall countingOnlyModule = state.getHub().modexpEffectiveCall();
 
-    countingOnlyModule.addLimit(MAX_VALUE);
+    countingOnlyModule.updateTally(MAX_VALUE);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(MAX_VALUE);
 
-    countingOnlyModule.addLimit(MAX_VALUE);
+    countingOnlyModule.updateTally(MAX_VALUE);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(MAX_VALUE);
 
     countingOnlyModule.popTransactionBundle();

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/precompileLimits/ModexpIllegalOperationTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/precompileLimits/ModexpIllegalOperationTests.java
@@ -13,7 +13,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.zktracer.module.precompileLimits;
+package net.consensys.linea.zktracer.module.limits.precompileLimits;
 
 import static java.lang.Integer.MAX_VALUE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/precompileLimits/ModexpIllegalOperationTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/precompileLimits/ModexpIllegalOperationTests.java
@@ -28,12 +28,12 @@ public class ModexpIllegalOperationTests {
     final ZkTracer state = new ZkTracer();
     final ModexpEffectiveCall countingOnlyModule = state.getHub().modexpEffectiveCall();
 
-    countingOnlyModule.addPrecompileLimit(1);
+    countingOnlyModule.addLimit(1);
 
-    countingOnlyModule.addPrecompileLimit(MAX_VALUE);
+    countingOnlyModule.addLimit(MAX_VALUE);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(MAX_VALUE);
 
-    countingOnlyModule.addPrecompileLimit(MAX_VALUE);
+    countingOnlyModule.addLimit(MAX_VALUE);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(MAX_VALUE);
 
     countingOnlyModule.popTransactionBundle();
@@ -45,12 +45,12 @@ public class ModexpIllegalOperationTests {
     final ZkTracer state = new ZkTracer();
     final ModexpEffectiveCall countingOnlyModule = state.getHub().modexpEffectiveCall();
 
-    countingOnlyModule.addPrecompileLimit(1);
+    countingOnlyModule.addLimit(1);
 
-    countingOnlyModule.addPrecompileLimit(MAX_VALUE);
+    countingOnlyModule.addLimit(MAX_VALUE);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(MAX_VALUE);
 
-    countingOnlyModule.addPrecompileLimit(1);
+    countingOnlyModule.addLimit(1);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(MAX_VALUE);
 
     countingOnlyModule.popTransactionBundle();
@@ -62,10 +62,10 @@ public class ModexpIllegalOperationTests {
     final ZkTracer state = new ZkTracer();
     final ModexpEffectiveCall countingOnlyModule = state.getHub().modexpEffectiveCall();
 
-    countingOnlyModule.addPrecompileLimit(MAX_VALUE);
+    countingOnlyModule.addLimit(MAX_VALUE);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(MAX_VALUE);
 
-    countingOnlyModule.addPrecompileLimit(MAX_VALUE);
+    countingOnlyModule.addLimit(MAX_VALUE);
     assertThat(countingOnlyModule.lineCount()).isEqualTo(MAX_VALUE);
 
     countingOnlyModule.popTransactionBundle();


### PR DESCRIPTION
Issues that are fixed:
- we weren't calling those modules at traceEndTx, so there were never triggered, so their lineCount remained at 0 all the time.
- for l2l1Logs, we were counting the sum of the log data size, instead of the nb of calls
-  all the computation were completely outdated, reviewed with @AlexandreBelling 