### PR TITLE
fix: reference tests build failure

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -9,4 +9,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@12a62d2
+      run: go install github.com/consensys/go-corset/cmd/go-corset@v1.0.0

--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -491,7 +491,13 @@ public class BlockchainReferenceTestTools {
 
     zkTracer.traceEndConflation(worldState);
 
-    ExecutionEnvironment.checkTracer(zkTracer, CORSET_VALIDATOR, Optional.of(log));
+    ExecutionEnvironment.checkTracer(
+        zkTracer,
+        CORSET_VALIDATOR,
+        Optional.of(log),
+        // NOTE: just use 0 for start and end block here, since this information is not used.
+        0,
+        0);
     assertThat(blockchain.getChainHeadHash()).isEqualTo(spec.getLastBlockHash());
   }
 


### PR DESCRIPTION
This fixes the reference tests build failure by adding in the missing constants for the start/end block.