### PR TITLE
feat: remove tracing module line counts from metadata

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -109,7 +109,7 @@ public class ZkTracer implements ConflationAwareOperationTracer {
     metadata.put("conflation", range);
     // include line counts
     final Map<String, String> lineCounts = new HashMap<>();
-    for (Module m : hub.getModulesToCount()) {
+    for (Module m : hub.getTracelessModules()) {
       lineCounts.put(m.moduleKey(), Integer.toString(m.lineCount()));
     }
     metadata.put("lineCounts", lineCounts);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -289,10 +289,7 @@ public class ZkTracer implements ConflationAwareOperationTracer {
     }
   }
 
-  /**
-   * When called, erase all tracing related to the bundle of all transactions since the last {@link
-   * commitTransactionBundle()}
-   */
+  /** When called, erase all tracing related to the bundle of all transactions since the last. */
   public void popTransactionBundle() {
     hub.popTransactionBundle();
   }
@@ -301,6 +298,13 @@ public class ZkTracer implements ConflationAwareOperationTracer {
     hub.commitTransactionBundle();
   }
 
+  /**
+   * Returns the total line count (i.e. including spillage) for both tracing and non-tracing
+   * modules. This method is called directly by the sequencer to determine whether a given
+   * transaction should go ahead. This method is also used to feed the line counting RPC end points.
+   *
+   * @return
+   */
   public Map<String, Integer> getModulesLineCount() {
     maybeThrowTracingExceptions();
     final HashMap<String, Integer> modulesLineCount = new HashMap<>();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -354,10 +354,7 @@ public class Hub implements Module {
    * @return the modules to count
    */
   public List<Module> getModulesToCount() {
-    return Stream.concat(
-            getModulesToTrace().stream(),
-            getTracelessModules().stream())
-        .toList();
+    return Stream.concat(getModulesToTrace().stream(), getTracelessModules().stream()).toList();
   }
 
   public Hub(final ChainConfig chain) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -254,7 +254,7 @@ public class Hub implements Module {
   @Getter private final BlakeRounds blakeRounds = new BlakeRounds();
 
   /** Those modules are used only by the sequencer, they don't have associated trace */
-  private List<Module> tracelessModules() {
+  public List<Module> getTracelessModules() {
     return List.of(
         blockTransactions,
         keccak,
@@ -348,45 +348,15 @@ public class Hub implements Module {
   }
 
   /**
-   * List all the modules for which to generate counters. Intersects with, but is not equal to
-   * {@code getModulesToTrace}.
+   * List all the modules for which to generate counters. This includes all the tracing modules (
+   * {@code getModulesToTrace}) as well as all the so-called traceless modules.
    *
    * @return the modules to count
    */
   public List<Module> getModulesToCount() {
     return Stream.concat(
-            Stream.of(
-                this,
-                add,
-                bin,
-                blakeModexpData,
-                blockdata,
-                blockhash,
-                ecData,
-                exp,
-                ext,
-                euc,
-                gas,
-                logData,
-                logInfo,
-                mmu,
-                mmio,
-                mod,
-                mul,
-                mxp,
-                oob,
-                rlpAddr,
-                rlpTxn,
-                rlpTxnRcpt,
-                rom,
-                romLex,
-                shakiraData,
-                shf,
-                stp,
-                trm,
-                txnData,
-                wcp),
-            Stream.concat(refTableModules.stream(), tracelessModules().stream()))
+            getModulesToTrace().stream(),
+            getTracelessModules().stream())
         .toList();
   }
 
@@ -441,7 +411,7 @@ public class Hub implements Module {
                     wcp, /* WARN: must be called BEFORE txnData */
                     txnData,
                     blockdata /* WARN: must be called AFTER txnData */),
-                tracelessModules().stream())
+                getTracelessModules().stream())
             .toList();
   }
 


### PR DESCRIPTION
This PR removes line counts from the embedded metadata for _tracing_ modules.  Thus, only line counts for non-tracing modules is retained.