### PR TITLE
fix: nightly tests

### DIFF
--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -29,7 +29,6 @@ jobs:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -vw --ansi-escapes=false --report --mir
-          ZKEVM_BIN: "zkevm_for_old_replay_tests.bin"
           NIGHTLY_TESTS_PARALLELISM: 2
 
       - name: Upload test report


### PR DESCRIPTION
This fixes the nightly tests by using the default `zkevm.bin` target rather than the older `zkevm_for_old_replay_tests.bin` which is no longer used.