### PR TITLE
Fix incorrect SLF4J logging format in validate method

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/corset/GoCorsetValidator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/corset/GoCorsetValidator.java
@@ -83,7 +83,7 @@ public class GoCorsetValidator extends AbstractExecutable {
         // Execute corset with a 5s timeout.
         outcome = super.exec(5, commands);
       } catch (Throwable e) {
-        log.error("Corset validation has thrown an exception: %s".formatted(e.getMessage()));
+        log.error("Corset validation has thrown an exception: {}", e.getMessage(), e);
         throw new RuntimeException(e);
       }
       // Manage coverage report


### PR DESCRIPTION
The validate method was incorrectly using .formatted() for logging an exception message. This is not compatible with SLF4J, which expects {} placeholders for argument substitution. As a result, the log message would not be properly formatted, and the stack trace would not be logged. Replaced .formatted() with proper SLF4J syntax. Ensured that the exception stack trace is correctly captured by passing e as the last argument.

