### PR TITLE
feat: sepearate our precompile call tests

### DIFF
--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup Test Environment
         uses: ./.github/actions/setup-environment
-        with:
-          go-corset: true
 
       - name: Generate General State Reference Tests
         run: ./gradlew generateGeneralStateReferenceTests -Dorg.gradle.caching=true

--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup Test Environment
         uses: ./.github/actions/setup-environment
-        with:
-          go-corset: true
 
       - name: Run Nightly tests
         run: GOMEMLIMIT=32GiB ./gradlew nightlyTests

--- a/.github/workflows/gradle-prc-call-tests.yml
+++ b/.github/workflows/gradle-prc-call-tests.yml
@@ -1,4 +1,4 @@
-name: Weekly Replay Tests
+name: Weekly Precompile Call Tests
 
 on:
   schedule:
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  weekly-replay-tests:
+  weekly-prc-call-tests:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     continue-on-error: true
     steps:
@@ -23,33 +23,19 @@ jobs:
       - name: Setup Test Environment
         uses: ./.github/actions/setup-environment
 
-      - name: Run Weekly tests
-        run: GOMEMLIMIT=55GiB ./gradlew weeklyTests
+      - name: Run Precompile Call tests
+        run: GOMEMLIMIT=10GiB ./gradlew prcCallTests
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
-          WEEKLY_TESTS_PARALLELISM: 2
+          PRC_CALL_TESTS_PARALLELISM: 128
           GOCORSET_FLAGS: -vw -b1024 --ansi-escapes=false --report --air
 
-      - name: Upload test report
+      - name: Upload weekly ecpairing test report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: weekly-tests-report
+          name: weekly-ecpairing-tests-report
           path: arithmetization/build/reports/tests/**/*
-
-      - name: Upload jacoco weekly tests coverage report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: jacoco-weekly-tests-coverage-report
-          path: arithmetization/build/reports/jacoco/jacocoWeeklyTestsReport/**/*
-
-      - name: Upload jacoco weekly tests exec file
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: jacoco-weekly-tests-exec-file
-          path: arithmetization/build/jacoco/weeklyTests.exec
 
       - name: Failure Notification
         if: ${{ failure() || cancelled() }}
@@ -58,5 +44,5 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: |
-             name: "Weekly (Go-Corset)"
-             status: "${{ job.status }}"
+            name: "Weekly EcPairing (Go-Corset)"
+            status: "${{ job.status }}"

--- a/.github/workflows/gradle-prc-call-tests.yml
+++ b/.github/workflows/gradle-prc-call-tests.yml
@@ -1,6 +1,7 @@
 name: Weekly Precompile Call Tests
 
 on:
+  pull_request:
   schedule:
     - cron: "0 4 * * 1"
   workflow_dispatch:

--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -67,7 +67,6 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           enable-ssh: ${{ inputs.tests-with-ssh }}
-          go-corset: true
 
       - name: Run unit tests
         run: GOMEMLIMIT=26GiB ./gradlew :arithmetization:test
@@ -115,7 +114,6 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           enable-ssh: ${{ inputs.tests-with-ssh }}
-          go-corset: true
 
       - name: Run replay tests
         run: GOMEMLIMIT=26GiB ./gradlew :arithmetization:fastReplayTests

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -42,8 +42,6 @@ jobs:
 
       - name: Setup Test Environment
         uses: ./.github/actions/setup-environment
-        with:
-          go-corset: true
 
       - name: Generate block chain reference tests
         run: ./gradlew :reference-tests:generateBlockchainReferenceTests -Dorg.gradle.caching=true

--- a/.github/workflows/validate-one-blockchain-test.yml
+++ b/.github/workflows/validate-one-blockchain-test.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Setup Test Environment
         uses: ./.github/actions/setup-environment
-        with:
-          go-corset: true
 
       - name: Run Reference Blockchain test sample
         run: ./gradlew referenceBlockchainTests -x spotlessCheck --tests "BlockchainReferenceTest_104"

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/Tests.java
@@ -19,6 +19,7 @@ import static net.consensys.linea.zktracer.instructionprocessing.callTests.prc.G
 import static net.consensys.linea.zktracer.instructionprocessing.callTests.prc.ecadd.MemoryContents.WELL_FORMED_POINTS;
 import static net.consensys.linea.zktracer.opcode.OpCode.*;
 
+import java.util.ArrayList;
 import java.util.stream.Stream;
 
 import net.consensys.linea.testing.BytecodeCompiler;
@@ -29,8 +30,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.Arguments;
 
-@Disabled
-@Tag("weekly")
+@Tag("prc-calltests")
 public class Tests extends PrecompileCallTests<CallParameters> {
 
   /** Non-parametric test to make sure things are working as expected. */

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/Tests.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.Arguments;
 
 @Disabled
-@Tag("weekly")
+@Tag("prc-calltests")
 public class Tests extends PrecompileCallTests<CallParameters> {
 
   public static Stream<Arguments> parameterGeneration() {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecpairing/Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecpairing/Tests.java
@@ -20,7 +20,7 @@ import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framewor
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.provider.Arguments;
 
-@Tag("weekly-ecpairing")
+@Tag("prc-calltests")
 public class Tests extends PrecompileCallTests<CallParameters> {
 
   public static Stream<Arguments> parameterGeneration() {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/Tests.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.provider.Arguments;
 
 @Disabled
-@Tag("weekly")
+@Tag("prc-calltests")
 public class Tests extends PrecompileCallTests<CallParameters> {
   public static Stream<Arguments> parameterGeneration() {
     return ParameterGeneration.parameterGeneration();

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/hash/Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/hash/Tests.java
@@ -62,7 +62,7 @@ import org.junit.jupiter.params.provider.Arguments;
  * <p>- play with (precompile) return data
  */
 @Disabled
-@Tag("weekly")
+@Tag("prc-calltests")
 public class Tests extends PrecompileCallTests<CallParameters> {
 
   /** Non-parametric test to make sure things are working as expected. */

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/modexp/Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/modexp/Tests.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.Arguments;
 
 @Disabled
-@Tag("weekly")
+@Tag("prc-calltests")
 public class Tests extends PrecompileCallTests<CallParameters> {
 
   public static Stream<Arguments> parameterGeneration() {

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -225,12 +225,12 @@ tasks.register("weeklyTests", Test) {
   systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
   systemProperty("junit.jupiter.execution.parallel.config.strategy", "fixed")
   systemProperty("junit.jupiter.execution.parallel.config.fixed.parallelism",
-          System.getenv().getOrDefault("WEEKLY_TESTS_PARALLELISM", "1").toInteger())
+          System.getenv().getOrDefault("WEEKLY_TESTS_PARALLELISM", "16").toInteger())
 
   useJUnitPlatform {
     excludeTags("nightly")
     excludeTags("replay")
-    excludeTags("weekly-ecpairing")
+    excludeTags("prc-calltests")
     includeTags("weekly")
   }
   finalizedBy(jacocoWeeklyTestsReport)
@@ -257,8 +257,7 @@ tasks.register("jacocoUnitFastReplayWeeklyNightlyReferenceBlockchainAndStateTest
   executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
 }
 
-// Gradle task to concatenate Unit, FastReplay, Nightly, Weekly and Reference Blockchain and State tests exec files
-tasks.register("weeklyEcPairingTests", Test) {
+tasks.register("prcCallTests", Test) {
   dependsOn(buildZkevmBin)
 
   systemProperty("junit.jupiter.execution.parallel.enabled", true)
@@ -266,13 +265,13 @@ tasks.register("weeklyEcPairingTests", Test) {
   systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
   systemProperty("junit.jupiter.execution.parallel.config.strategy", "fixed")
   systemProperty("junit.jupiter.execution.parallel.config.fixed.parallelism",
-          System.getenv().getOrDefault("WEEKLY_TESTS_PARALLELISM", "1").toInteger())
+          System.getenv().getOrDefault("PRC_CALL_TESTS_PARALLELISM", "8").toInteger())
 
   useJUnitPlatform {
     excludeTags("nightly")
     excludeTags("replay")
     excludeTags("weekly")
-    includeTags("weekly-ecpairing")
+    includeTags("prc-calltests")
   }
 }
 


### PR DESCRIPTION
Since the precompile call tests have a different dynamic from other weekly tests, have moved all of them into the group that was previously the weekly ecpairing suite.  That way, the parallelism for this group can be dramatically increased without causing other (costly and unrelated) weekly tests from failing.