### PR TITLE
feat: upgrade warnings to errors in go-corset

### DIFF
--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -32,7 +32,7 @@ jobs:
           REFERENCE_TESTS_PARALLELISM: 4
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
-          GOCORSET_FLAGS: -vw -b1024 --ansi-escapes=false --report --air
+          GOCORSET_FLAGS: -v -b1024 --ansi-escapes=false --report --air
 
       - name: Upload test report
         if: always()

--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
-          GOCORSET_FLAGS: -vw --ansi-escapes=false --report --mir
+          GOCORSET_FLAGS: -v --ansi-escapes=false --report --mir
           NIGHTLY_TESTS_PARALLELISM: 2
 
       - name: Upload test report

--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
-          GOCORSET_FLAGS: -b1024 -vw --ansi-escapes=false --report --air
+          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
           UNIT_TESTS_PARALLELISM: 4
 
       - name: Upload test report
@@ -119,7 +119,7 @@ jobs:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           REPLAY_TESTS_PARALLELISM: 4
           CORSET_FLAGS: disable
-          GOCORSET_FLAGS: -b1024 -vw --ansi-escapes=false --report --air
+          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
 
       - name: Upload test report
         if: ${{ always() }}

--- a/.github/workflows/gradle-weekly-tests.yml
+++ b/.github/workflows/gradle-weekly-tests.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           WEEKLY_TESTS_PARALLELISM: 26
-          GOCORSET_FLAGS: -vw -b1024 --ansi-escapes=false --report --hir
+          GOCORSET_FLAGS: -v -b1024 --ansi-escapes=false --report --hir
 
       - name: Upload test report
         if: always()
@@ -76,7 +76,7 @@ jobs:
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           WEEKLY_TESTS_PARALLELISM: 20
-          GOCORSET_FLAGS: -vw -b1024 --ansi-escapes=false --report --hir
+          GOCORSET_FLAGS: -v -b1024 --ansi-escapes=false --report --hir
 
       - name: Upload prc calls test report
         if: always()

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -69,7 +69,7 @@ jobs:
           REFERENCE_TESTS_PARALLELISM: 4
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
-          GOCORSET_FLAGS: -b1024 -vw --ansi-escapes=false --report --air
+          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
           FAILED_TEST_JSON_DIRECTORY: ${{ github.workspace }}/tmp/${{ steps.extract_branch.outputs.branch }}/
           FAILED_MODULE: ${{ inputs.failed_module || '' }}
           FAILED_CONSTRAINT: ${{ inputs.failed_constraint || '' }}

--- a/.github/workflows/validate-one-blockchain-test.yml
+++ b/.github/workflows/validate-one-blockchain-test.yml
@@ -28,4 +28,4 @@ jobs:
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
-          GOCORSET_FLAGS: -b1024 -vw --ansi-escapes=false --report --air
+          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air

--- a/arithmetization/src/main/java/net/consensys/linea/corset/GoCorsetValidator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/corset/GoCorsetValidator.java
@@ -122,7 +122,7 @@ public class GoCorsetValidator extends AbstractExecutable {
     ArrayList<String> options = new ArrayList<>();
     // Determine options to use (either default or override)
     String flags =
-        System.getenv().getOrDefault("GOCORSET_FLAGS", "-w --report --report-context 2 --hir ");
+        System.getenv().getOrDefault("GOCORSET_FLAGS", "--report --report-context 2 --hir ");
     // Determine whether to generate a coverage report (or not).
     String coverage = System.getenv().get("GOCORSET_COVERAGE");
     // Specify corset binary


### PR DESCRIPTION
This now prevents warnings from being reported for traces which are invalid in some way.  Since Trace.java files are now automatically generated, such errors should never arise in practice.  Hiding them as warnings is potentially hazardous.  This was originally done only to retain backwards compatibility with the original tool.