### PR TITLE
configure go-corset and linea-constraints

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -9,4 +9,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@v1.0.7
+      run: go install github.com/consensys/go-corset/cmd/go-corset@v1.1.0


### PR DESCRIPTION
**NOTE:** do not merge --- this is for testing only.

This sets `go-corset` to its current head, and `linea-constraints` to the proposed upgrade branch.