### PR TITLE
feat: refactor to utilise trace interface

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -9,4 +9,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@v1.1.3
+      run: go install github.com/consensys/go-corset/cmd/go-corset@v1.1.6

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/CountingOnlyModule.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/CountingOnlyModule.java
@@ -41,7 +41,7 @@ public interface CountingOnlyModule extends Module {
   }
 
   @Override
-  default int spillage() {
+  default int spillage(Trace trace) {
     return 0;
   }
 
@@ -51,7 +51,7 @@ public interface CountingOnlyModule extends Module {
   }
 
   @Override
-  default List<Trace.ColumnHeader> columnHeaders() {
+  default List<Trace.ColumnHeader> columnHeaders(Trace trace) {
     throw new IllegalStateException("should never be called");
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/Module.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/Module.java
@@ -80,9 +80,9 @@ public interface Module {
    *
    * @return
    */
-  int spillage();
+  int spillage(Trace trace);
 
-  List<Trace.ColumnHeader> columnHeaders();
+  List<Trace.ColumnHeader> columnHeaders(Trace trace);
 
   default void commit(Trace trace) {
     throw new UnsupportedOperationException();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/Add.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/Add.java
@@ -58,20 +58,20 @@ public class Add implements OperationSetModule<AddOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Add.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.add().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Add.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.add().spillage();
   }
 
   @Override
   public void commit(Trace trace) {
     int stamp = 0;
     for (AddOperation op : sortOperations(new AddOperationComparator())) {
-      op.trace(++stamp, trace.add);
+      op.trace(++stamp, trace.add());
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/bin/Bin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/bin/Bin.java
@@ -64,20 +64,20 @@ public class Bin implements OperationSetModule<BinOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Bin.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.bin().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Bin.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.bin().spillage();
   }
 
   @Override
   public void commit(Trace trace) {
     int stamp = 0;
     for (BinOperation op : operations.sortOperations(new BinOperationComparator())) {
-      op.traceBinOperation(++stamp, trace.bin);
+      op.traceBinOperation(++stamp, trace.bin());
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/BlakeModexpData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/BlakeModexpData.java
@@ -67,20 +67,20 @@ public class BlakeModexpData implements OperationListModule<BlakeModexpDataOpera
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Blake2fmodexpdata.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.blake2fmodexpdata().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Blake2fmodexpdata.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.blake2fmodexpdata().spillage();
   }
 
   @Override
   public void commit(Trace trace) {
     int stamp = 0;
     for (BlakeModexpDataOperation o : operations.getAll()) {
-      o.trace(trace.blake2fmodexpdata, ++stamp);
+      o.trace(trace.blake2fmodexpdata(), ++stamp);
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/Blockdata.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/Blockdata.java
@@ -121,19 +121,19 @@ public class Blockdata implements Module {
   }
 
   @Override
-  public int spillage() {
-    return Trace.Blockdata.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.blockdata().spillage();
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Blockdata.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.blockdata().headers(this.lineCount());
   }
 
   @Override
   public void commit(Trace trace) {
     for (BlockdataOperation blockData : operations) {
-      blockData.trace(trace.blockdata);
+      blockData.trace(trace.blockdata());
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Blockhash.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Blockhash.java
@@ -115,13 +115,13 @@ public class Blockhash implements OperationSetModule<BlockhashOperation>, PostOp
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Blockhash.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.blockhash().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Blockhash.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.blockhash().spillage();
   }
 
   @Override
@@ -131,8 +131,8 @@ public class Blockhash implements OperationSetModule<BlockhashOperation>, PostOp
           op.blockhashRes() == Bytes32.ZERO
               ? this.blockHashMap.getOrDefault(op.blockhashArg(), Bytes32.ZERO)
               : op.blockhashRes();
-      op.traceMacro(trace.blockhash, blockhashVal);
-      op.tracePreprocessing(trace.blockhash);
+      op.traceMacro(trace.blockhash(), blockhashVal);
+      op.tracePreprocessing(trace.blockhash());
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/EcData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/EcData.java
@@ -65,13 +65,13 @@ public class EcData implements OperationListModule<EcDataOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Ecdata.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.ecdata().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Ecdata.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.ecdata().spillage();
   }
 
   @Override
@@ -79,7 +79,7 @@ public class EcData implements OperationListModule<EcDataOperation> {
     int stamp = 0;
     long previousId = 0;
     for (EcDataOperation op : operations.getAll()) {
-      op.trace(trace.ecdata, ++stamp, previousId);
+      op.trace(trace.ecdata(), ++stamp, previousId);
       previousId = op.id();
     }
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Euc.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Euc.java
@@ -68,14 +68,14 @@ public class Euc implements OperationSetModule<EucOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Euc.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.euc().headers(this.lineCount());
   }
 
   @Override
   public void commit(Trace trace) {
     for (EucOperation eucOperation : operations.sortOperations(new EucOperationComparator())) {
-      eucOperation.trace(trace.euc);
+      eucOperation.trace(trace.euc());
     }
   }
 
@@ -87,8 +87,8 @@ public class Euc implements OperationSetModule<EucOperation> {
   }
 
   @Override
-  public int spillage() {
-    return Trace.Euc.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.euc().spillage();
   }
 
   public EucOperation callEUC(final Bytes dividend, final Bytes divisor) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/Exp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/Exp.java
@@ -49,22 +49,22 @@ public class Exp implements OperationSetModule<ExpOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Exp.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.exp().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Exp.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.exp().spillage();
   }
 
   @Override
   public void commit(Trace trace) {
     int stamp = 0;
     for (ExpOperation expOp : operations.sortOperations(new ExpOperationComparator())) {
-      expOp.traceComputation(++stamp, trace.exp);
-      expOp.traceMacro(stamp, trace.exp);
-      expOp.tracePreprocessing(stamp, trace.exp);
+      expOp.traceComputation(++stamp, trace.exp());
+      expOp.traceMacro(stamp, trace.exp());
+      expOp.tracePreprocessing(stamp, trace.exp());
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ext/Ext.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ext/Ext.java
@@ -76,20 +76,20 @@ public class Ext implements OperationSetModule<ExtOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Ext.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.ext().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Ext.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.ext().spillage();
   }
 
   @Override
   public void commit(Trace trace) {
     int stamp = 0;
     for (ExtOperation operation : operations.sortOperations(new ExtOperationComparator())) {
-      operation.trace(trace.ext, ++stamp);
+      operation.trace(trace.ext(), ++stamp);
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/gas/Gas.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/gas/Gas.java
@@ -57,19 +57,19 @@ public class Gas implements OperationSetModule<GasOperation>, PostOpcodeDefer {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Gas.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.gas().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Gas.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.gas().spillage();
   }
 
   @Override
   public void commit(Trace trace) {
     for (GasOperation gasOperation : operations.sortOperations(new GasOperationComparator())) {
-      gasOperation.trace(trace.gas);
+      gasOperation.trace(trace.gas());
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -180,13 +180,13 @@ public abstract class Hub implements Module {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Hub.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.hub().headers(this.lineCount());
   }
 
   @Override
   public void commit(Trace trace) {
-    state.commit(trace.hub);
+    state.commit(trace.hub());
   }
 
   @Override
@@ -195,8 +195,8 @@ public abstract class Hub implements Module {
   }
 
   @Override
-  public int spillage() {
-    return Trace.Hub.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.hub().spillage();
   }
 
   /** List of all modules of the ZK-evm */

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/BlockTransactions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/BlockTransactions.java
@@ -53,12 +53,12 @@ public class BlockTransactions implements Module {
   }
 
   @Override
-  public int spillage() {
+  public int spillage(Trace trace) {
     return 0;
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
     throw new UnsupportedOperationException("Not implemented");
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2Block.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L2Block.java
@@ -84,12 +84,12 @@ public class L2Block implements Module {
   }
 
   @Override
-  public int spillage() {
+  public int spillage(Trace trace) {
     return 0;
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
     throw new IllegalStateException("non-tracing module");
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/logdata/LogData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/logdata/LogData.java
@@ -61,8 +61,8 @@ public class LogData implements Module {
   }
 
   @Override
-  public int spillage() {
-    return Trace.Logdata.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.logdata().spillage();
   }
 
   private int lineCountForLogData(RlpTxrcptOperation tx) {
@@ -82,8 +82,8 @@ public class LogData implements Module {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Logdata.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.logdata().headers(this.lineCount());
   }
 
   @Override
@@ -99,9 +99,9 @@ public class LogData implements Module {
         for (Log log : tx.logs()) {
           absLogNum += 1;
           if (log.getData().isEmpty()) {
-            traceLogWoData(absLogNum, absLogNumMax, trace.logdata);
+            traceLogWoData(absLogNum, absLogNumMax, trace.logdata());
           } else {
-            traceLog(log, absLogNum, absLogNumMax, trace.logdata);
+            traceLog(log, absLogNum, absLogNumMax, trace.logdata());
           }
         }
       }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/loginfo/LogInfo.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/loginfo/LogInfo.java
@@ -68,13 +68,13 @@ public class LogInfo implements Module {
   }
 
   @Override
-  public int spillage() {
-    return Trace.Loginfo.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.loginfo().spillage();
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Loginfo.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.loginfo().headers(this.lineCount());
   }
 
   @Override
@@ -89,11 +89,11 @@ public class LogInfo implements Module {
     for (RlpTxrcptOperation tx : rlpTxnRcpt.operations().getAll()) {
       absTxNum += 1;
       if (tx.logs().isEmpty()) {
-        traceTxWoLog(absTxNum, absLogNum, absLogNumMax, trace.loginfo);
+        traceTxWoLog(absTxNum, absLogNum, absLogNumMax, trace.loginfo());
       } else {
         for (Log log : tx.logs()) {
           absLogNum += 1;
-          traceLog(log, absTxNum, absLogNum, absLogNumMax, trace.loginfo);
+          traceLog(log, absTxNum, absLogNum, absLogNumMax, trace.loginfo());
         }
       }
     }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Mmio.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Mmio.java
@@ -76,13 +76,13 @@ public class Mmio implements Module {
   }
 
   @Override
-  public int spillage() {
-    return Trace.Mmio.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.mmio().spillage();
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Mmio.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.mmio().headers(this.lineCount());
   }
 
   @Override
@@ -105,7 +105,7 @@ public class Mmio implements Module {
                     .get(currentMmioInstNumber)
                     .mmioInstruction());
 
-        trace(trace.mmio, mmioData, ++stamp);
+        trace(trace.mmio(), mmioData, ++stamp);
       }
     }
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/Mmu.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/Mmu.java
@@ -46,13 +46,13 @@ public class Mmu implements OperationListModule<MmuOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Mmu.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.mmu().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Mmu.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.mmu().spillage();
   }
 
   @Override
@@ -65,7 +65,7 @@ public class Mmu implements OperationListModule<MmuOperation> {
       mmuOperation.getCFI();
       mmuOperation.fillLimb();
 
-      mmioStamp = mmuOperation.trace(++mmuStamp, mmioStamp, trace.mmu);
+      mmioStamp = mmuOperation.trace(++mmuStamp, mmioStamp, trace.mmu());
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mod/Mod.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mod/Mod.java
@@ -52,20 +52,20 @@ public class Mod implements OperationSetModule<ModOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Mod.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.mod().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Mod.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.mod().spillage();
   }
 
   @Override
   public void commit(Trace trace) {
     int stamp = 0;
     for (ModOperation op : operations.sortOperations(new ModOperationComparator())) {
-      op.trace(trace.mod, ++stamp);
+      op.trace(trace.mod(), ++stamp);
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mul/Mul.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mul/Mul.java
@@ -60,21 +60,21 @@ public class Mul implements OperationSetModule<MulOperation> {
   }
 
   @Override
-  public int spillage() {
-    return Trace.Mul.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.mul().spillage();
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Mul.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.mul().headers(this.lineCount());
   }
 
   @Override
   public void commit(Trace trace) {
     int stamp = 0;
     for (MulOperation op : operations.sortOperations(new MulOperationComparator())) {
-      op.trace(trace.mul, ++stamp);
+      op.trace(trace.mul(), ++stamp);
     }
-    (new MulOperation(OpCode.EXP, Bytes32.ZERO, Bytes32.ZERO)).trace(trace.mul, stamp + 1);
+    (new MulOperation(OpCode.EXP, Bytes32.ZERO, Bytes32.ZERO)).trace(trace.mul(), stamp + 1);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/Mxp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/Mxp.java
@@ -41,20 +41,20 @@ public class Mxp implements OperationListModule<MxpOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Mxp.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.mxp().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Mxp.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.mxp().spillage();
   }
 
   @Override
   public void commit(Trace trace) {
     int stamp = 0;
     for (MxpOperation op : operations.getAll()) {
-      op.trace(++stamp, trace.mxp);
+      op.trace(++stamp, trace.mxp());
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/oob/Oob.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/oob/Oob.java
@@ -72,20 +72,20 @@ public class Oob implements OperationSetModule<OobOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Oob.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.oob().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Oob.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.oob().spillage();
   }
 
   @Override
   public void commit(Trace trace) {
     int stamp = 0;
     for (OobOperation op : operations.getAll()) {
-      traceOperation(op, ++stamp, trace.oob);
+      traceOperation(op, ++stamp, trace.oob());
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpaddr/RlpAddr.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpaddr/RlpAddr.java
@@ -307,20 +307,20 @@ public class RlpAddr implements OperationSetModule<RlpAddrOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Rlpaddr.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.rlpaddr().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Rlpaddr.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.rlpaddr().spillage();
   }
 
   @Override
   public void commit(Trace trace) {
     int stamp = 0;
     for (RlpAddrOperation op : operations.sortOperations(new RlpAddrOperationComparator())) {
-      traceOperation(op, ++stamp, trace.rlpaddr);
+      traceOperation(op, ++stamp, trace.rlpaddr());
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/RlpTxn.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/RlpTxn.java
@@ -1051,20 +1051,20 @@ public class RlpTxn implements OperationListModule<RlpTxnOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Rlptxn.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.rlptxn().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Rlptxn.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.rlptxn().spillage();
   }
 
   @Override
   public void commit(Trace trace) {
     int absTxNum = 0;
     for (RlpTxnOperation op : operations.getAll()) {
-      traceOperation(op, ++absTxNum, trace.rlptxn);
+      traceOperation(op, ++absTxNum, trace.rlptxn());
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxrcpt/RlpTxnRcpt.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxrcpt/RlpTxnRcpt.java
@@ -764,13 +764,13 @@ public class RlpTxnRcpt implements OperationListModule<RlpTxrcptOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Rlptxrcpt.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.rlptxrcpt().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Rlptxrcpt.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.rlptxrcpt().spillage();
   }
 
   @Override
@@ -782,7 +782,7 @@ public class RlpTxnRcpt implements OperationListModule<RlpTxrcptOperation> {
 
     int absTxNum = 0;
     for (RlpTxrcptOperation op : operations.getAll()) {
-      traceOperation(op, ++absTxNum, absLogNumMax, trace.rlptxrcpt);
+      traceOperation(op, ++absTxNum, absLogNumMax, trace.rlptxrcpt());
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rom/Rom.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rom/Rom.java
@@ -44,13 +44,13 @@ public class Rom implements Module {
   }
 
   @Override
-  public int spillage() {
-    return Trace.Rom.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.rom().spillage();
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Rom.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.rom().headers(this.lineCount());
   }
 
   @Override
@@ -58,7 +58,7 @@ public class Rom implements Module {
     int codeFragmentIndex = 0;
     final int codeFragmentIndexInfinity = romLex.sortedOperations().size();
     for (RomOperation chunk : romLex.sortedOperations()) {
-      chunk.trace(trace.rom, ++codeFragmentIndex, codeFragmentIndexInfinity);
+      chunk.trace(trace.rom(), ++codeFragmentIndex, codeFragmentIndexInfinity);
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/RomLex.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/RomLex.java
@@ -288,8 +288,8 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
   }
 
   @Override
-  public int spillage() {
-    return Trace.Romlex.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.romlex().spillage();
   }
 
   @Override
@@ -299,8 +299,8 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Romlex.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.romlex().headers(this.lineCount());
   }
 
   @Override
@@ -309,7 +309,7 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
 
     int cfi = 0;
     for (RomOperation operation : sortedOperations) {
-      traceOperation(operation, ++cfi, codeFragmentIndexInfinity, trace.romlex);
+      traceOperation(operation, ++cfi, codeFragmentIndexInfinity, trace.romlex());
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shakiradata/ShakiraData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shakiradata/ShakiraData.java
@@ -56,8 +56,8 @@ public class ShakiraData implements OperationListModule<ShakiraDataOperation> {
   }
 
   @Override
-  public int spillage() {
-    return Trace.Shakiradata.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.shakiradata().spillage();
   }
 
   public void call(final ShakiraDataOperation operation) {
@@ -77,15 +77,15 @@ public class ShakiraData implements OperationListModule<ShakiraDataOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Shakiradata.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.shakiradata().headers(this.lineCount());
   }
 
   @Override
   public void commit(Trace trace) {
     int stamp = 0;
     for (ShakiraDataOperation operation : operations.getAll()) {
-      operation.trace(trace.shakiradata, ++stamp);
+      operation.trace(trace.shakiradata(), ++stamp);
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Shf.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Shf.java
@@ -51,20 +51,20 @@ public class Shf implements OperationSetModule<ShfOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Shf.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.shf().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Shf.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.shf().spillage();
   }
 
   @Override
   public void commit(Trace trace) {
     int stamp = 0;
     for (ShfOperation op : operations.sortOperations(new ShfOperationComparator())) {
-      op.trace(trace.shf, ++stamp);
+      op.trace(trace.shf(), ++stamp);
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/Stp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/Stp.java
@@ -77,20 +77,20 @@ public class Stp implements OperationSetModule<StpOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Stp.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.stp().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Stp.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.stp().spillage();
   }
 
   @Override
   public void commit(Trace trace) {
     int stamp = 0;
     for (StpOperation operation : operations.sortOperations(new StpOperationComparator())) {
-      operation.trace(trace.stp, ++stamp);
+      operation.trace(trace.stp(), ++stamp);
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/bin/BinRt.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/bin/BinRt.java
@@ -41,19 +41,19 @@ public class BinRt implements Module {
   }
 
   @Override
-  public int spillage() {
-    return Trace.Binreftable.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.binreftable().spillage();
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Binreftable.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.binreftable().headers(this.lineCount());
   }
 
   public void commit(Trace trace) {
     // AND
     UnsignedByte opCode = UnsignedByte.of(OpCode.AND.byteValue());
-    Trace.Binreftable binrt = trace.binreftable;
+    Trace.Binreftable binrt = trace.binreftable();
     //
     for (short input1 = 0; input1 <= 255; input1++) {
       final Bytes input1Bytes = Bytes.of(input1);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/InstructionDecoder.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/InstructionDecoder.java
@@ -106,13 +106,13 @@ public final class InstructionDecoder implements Module {
   }
 
   @Override
-  public int spillage() {
-    return Trace.Instdecoder.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.instdecoder().spillage();
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Instdecoder.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.instdecoder().headers(this.lineCount());
   }
 
   @Override
@@ -124,11 +124,11 @@ public final class InstructionDecoder implements Module {
 
   protected void traceOpcode(final int i, final Trace trace) {
     final OpCodeData op = OpCode.of(i).getData();
-    traceFamily(op, trace.instdecoder);
-    traceStackSettings(op, trace.instdecoder);
-    traceBillingSettings(op, trace.instdecoder);
+    traceFamily(op, trace.instdecoder());
+    traceStackSettings(op, trace.instdecoder());
+    traceBillingSettings(op, trace.instdecoder());
     trace
-        .instdecoder
+        .instdecoder()
         .opcode(UnsignedByte.of(i))
         .isPush(op.isNonTrivialPush())
         .isJumpdest(op.isJumpDest())

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/shf/ShfRt.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/shf/ShfRt.java
@@ -40,13 +40,13 @@ public record ShfRt() implements Module {
   }
 
   @Override
-  public int spillage() {
-    return Trace.Shfreftable.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.shfreftable().spillage();
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Shfreftable.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.shfreftable().headers(this.lineCount());
   }
 
   public void commit(Trace trace) {
@@ -54,7 +54,7 @@ public record ShfRt() implements Module {
       final UnsignedByte unsignedByteA = UnsignedByte.of(a);
       for (int uShp = 0; uShp <= 8; uShp++) {
         trace
-            .shfreftable
+            .shfreftable()
             .byte1(UnsignedByte.of(a))
             .las(unsignedByteA.shiftLeft(8 - uShp))
             .mshp(UnsignedByte.of(uShp))

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/trm/Trm.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/trm/Trm.java
@@ -52,19 +52,19 @@ public class Trm implements OperationSetModule<TrmOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Trm.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.trm().headers(this.lineCount());
   }
 
   @Override
-  public int spillage() {
-    return Trace.Trm.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.trm().spillage();
   }
 
   @Override
   public void commit(Trace trace) {
     for (TrmOperation operation : operations.sortOperations(new TrmOperationComparator())) {
-      operation.trace(trace.trm);
+      operation.trace(trace.trm());
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/module/TxnData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/module/TxnData.java
@@ -82,8 +82,8 @@ public abstract class TxnData implements OperationListModule<TxndataOperation> {
   }
 
   @Override
-  public int spillage() {
-    return Trace.Txndata.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.txndata().spillage();
   }
 
   public BlockSnapshot currentBlock() {
@@ -95,8 +95,8 @@ public abstract class TxnData implements OperationListModule<TxndataOperation> {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Txndata.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.txndata().headers(this.lineCount());
   }
 
   @Override
@@ -104,7 +104,7 @@ public abstract class TxnData implements OperationListModule<TxndataOperation> {
     final int absTxNumMax = operations.size();
 
     for (TxndataOperation tx : operations.getAll()) {
-      tx.traceTx(trace.txndata, blocks.get(tx.getTx().getRelativeBlockNumber() - 1), absTxNumMax);
+      tx.traceTx(trace.txndata(), blocks.get(tx.getTx().getRelativeBlockNumber() - 1), absTxNumMax);
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Wcp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Wcp.java
@@ -131,8 +131,8 @@ public class Wcp implements Module {
   }
 
   @Override
-  public List<Trace.ColumnHeader> columnHeaders() {
-    return Trace.Wcp.headers(this.lineCount());
+  public List<Trace.ColumnHeader> columnHeaders(Trace trace) {
+    return trace.wcp().headers(this.lineCount());
   }
 
   @Override
@@ -141,7 +141,7 @@ public class Wcp implements Module {
     final WcpOperationComparator comparator = new WcpOperationComparator();
     for (ModuleOperationStackedSet<WcpOperation> operationsSet : operations) {
       for (WcpOperation operation : operationsSet.sortOperations(comparator)) {
-        operation.trace(trace.wcp, ++stamp);
+        operation.trace(trace.wcp(), ++stamp);
       }
     }
   }
@@ -153,8 +153,8 @@ public class Wcp implements Module {
   }
 
   @Override
-  public int spillage() {
-    return Trace.Wcp.SPILLAGE;
+  public int spillage(Trace trace) {
+    return trace.wcp().spillage();
   }
 
   public boolean callLT(final Bytes32 arg1, final Bytes32 arg2) {

--- a/gradle/corset.gradle
+++ b/gradle/corset.gradle
@@ -26,8 +26,9 @@ tasks.register('corsetExists') {
 
 // Allowing overriding the default zkevm.bin file.
 def ZKEVM_BIN = System.getenv("ZKEVM_BIN") ?: "zkevm.bin"
-// Specify where the trace file should be generated.
 def TRACE_FILE = "arithmetization/src/main/java/net/consensys/linea/zktracer/Trace.java"
+// Specify where the trace file should be generated.
+def LONDON_TRACE_FILE = "arithmetization/src/main/java/net/consensys/linea/zktracer/TraceLondon.java"
 // Specify package to use for trace file
 def TRACE_PKG = "net.consensys.linea.zktracer"
 
@@ -58,14 +59,33 @@ tasks.register('buildZkevmBin', Exec) {
     }
 }
 
-// Task which generates the Trace.java file using go-corset.
+// Task which generates the Trace.java interface using go-corset.
 tasks.register('buildTracer', Exec) {
-    group "Trace files generation"
+    group "Trace.java generation"
     dependsOn 'buildZkevmBin'
     // Locate target file
-    def traceJava = getRootProject().file(TRACE_FILE)    
+    def traceJava = getRootProject().file(TRACE_FILE)
     // Configure full path to zkevm.bin
     def zkevmBin = getRootProject().file('linea-constraints/' + ZKEVM_BIN)
-    // Run go-corset generation
-    commandLine 'go-corset','generate','-p',TRACE_PKG,'-o',traceJava,zkevmBin
+    // Generate trace interface
+    commandLine 'go-corset','generate','-p',TRACE_PKG,'-i',traceJava,zkevmBin
+}
+
+// Task which generates the TraceLondon.java file using go-corset.
+tasks.register('buildLondonTracer', Exec) {
+    group "TraceLondon.java generation"
+    dependsOn 'buildZkevmBin'
+    // Locate target file
+    def traceJava = getRootProject().file(LONDON_TRACE_FILE)        
+    // Configure full path to zkevm.bin
+    def zkevmBin = getRootProject().file('linea-constraints/' + ZKEVM_BIN)
+    // Generate trace class(es)
+    commandLine 'go-corset','generate','-p',TRACE_PKG,'-o',traceJava,'-e','Trace',zkevmBin
+}
+
+// Task which generates all trace files
+tasks.register('buildAllTracers') {
+    group "Trace files generation (all forks)"
+    dependsOn 'buildTracer'
+    dependsOn 'buildLondonTracer'    
 }

--- a/gradle/lint.gradle
+++ b/gradle/lint.gradle
@@ -40,7 +40,7 @@ spotless {
   java {
     // This path needs to be relative to each project
     target 'src/**/*.java'
-    targetExclude '**/Trace.java', '**/GlobalConstants.java'
+    targetExclude '**/Trace*.java', '**/GlobalConstants.java'
         
     removeUnusedImports()
     googleJavaFormat('1.17.0')

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -304,4 +304,4 @@ tasks.register("jacocoUnitFastReplayWeeklyNightlyReferenceBlockchainAndStateTest
 
 // Configure default build task to require the tracer is built first.
 // This only makes sense for projects which need the tracer.
-compileJava.dependsOn 'buildTracer'
+compileJava.dependsOn 'buildAllTracers'


### PR DESCRIPTION
The code now generates an interface "Trace.java" which is implemented by "TraceLondon.java".  In principle, this means we can have different forks implementing this same interface, with the shared commonality being exposed.