### PR TITLE
chore: remove slack API plugin

### DIFF
--- a/arithmetization/build.gradle
+++ b/arithmetization/build.gradle
@@ -43,10 +43,8 @@ dependencies {
   implementation "${besuArtifactGroup}.internal:rlp"
 
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-
-  implementation 'com.slack.api:slack-api-client'
-
   implementation 'info.picocli:picocli'
+  implementation 'com.google.code.gson:gson'
 
   implementation 'io.consensys.tuweni:tuweni-bytes'
   implementation 'io.consensys.tuweni:tuweni-units'

--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -55,7 +55,5 @@ dependencyManagement {
     }
 
     dependency 'com.google.code.gson:gson:2.11.0'
-
-    dependency 'com.slack.api:slack-api-client:1.32.1'
   }
 }


### PR DESCRIPTION
This plugin was previously used by the shadow node to report outages, etc.  However, the shadow node is no longer in use and, hence, this dependency is no longer required.