### PR TITLE
feat: fix state tests

### DIFF
--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: "0 23 * * 1-5"
   workflow_dispatch:
+    inputs:
+      test_filter:
+        description: Filter tests to run (via Gradle)
+        required: false
+        type: string
+        default: "GeneralStateReferenceTest_*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,9 +33,9 @@ jobs:
           JAVA_OPTS: -Dorg.gradle.daemon=false
 
       - name: Run General State Reference Tests
-        run: GOMEMLIMIT=20GiB ./gradlew referenceGeneralStateTests
+        run: GOMAXPROCS=14 GOMEMLIMIT=20GiB ./gradlew referenceGeneralStateTests -x spotlessCheck --tests "${{ inputs.test_filter || 'GeneralStateReferenceTest_*' }}"
         env:
-          REFERENCE_TESTS_PARALLELISM: 4
+          REFERENCE_TESTS_PARALLELISM: 2
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -v -b1024 --ansi-escapes=false --report --air

--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -33,9 +33,9 @@ jobs:
           JAVA_OPTS: -Dorg.gradle.daemon=false
 
       - name: Run General State Reference Tests
-        run: GOMAXPROCS=14 GOMEMLIMIT=20GiB ./gradlew referenceGeneralStateTests -x spotlessCheck --tests "${{ inputs.test_filter || 'GeneralStateReferenceTest_*' }}"
+        run: GOMAXPROCS=10 GOMEMLIMIT=20GiB ./gradlew referenceGeneralStateTests -x spotlessCheck --tests "${{ inputs.test_filter || 'GeneralStateReferenceTest_*' }}"
         env:
-          REFERENCE_TESTS_PARALLELISM: 2
+          REFERENCE_TESTS_PARALLELISM: 3
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -v -b1024 --ansi-escapes=false --report --air

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   blockchain-reference-tests:
-    runs-on: [ubuntu-latest-128]
+    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -63,10 +63,10 @@ jobs:
         run: mv ${{ github.workspace }}/tmp/${{ steps.extract_branch.outputs.branch }}/failedBlockchainReferenceTests.json ${{ github.workspace }}/tmp/${{ steps.extract_branch.outputs.branch }}/failedBlockchainReferenceTests-input.json
 
       - name: Run reference blockchain tests
-        run: GOMEMLIMIT=20GiB ./gradlew referenceBlockchainTests -x spotlessCheck --tests "${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}"
+        run: GOMAXPROCS=14 GOMEMLIMIT=20GiB ./gradlew referenceBlockchainTests -x spotlessCheck --tests "${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}"
         timeout-minutes: 360
         env:
-          REFERENCE_TESTS_PARALLELISM: 4
+          REFERENCE_TESTS_PARALLELISM: 2
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -63,10 +63,10 @@ jobs:
         run: mv ${{ github.workspace }}/tmp/${{ steps.extract_branch.outputs.branch }}/failedBlockchainReferenceTests.json ${{ github.workspace }}/tmp/${{ steps.extract_branch.outputs.branch }}/failedBlockchainReferenceTests-input.json
 
       - name: Run reference blockchain tests
-        run: GOMAXPROCS=14 GOMEMLIMIT=20GiB ./gradlew referenceBlockchainTests -x spotlessCheck --tests "${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}"
+        run: GOMAXPROCS=10 GOMEMLIMIT=20GiB ./gradlew referenceBlockchainTests -x spotlessCheck --tests "${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}"
         timeout-minutes: 360
         env:
-          REFERENCE_TESTS_PARALLELISM: 2
+          REFERENCE_TESTS_PARALLELISM: 3
           JAVA_OPTS: -Dorg.gradle.daemon=false
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air

--- a/reference-tests/build.gradle
+++ b/reference-tests/build.gradle
@@ -62,10 +62,6 @@ tasks.register('referenceBlockchainTests', Test) {
   dependsOn generateBlockchainReferenceTests
   environment.put("REFERENCE_TEST_OUTCOME_OUTPUT_FILE", "BlockchainReferenceTestOutcome.json")
 
-  boolean isCiServer = System.getenv().containsKey("CI")
-  minHeapSize = isCiServer ? "8g" :"4g"
-  maxHeapSize = isCiServer ? "32g" : "8g"
-
   useJUnitPlatform {
     includeTags("BlockchainReferenceTest")
   }
@@ -89,10 +85,6 @@ tasks.register('referenceGeneralStateTests', Test) {
   useJUnitPlatform {
     includeTags("GeneralStateReferenceTest")
   }
-
-  boolean isCiServer = System.getenv().containsKey("CI")
-  minHeapSize = "4g"
-  maxHeapSize = isCiServer ? "32g" : "8g"
 }
 
 tasks.register("jacocoReferenceGeneralStateTestsReport", JacocoReport) {
@@ -108,10 +100,14 @@ tasks.register("jacocoReferenceGeneralStateTestsReport", JacocoReport) {
   tasks.named("referenceGeneralStateTests"),
   tasks.named("referenceBlockchainTests"),
 ].forEach {
-  it.configure {
+   it.configure {
+    // Configure resource limits    
+    boolean isCiServer = System.getenv().containsKey("CI")
+    minHeapSize = "256m"
+    maxHeapSize = isCiServer ? "32g" : "8g"           
     // Configure parallelism
     environment.put("blockchain", System.getenv("blockchain") ?: "Ethereum")
-    systemProperty("junit.jupiter.execution.timeout.default", "15 m")  // 5 minutes
+    systemProperty("junit.jupiter.execution.timeout.default", "15 m")
     systemProperty("junit.jupiter.execution.parallel.enabled", "true")
     systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
     systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")


### PR DESCRIPTION
This tweaks the parameters for the general state tests and blockchain reference tests, and moves the blockchain reference tests over to the locally hosted runners.

Additionally, this puts in place an optional filter on tests to run for the general state tests.  This is available when running the action directly via github, exactly as it already is for the blockchain reference tests.
