### PR TITLE
feat: run unit tests per fork

### DIFF
--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -74,7 +74,7 @@ jobs:
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
           UNIT_TESTS_PARALLELISM: 4
-          UNIT_TESTS_FORK: LONDON
+          UNIT_REPLAY_TESTS_FORK: LONDON
 
       - name: Upload test report
         if: ${{ always() }}
@@ -121,7 +121,7 @@ jobs:
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
           UNIT_TESTS_PARALLELISM: 4
-          UNIT_TESTS_FORK: SHANGHAI
+          UNIT_REPLAY_TESTS_FORK: SHANGHAI
 
       - name: Upload test report
         if: ${{ always() }}
@@ -168,6 +168,7 @@ jobs:
           REPLAY_TESTS_PARALLELISM: 4
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
+          UNIT_REPLAY_TESTS_FORK: LONDON
 
       - name: Upload test report
         if: ${{ always() }}

--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -51,9 +51,13 @@ jobs:
         run: ./gradlew --no-daemon --parallel clean spotlessCheck
 
   # ==================================================================
-  # Unit Tests for London
+  # Unit Tests
   # ==================================================================
-  unit-tests-london:
+  unit-tests:
+    strategy:
+      matrix:
+        name: [london, shanghai]
+        zkevm_fork: [LONDON, SHANGHAI]
     needs: [ build ]
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     steps:
@@ -74,74 +78,27 @@ jobs:
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
           UNIT_TESTS_PARALLELISM: 4
-          UNIT_REPLAY_TESTS_FORK: LONDON
+          ZKEVM_FORK: ${{ matrix.zkevm_fork }}
 
       - name: Upload test report
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: unit-tests-report-london
+          name: unit-tests-report-${{ matrix.name }}
           path: arithmetization/build/reports/tests/**/*
 
       - name: Upload jacoco unit tests coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jacoco-unit-tests-coverage-report-london
+          name: jacoco-unit-tests-coverage-report-${{ matrix.name }}
           path: arithmetization/build/reports/jacoco/test/**/*
 
       - name: Upload jacoco unit tests exec file
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jacoco-unit-tests-exec-file-london
-          path: arithmetization/build/jacoco/test.exec
-
-  # ==================================================================
-  # Unit Tests for Shanghai
-  # ==================================================================
-  unit-tests-shanghai:
-    needs: [ build ]
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          submodules: false
-
-      - name: Setup Test Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          enable-ssh: ${{ inputs.tests-with-ssh }}
-
-      - name: Run unit tests
-        run: GOMEMLIMIT=26GiB ./gradlew :arithmetization:test
-        env:
-          JAVA_OPTS: -Dorg.gradle.daemon=false
-          CORSET_FLAGS: disable
-          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
-          UNIT_TESTS_PARALLELISM: 4
-          UNIT_REPLAY_TESTS_FORK: SHANGHAI
-
-      - name: Upload test report
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-tests-report-shanghai
-          path: arithmetization/build/reports/tests/**/*
-
-      - name: Upload jacoco unit tests coverage report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: jacoco-unit-tests-coverage-report-shanghai
-          path: arithmetization/build/reports/jacoco/test/**/*
-
-      - name: Upload jacoco unit tests exec file
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: jacoco-unit-tests-exec-file-shanghai
+          name: jacoco-unit-tests-exec-file-${{ matrix.name }}
           path: arithmetization/build/jacoco/test.exec
 
   # ==================================================================
@@ -168,7 +125,7 @@ jobs:
           REPLAY_TESTS_PARALLELISM: 4
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
-          UNIT_REPLAY_TESTS_FORK: LONDON
+          ZKEVM_FORK: LONDON
 
       - name: Upload test report
         if: ${{ always() }}

--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -51,9 +51,9 @@ jobs:
         run: ./gradlew --no-daemon --parallel clean spotlessCheck
 
   # ==================================================================
-  # Unit Tests
+  # Unit Tests for London
   # ==================================================================
-  unit-tests:
+  unit-tests-london:
     needs: [ build ]
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     steps:
@@ -74,26 +74,74 @@ jobs:
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
           UNIT_TESTS_PARALLELISM: 4
+          UNIT_TESTS_FORK: LONDON
 
       - name: Upload test report
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: unit-tests-report
+          name: unit-tests-report-london
           path: arithmetization/build/reports/tests/**/*
 
       - name: Upload jacoco unit tests coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jacoco-unit-tests-coverage-report
+          name: jacoco-unit-tests-coverage-report-london
           path: arithmetization/build/reports/jacoco/test/**/*
 
       - name: Upload jacoco unit tests exec file
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jacoco-unit-tests-exec-file
+          name: jacoco-unit-tests-exec-file-london
+          path: arithmetization/build/jacoco/test.exec
+
+  # ==================================================================
+  # Unit Tests for Shanghai
+  # ==================================================================
+  unit-tests-shanghai:
+    needs: [ build ]
+    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-environment
+        with:
+          enable-ssh: ${{ inputs.tests-with-ssh }}
+
+      - name: Run unit tests
+        run: GOMEMLIMIT=26GiB ./gradlew :arithmetization:test
+        env:
+          JAVA_OPTS: -Dorg.gradle.daemon=false
+          CORSET_FLAGS: disable
+          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
+          UNIT_TESTS_PARALLELISM: 4
+          UNIT_TESTS_FORK: SHANGHAI
+
+      - name: Upload test report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-tests-report-shanghai
+          path: arithmetization/build/reports/tests/**/*
+
+      - name: Upload jacoco unit tests coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-unit-tests-coverage-report-shanghai
+          path: arithmetization/build/reports/jacoco/test/**/*
+
+      - name: Upload jacoco unit tests exec file
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-unit-tests-exec-file-shanghai
           path: arithmetization/build/jacoco/test.exec
 
   # ==================================================================

--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -56,7 +56,6 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        name: [london, shanghai]
         zkevm_fork: [LONDON, SHANGHAI]
     needs: [ build ]
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
@@ -84,21 +83,21 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: unit-tests-report-${{ matrix.name }}
+          name: unit-tests-report-${{ matrix.zkevm_fork }}
           path: arithmetization/build/reports/tests/**/*
 
       - name: Upload jacoco unit tests coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jacoco-unit-tests-coverage-report-${{ matrix.name }}
+          name: jacoco-unit-tests-coverage-report-${{ matrix.zkevm_fork }}
           path: arithmetization/build/reports/jacoco/test/**/*
 
       - name: Upload jacoco unit tests exec file
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jacoco-unit-tests-exec-file-${{ matrix.name }}
+          name: jacoco-unit-tests-exec-file-${{ matrix.zkevm_fork }}
           path: arithmetization/build/jacoco/test.exec
 
   # ==================================================================

--- a/arithmetization/src/test/java/net/consensys/linea/ZkCounterTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/ZkCounterTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
@@ -45,7 +46,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class ZkCounterTest {
+public class ZkCounterTest extends TracerTestBase {
 
   @Test
   void twoSuccessfullL2l1Logs() {
@@ -62,7 +63,7 @@ public class ZkCounterTest {
             .balance(Wei.fromEth(1))
             .address(TEST_DEFAULT.contract())
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     // LOG1 with right topic, and no data
                     .push(TEST_DEFAULT.topic()) // topic
                     .push(0) //  size
@@ -92,7 +93,7 @@ public class ZkCounterTest {
             .build();
 
     final ToyExecutionEnvironmentV2 toyWorld =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(senderAccount, l2l1LogSMC))
             .transaction(tx)
             .zkTracerValidator(zkTracer -> {})
@@ -132,7 +133,7 @@ public class ZkCounterTest {
             .balance(Wei.fromEth(1))
             .address(Address.wrap(Bytes.repeat((byte) 1, Address.SIZE)))
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     // LOG1 with right topic, and no data
                     .push(TEST_DEFAULT.topic()) // topic
                     .push(0) //  size
@@ -146,7 +147,7 @@ public class ZkCounterTest {
             .balance(Wei.fromEth(1))
             .address(Address.wrap(Bytes.repeat((byte) 2, Address.SIZE)))
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     // LOG1 with right topic, and no data
                     .push(TEST_DEFAULT.topic()) // topic
                     .push(0) //  size
@@ -164,7 +165,7 @@ public class ZkCounterTest {
             .balance(Wei.fromEth(1))
             .address(TEST_DEFAULT.contract())
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     // LOG2 with right topic, not at the right place
                     .push(TEST_DEFAULT.topic()) // topic 2
                     .push(Bytes.of(1)) // topic 1
@@ -188,7 +189,7 @@ public class ZkCounterTest {
             .build();
 
     final ToyExecutionEnvironmentV2 toyWorld =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(senderAccount, l2l1LogSMC, LOG_ACCOUNT_AND_REVERT, LOG_ACCOUNT))
             .transaction(tx)
             .zkTracerValidator(zkTracer -> {})
@@ -226,7 +227,7 @@ public class ZkCounterTest {
             .balance(Wei.fromEth(1))
             .address(Address.wrap(Bytes.repeat((byte) 1, Address.SIZE)))
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     // populate memory with some data
                     .push(56) // value
                     .push(3) //  offset
@@ -253,7 +254,7 @@ public class ZkCounterTest {
             .build();
 
     final ToyExecutionEnvironmentV2 toyWorld =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(senderAccount, callPRC))
             .transaction(tx)
             .zkTracerValidator(zkTracer -> {})
@@ -309,7 +310,7 @@ public class ZkCounterTest {
             .balance(Wei.fromEth(1))
             .address(Address.wrap(Bytes.repeat((byte) 1, Address.SIZE)))
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     // populate memory with BBS
                     .push(base ? 513 : 4) // value
                     .push(BBS_MIN_OFFSET) //  offset
@@ -344,7 +345,7 @@ public class ZkCounterTest {
             .build();
 
     final ToyExecutionEnvironmentV2 toyWorld =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(senderAccount, callPRC))
             .transaction(tx)
             .zkTracerValidator(zkTracer -> {})

--- a/arithmetization/src/test/java/net/consensys/linea/replaytests/Issue1180Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/replaytests/Issue1180Tests.java
@@ -39,7 +39,7 @@ public class Issue1180Tests extends TracerTestBase {
 
   @Test
   void failingSmodInstructionTest() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push("ffffffffffffffffffffffffffffffffffffffffffffffffffdc633cace676d7")
         .push("0000000000000000000000000000000000000000000000000000000000000000")

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ContractsForSLoadAndSStoreTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ContractsForSLoadAndSStoreTest.java
@@ -80,14 +80,14 @@ public class ContractsForSLoadAndSStoreTest extends TracerTestBase {
     List<ToyAccount> accounts = List.of(userAccount, contractAccount);
 
     ToyExecutionEnvironmentV2 toyExecutionEnvironmentV2 =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(accounts)
             .transactions(List.of(txToInitiateRecursiveCalls))
             .transactionProcessingResultValidator(
                 TransactionProcessingResultValidator.EMPTY_VALIDATOR)
             .build();
 
-    toyExecutionEnvironmentV2.run(testInfo);
+    toyExecutionEnvironmentV2.run();
   }
 
   @Test
@@ -243,7 +243,7 @@ public class ContractsForSLoadAndSStoreTest extends TracerTestBase {
             contractAccountE);
 
     ToyExecutionEnvironmentV2 toyExecutionEnvironmentV2 =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(accounts)
             .transactions(
                 List.of(
@@ -257,6 +257,6 @@ public class ContractsForSLoadAndSStoreTest extends TracerTestBase {
                 TransactionProcessingResultValidator.EMPTY_VALIDATOR)
             .build();
 
-    toyExecutionEnvironmentV2.run(testInfo);
+    toyExecutionEnvironmentV2.run();
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleBesuTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleBesuTest.java
@@ -56,11 +56,11 @@ public class ExampleBesuTest extends TracerTestBase {
     Transaction tx =
         ToyTransaction.builder().sender(senderAccount).to(receiverAccount).keyPair(keyPair).build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, receiverAccount))
         .transaction(tx)
         .runWithBesuNode(true)
         .build()
-        .run(testInfo);
+        .run();
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleBesuTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleBesuTest.java
@@ -29,9 +29,13 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class ExampleBesuTest extends TracerTestBase {
+  // TODO: will be reenabled once https://github.com/Consensys/zkevm-monorepo/issues/4247 is
+  // resolved
+  @Disabled
   @Test
   void test() {
     KeyPair keyPair = new SECP256K1().generateKeyPair();

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleBesuTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleBesuTest.java
@@ -50,7 +50,7 @@ public class ExampleBesuTest extends TracerTestBase {
             .nonce(6)
             .address(Address.fromHexString("0x111111"))
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     .push(32, 0xbeef)
                     .push(32, 0xdead)
                     .op(OpCode.ADD)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleMultiBlockTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleMultiBlockTest.java
@@ -165,7 +165,7 @@ class ExampleMultiBlockTest extends TracerTestBase {
             .build();
 
     MultiBlockExecutionEnvironment.MultiBlockExecutionEnvironmentBuilder builder =
-        MultiBlockExecutionEnvironment.builder();
+        MultiBlockExecutionEnvironment.builder(testInfo);
     builder
         .accounts(
             List.of(
@@ -209,7 +209,7 @@ class ExampleMultiBlockTest extends TracerTestBase {
     Transaction tx =
         ToyTransaction.builder().sender(senderAccount).to(receiverAccount).keyPair(keyPair).build();
 
-    MultiBlockExecutionEnvironment.builder()
+    MultiBlockExecutionEnvironment.builder(testInfo)
         .accounts(List.of(senderAccount, receiverAccount))
         .addBlock(List.of(tx))
         .build()
@@ -306,7 +306,7 @@ class ExampleMultiBlockTest extends TracerTestBase {
           }
         };
 
-    MultiBlockExecutionEnvironment.builder()
+    MultiBlockExecutionEnvironment.builder(testInfo)
         .accounts(List.of(senderAccount, frameworkEntrypointAccount, snippetAccount))
         .addBlock(List.of(tx))
         .addBlock(List.of(tx2))

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleMultiBlockTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleMultiBlockTest.java
@@ -199,7 +199,7 @@ class ExampleMultiBlockTest extends TracerTestBase {
             .nonce(6)
             .address(Address.fromHexString("0x111111"))
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     .push(32, 0xbeef)
                     .push(32, 0xdead)
                     .op(OpCode.ADD)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleSolidityTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleSolidityTest.java
@@ -134,12 +134,12 @@ public class ExampleSolidityTest extends TracerTestBase {
           }
         };
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, frameworkEntrypointAccount, snippetAccount))
         .transaction(tx)
         .transactionProcessingResultValidator(resultValidator)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -183,12 +183,12 @@ public class ExampleSolidityTest extends TracerTestBase {
           assertEquals(response.singleInt, BigInteger.valueOf(123456));
         };
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, contractAccount))
         .transaction(tx)
         .transactionProcessingResultValidator(resultValidator)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -223,11 +223,11 @@ public class ExampleSolidityTest extends TracerTestBase {
             .keyPair(senderkeyPair)
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, contractAccount))
         .transaction(tx)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -302,11 +302,11 @@ public class ExampleSolidityTest extends TracerTestBase {
             .gasLimit(500000L)
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, yulAccount, frameworkEntrypointAccount))
         .transaction(tx)
         .transactionProcessingResultValidator(resultValidator)
         .build()
-        .run(testInfo);
+        .run();
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleTxTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleTxTest.java
@@ -60,10 +60,10 @@ class ExampleTxTest extends TracerTestBase {
     Transaction tx =
         ToyTransaction.builder().sender(senderAccount).to(receiverAccount).keyPair(keyPair).build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, receiverAccount))
         .transaction(tx)
         .build()
-        .run(testInfo);
+        .run();
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleTxTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleTxTest.java
@@ -50,7 +50,7 @@ class ExampleTxTest extends TracerTestBase {
             .nonce(6)
             .address(Address.fromHexString("0x111111"))
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     .push(32, 0xbeef)
                     .push(32, 0xdead)
                     .op(OpCode.ADD)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/MultiBlockUtils.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/MultiBlockUtils.java
@@ -75,7 +75,7 @@ public class MultiBlockUtils extends TracerTestBase {
     }
 
     MultiBlockExecutionEnvironment.MultiBlockExecutionEnvironmentBuilder builder =
-        MultiBlockExecutionEnvironment.builder()
+        MultiBlockExecutionEnvironment.builder(testInfo)
             .accounts(
                 Stream.concat(senderAccounts.stream(), receiverAccounts.stream())
                     .collect(Collectors.toList()));

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/MultipleCallsRevertingTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/MultipleCallsRevertingTest.java
@@ -186,14 +186,14 @@ public class MultipleCallsRevertingTest extends TracerTestBase {
     transactions.add(txToInitiateCalls);
 
     ToyExecutionEnvironmentV2 toyExecutionEnvironmentV2 =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(accounts)
             .transactions(transactions)
             .transactionProcessingResultValidator(
                 TransactionProcessingResultValidator.EMPTY_VALIDATOR)
             .build();
 
-    toyExecutionEnvironmentV2.run(testInfo);
+    toyExecutionEnvironmentV2.run();
   }
 
   private static Stream<Arguments> contractForSLoadAndSStoreTestSource() {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/OpCodesTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/OpCodesTest.java
@@ -38,7 +38,7 @@ public class OpCodesTest extends TracerTestBase {
   }
 
   private Bytes getAllOpCodesProgram() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     for (OpCodeData opCodeData : opCodeDataList) {
       if (opCodeData != null) {
         if (opCodeData.instructionFamily() != InstructionFamily.HALT

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/SignedOperationsExtensiveTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/SignedOperationsExtensiveTest.java
@@ -45,7 +45,7 @@ public class SignedOperationsExtensiveTest extends TracerTestBase {
   @ParameterizedTest
   @MethodSource("signedComparisonsModDivTestSource")
   void signedComparisonsModDivTest(OpCode opCode, String a, String b) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram().push(b).push(a).op(opCode);
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo).push(b).push(a).op(opCode);
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
     bytecodeRunner.run(testInfo);
   }
@@ -113,7 +113,7 @@ public class SignedOperationsExtensiveTest extends TracerTestBase {
   @MethodSource("signExtendTestSource")
   private void signExtendTest(String position, String value) {
     BytecodeCompiler program =
-        BytecodeCompiler.newProgram().push(value).push(position).op(OpCode.SIGNEXTEND);
+        BytecodeCompiler.newProgram(testInfo).push(value).push(position).op(OpCode.SIGNEXTEND);
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
     bytecodeRunner.run(testInfo);
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/Utils.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/Utils.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer;
 
+import static net.consensys.linea.reporting.TracerTestBase.testInfo;
 import static net.consensys.linea.testing.BytecodeCompiler.newProgram;
 
 import net.consensys.linea.zktracer.opcode.OpCode;
@@ -22,10 +23,11 @@ import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 
 public class Utils {
-  public static final Bytes REVERT = newProgram().push(0).push(0).op(OpCode.REVERT).compile();
+  public static final Bytes REVERT =
+      newProgram(testInfo).push(0).push(0).op(OpCode.REVERT).compile();
 
   public static final Bytes POPULATE_MEMORY =
-      newProgram()
+      newProgram(testInfo)
           .op(OpCode.CALLDATASIZE) // size
           .push(0) // offset
           .push(0) // dest offset
@@ -33,7 +35,7 @@ public class Utils {
           .compile();
 
   public static Bytes call(Address address, boolean staticCall) {
-    return newProgram()
+    return newProgram(testInfo)
         .immediate(POPULATE_MEMORY)
         .push(0) // retSize
         .push(0) // retOffset
@@ -47,7 +49,7 @@ public class Utils {
   }
 
   public static Bytes delegateCall(Address address) {
-    return newProgram()
+    return newProgram(testInfo)
         .immediate(POPULATE_MEMORY)
         .push(0) // retSize
         .push(0) // retOffset

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/ExceptionAtContextReEntry.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/ExceptionAtContextReEntry.java
@@ -54,11 +54,11 @@ public class ExceptionAtContextReEntry extends TracerTestBase {
   @Test
   public void firstInstructionAfterResumingFromUnsuccessfulMessageCallIsExceptional() {
 
-    BytecodeCompiler initCode = BytecodeCompiler.newProgram();
+    BytecodeCompiler initCode = BytecodeCompiler.newProgram(testInfo);
     initCode.push(ADD.byteValue()).push(0).op(MSTORE8).push(1).push(0).op(RETURN);
     // this init code deploys the byte code "0x01" (when given sufficient gas)
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     // we do a deployment of a smart contract whose bytecode is "0x01"
     Bytes initCodeBytes = initCode.compile();
@@ -105,7 +105,7 @@ public class ExceptionAtContextReEntry extends TracerTestBase {
   @Test
   public void firstInstructionAfterResumingFromSuccessfulMessageCallIsExceptional() {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     // message call to a simple smart contract
     program
@@ -135,7 +135,7 @@ public class ExceptionAtContextReEntry extends TracerTestBase {
   @Test
   public void firstInstructionAfterResumingFromSuccessfulContractCreationIsExceptional() {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program.push(0).push(0).push(0).op(CREATE);
 
     // the previous operation leaves the stack in the following state
@@ -157,7 +157,7 @@ public class ExceptionAtContextReEntry extends TracerTestBase {
   @Test
   public void firstInstructionAfterResumingFromUnsuccessfulContractCreationIsExceptional() {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program.push(ADD.byteValue()).push(0).op(MSTORE8);
     // memory = [01 00 00 ... [
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/ExceptionUtils.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/ExceptionUtils.java
@@ -68,7 +68,7 @@ public class ExceptionUtils extends TracerTestBase {
   }
 
   public static BytecodeCompiler getProgramStaticCallToCodeAddress(int gas) {
-    return BytecodeCompiler.newProgram()
+    return BytecodeCompiler.newProgram(testInfo)
         .push(0) // byte size of return data
         .push(0) // retOffset
         .push(0) // byte size calldata
@@ -79,7 +79,7 @@ public class ExceptionUtils extends TracerTestBase {
   }
 
   public static BytecodeCompiler getProgramStaticCallToCodeAccount() {
-    return BytecodeCompiler.newProgram()
+    return BytecodeCompiler.newProgram(testInfo)
         .push(0) // byte size of return data
         .push(0) // retOffset
         .push(0) // byte size calldata
@@ -120,7 +120,7 @@ public class ExceptionUtils extends TracerTestBase {
     Bytes initCodePart2 =
         Bytes.fromHexString("0xFF60005260206000F30000000000000000000000000000000000000000000000");
 
-    return BytecodeCompiler.newProgram()
+    return BytecodeCompiler.newProgram(testInfo)
         .push(initCodePart1) // value
         .push(0) // offset
         .op(OpCode.MSTORE)
@@ -133,7 +133,7 @@ public class ExceptionUtils extends TracerTestBase {
     BytecodeCompiler program =
         (opCode == OpCode.CREATE || opCode == OpCode.CREATE2)
             ? getPgPushInitCodeToMem()
-            : BytecodeCompiler.newProgram();
+            : BytecodeCompiler.newProgram(testInfo);
     switch (opCode) {
       case LOG0 -> program
           .push(32) // size
@@ -208,7 +208,7 @@ public class ExceptionUtils extends TracerTestBase {
     checkArgument(startByte >= 0);
     checkArgument(startByte < 256);
 
-    BytecodeCompiler initProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler initProgram = BytecodeCompiler.newProgram(testInfo);
     initProgram
         .push(Integer.toHexString(startByte))
         .push(0)
@@ -220,7 +220,7 @@ public class ExceptionUtils extends TracerTestBase {
     final String initProgramAsString = initProgram.compile().toString().substring(2);
     final int initProgramByteSize = initProgram.compile().size();
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(initProgramAsString + "00".repeat(32 - initProgramByteSize))

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/InvalidCodePrefixAndMaxCodeSizeExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/InvalidCodePrefixAndMaxCodeSizeExceptionTest.java
@@ -55,7 +55,7 @@ public class InvalidCodePrefixAndMaxCodeSizeExceptionTest extends TracerTestBase
     ToyAccount userAccount =
         ToyAccount.builder().balance(Wei.fromEth(1000)).nonce(1).address(userAddress).build();
 
-    BytecodeCompiler initProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler initProgram = BytecodeCompiler.newProgram(testInfo);
 
     initProgram
         .push(Integer.toHexString(EIP_3541_MARKER))
@@ -101,7 +101,7 @@ public class InvalidCodePrefixAndMaxCodeSizeExceptionTest extends TracerTestBase
     ToyAccount userAccount =
         ToyAccount.builder().balance(Wei.fromEth(1000)).nonce(1).address(userAddress).build();
 
-    BytecodeCompiler initProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler initProgram = BytecodeCompiler.newProgram(testInfo);
 
     initProgram.push(MAX_CODE_SIZE + 1).push(0).op(OpCode.RETURN);
 
@@ -136,7 +136,7 @@ public class InvalidCodePrefixAndMaxCodeSizeExceptionTest extends TracerTestBase
   // (success)
   @Test
   void invalidCodePrefixExceptionForCreateTest() {
-    BytecodeCompiler initProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler initProgram = BytecodeCompiler.newProgram(testInfo);
     initProgram
         .push(Integer.toHexString(EIP_3541_MARKER))
         .push(0)
@@ -147,7 +147,7 @@ public class InvalidCodePrefixAndMaxCodeSizeExceptionTest extends TracerTestBase
     final String initProgramAsString = initProgram.compile().toString().substring(2);
     final int initProgramByteSize = initProgram.compile().size();
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(initProgramAsString + "00".repeat(32 - initProgramByteSize))
@@ -170,12 +170,12 @@ public class InvalidCodePrefixAndMaxCodeSizeExceptionTest extends TracerTestBase
   // (success)
   @Test
   void maxCodeSizeExceptionForCreateTest() {
-    BytecodeCompiler initProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler initProgram = BytecodeCompiler.newProgram(testInfo);
     initProgram.push(MAX_CODE_SIZE + 1).push(0).op(OpCode.RETURN);
     final String initProgramAsString = initProgram.compile().toString().substring(2);
     final int initProgramByteSize = initProgram.compile().size();
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(initProgramAsString + "00".repeat(32 - initProgramByteSize))

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/InvalidCodePrefixAndMaxCodeSizeExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/InvalidCodePrefixAndMaxCodeSizeExceptionTest.java
@@ -80,9 +80,12 @@ public class InvalidCodePrefixAndMaxCodeSizeExceptionTest extends TracerTestBase
     checkArgument(tx.isContractCreation());
 
     ToyExecutionEnvironmentV2 toyExecutionEnvironment =
-        ToyExecutionEnvironmentV2.builder().accounts(List.of(userAccount)).transaction(tx).build();
+        ToyExecutionEnvironmentV2.builder(testInfo)
+            .accounts(List.of(userAccount))
+            .transaction(tx)
+            .build();
 
-    toyExecutionEnvironment.run(testInfo);
+    toyExecutionEnvironment.run();
 
     assertEquals(
         INVALID_CODE_PREFIX,
@@ -117,9 +120,12 @@ public class InvalidCodePrefixAndMaxCodeSizeExceptionTest extends TracerTestBase
     checkArgument(tx.isContractCreation());
 
     ToyExecutionEnvironmentV2 toyExecutionEnvironment =
-        ToyExecutionEnvironmentV2.builder().accounts(List.of(userAccount)).transaction(tx).build();
+        ToyExecutionEnvironmentV2.builder(testInfo)
+            .accounts(List.of(userAccount))
+            .transaction(tx)
+            .build();
 
-    toyExecutionEnvironment.run(testInfo);
+    toyExecutionEnvironment.run();
 
     assertEquals(
         TracedException.MAX_CODE_SIZE_EXCEPTION,

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/InvalidOpcodeExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/InvalidOpcodeExceptionTest.java
@@ -38,7 +38,7 @@ public class InvalidOpcodeExceptionTest extends TracerTestBase {
 
   @Test
   void invalidOpcodeExceptionTest() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program.op(OpCode.INVALID);
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
     bytecodeRunner.run(testInfo);
@@ -50,7 +50,7 @@ public class InvalidOpcodeExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @MethodSource("nonOpcodeExceptionSource")
   void nonOpcodeExceptionTest(int value) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program.immediate(value);
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
     bytecodeRunner.run(testInfo);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/MemoryExpansionExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/MemoryExpansionExceptionTest.java
@@ -45,7 +45,7 @@ public class MemoryExpansionExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @MethodSource("memoryExpansionExceptionTestSource")
   public void memoryExpansionExceptionTest(boolean triggerRoob, OpCode opCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     new MxpTestUtils().triggerNonTrivialButMxpxOrRoobForOpCode(program, triggerRoob, opCode);
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
     bytecodeRunner.run(testInfo);
@@ -60,7 +60,7 @@ public class MemoryExpansionExceptionTest extends TracerTestBase {
   public void soloMemoryExpansionTest() {
     boolean triggerRoob = false;
     OpCode opCode = OpCode.CODECOPY;
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     new MxpTestUtils().triggerNonTrivialButMxpxOrRoobForOpCode(program, triggerRoob, opCode);
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
     bytecodeRunner.run(testInfo);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfGasExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfGasExceptionTest.java
@@ -51,7 +51,7 @@ public class OutOfGasExceptionTest extends TracerTestBase {
   @MethodSource("outOfGasExceptionWithEmptyAccountsAndNoMemoryExpansionCostTestSource")
   void outOfGasExceptionWithEmptyAccountsAndNoMemoryExpansionCostTest(
       OpCode opCode, int nPushes, int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     for (int i = 0; i < nPushes; i++) {
       // In order to disambiguate between empty stack items and writing a result of 0 on the stack
@@ -128,7 +128,7 @@ public class OutOfGasExceptionTest extends TracerTestBase {
    */
   void outOfGasExceptionCallTest(
       int value, boolean targetAddressExists, boolean isWarm, int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     if (targetAddressExists && isWarm) {
       // Note: this is a possible way to warm the address
@@ -199,7 +199,7 @@ public class OutOfGasExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionSLoad(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(2) // value
@@ -226,7 +226,7 @@ public class OutOfGasExceptionTest extends TracerTestBase {
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionJump(int cornerCase) {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(4)
             .op(OpCode.JUMP)
             .op(OpCode.INVALID)
@@ -254,7 +254,7 @@ public class OutOfGasExceptionTest extends TracerTestBase {
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionJumpi(int cornerCase) {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(1) // pc = 0, 1
             .push(7) // pc = 2, 3
             .op(OpCode.JUMPI) // pc = 4

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfGasExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfGasExceptionTest.java
@@ -71,7 +71,7 @@ public class OutOfGasExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 
@@ -156,10 +156,10 @@ public class OutOfGasExceptionTest extends TracerTestBase {
               .nonce(10)
               .address(Address.fromHexString("ca11ee"))
               .build();
-      gasCost = bytecodeRunner.runOnlyForGasCost(List.of(calleeAccount));
+      gasCost = bytecodeRunner.runOnlyForGasCost(List.of(calleeAccount), testInfo);
       bytecodeRunner.run(gasCost + cornerCase, List.of(calleeAccount), testInfo);
     } else {
-      gasCost = bytecodeRunner.runOnlyForGasCost();
+      gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
       bytecodeRunner.run(gasCost + cornerCase, testInfo);
     }
 
@@ -214,7 +214,7 @@ public class OutOfGasExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 
@@ -242,7 +242,7 @@ public class OutOfGasExceptionTest extends TracerTestBase {
       // 21000L intrinsic gas cost + 3L PUSH + 8L JUMP, and we retrieve 1
       gasCost = GAS_CONST_G_TRANSACTION + GAS_CONST_G_VERY_LOW + GAS_CONST_G_MID - 1L;
     } else {
-      gasCost = bytecodeRunner.runOnlyForGasCost();
+      gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
     }
     bytecodeRunner.run(gasCost, testInfo);
 
@@ -273,7 +273,7 @@ public class OutOfGasExceptionTest extends TracerTestBase {
       // 21000L intrinsic gas cost + 3L PUSH + 10L JUMP, and we retrieve 1
       gasCost = GAS_CONST_G_TRANSACTION + 2 * GAS_CONST_G_VERY_LOW + GAS_CONST_G_HIGH - 1L;
     } else {
-      gasCost = bytecodeRunner.runOnlyForGasCost();
+      gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
     }
 
     bytecodeRunner.run(gasCost, testInfo);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfGasMemExpExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfGasMemExpExceptionTest.java
@@ -52,7 +52,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 
@@ -77,7 +77,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 
@@ -108,7 +108,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 
@@ -132,7 +132,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost(calldata);
+    long gasCost = bytecodeRunner.runOnlyForGasCost(calldata, testInfo);
 
     bytecodeRunner.run(Wei.fromEth(1), gasCost + cornerCase, List.of(), calldata, testInfo);
 
@@ -157,7 +157,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 
@@ -196,7 +196,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 
@@ -224,7 +224,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost(List.of(codeOwnerAccount));
+    long gasCost = bytecodeRunner.runOnlyForGasCost(List.of(codeOwnerAccount), testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, List.of(codeOwnerAccount), testInfo);
 
@@ -250,7 +250,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 
@@ -271,7 +271,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost(List.of(returnDataProviderAccount));
+    long gasCost = bytecodeRunner.runOnlyForGasCost(List.of(returnDataProviderAccount), testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, List.of(returnDataProviderAccount), testInfo);
 
@@ -297,7 +297,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 
@@ -325,7 +325,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = programInitCodeToMem.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 
@@ -366,7 +366,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 
@@ -391,7 +391,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 
@@ -417,7 +417,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 
@@ -444,7 +444,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 
@@ -472,7 +472,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
 
-    long gasCost = bytecodeRunner.runOnlyForGasCost();
+    long gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     bytecodeRunner.run(gasCost + cornerCase, testInfo);
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfGasMemExpExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfGasMemExpExceptionTest.java
@@ -42,7 +42,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionMStore(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(Bytes.fromHexString("0xFF")) // value
@@ -67,7 +67,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionMStore8(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(Bytes.fromHexString("0xFF")) // value
@@ -92,7 +92,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionMLoad(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(
@@ -119,7 +119,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionCallDataCopy(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     Bytes calldata =
         Bytes.fromHexString("0x7FFFFFFFFFFFFF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
@@ -143,7 +143,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionCodeCopy(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(Bytes.fromHexString("0xFA")) // value
@@ -168,7 +168,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionWarmExtCodeCopy(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         // constructor
@@ -207,7 +207,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {0})
   void outOfGasExceptionColdExtCodeCopy(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     final int foreignCodeSize = 70;
     final ToyAccount codeOwnerAccount =
@@ -235,7 +235,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionReturn(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(
@@ -282,7 +282,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionRevert(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(
@@ -353,7 +353,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionLog0(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(Bytes.fromHexString("0x7F")) // value
@@ -377,7 +377,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {0})
   void outOfGasExceptionLog1(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(Bytes.fromHexString("0x7F")) // value
@@ -402,7 +402,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionLog2(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(Bytes.fromHexString("0x7F")) // value
@@ -428,7 +428,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionLog3(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(Bytes.fromHexString("0x7F")) // value
@@ -455,7 +455,7 @@ public class OutOfGasMemExpExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {-1, 0, 1})
   void outOfGasExceptionLog4(int cornerCase) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(Bytes.fromHexString("0x7F")) // value

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfSStoreExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfSStoreExceptionTest.java
@@ -39,7 +39,7 @@ public class OutOfSStoreExceptionTest extends TracerTestBase {
         Trace.GAS_CONST_G_CALL_STIPEND + 1
       })
   void outOfSStoreExceptionTest(long remainingGasAfterPushes) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program.push(0).push(0).op(OpCode.SSTORE);
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/StackOverflowExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/StackOverflowExceptionTest.java
@@ -39,7 +39,7 @@ public class StackOverflowExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @MethodSource("stackOverflowExceptionSource")
   void stackOverflowExceptionTest(OpCode opCode, int alpha, int delta) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     for (int i = 0; i < 1024; i++) {
       program.push(0);
     }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/StackUnderflowExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/StackUnderflowExceptionTest.java
@@ -40,7 +40,7 @@ public class StackUnderflowExceptionTest extends TracerTestBase {
   @MethodSource("stackUnderflowExceptionSource")
   void stackUnderflowExceptionTest(
       OpCode opCode, int nPushes, boolean triggersStackUnderflowExceptions) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     for (int i = 0; i < nPushes; i++) {
       program.push(0);
     }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/StaticExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/StaticExceptionTest.java
@@ -40,7 +40,7 @@ public class StaticExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {0, 1})
   void staticExceptionDueToCallWithNonZeroValueTest(int value) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(0) // return at capacity
         .push(0) // return at offset
@@ -50,7 +50,7 @@ public class StaticExceptionTest extends TracerTestBase {
         .op(GAS)
         .op(OpCode.STATICCALL);
 
-    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram(testInfo);
     calleeProgram
         .push(0) // return at capacity
         .push(0) // return at offset
@@ -82,7 +82,7 @@ public class StaticExceptionTest extends TracerTestBase {
 
   @Test
   void staticExceptionDueToSStoreTest() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(0) // return at capacity
         .push(0) // return at offset
@@ -92,7 +92,7 @@ public class StaticExceptionTest extends TracerTestBase {
         .push(1000) // gas
         .op(OpCode.STATICCALL);
 
-    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram(testInfo);
     calleeProgram.push(0).push(0).op(OpCode.SSTORE);
 
     final ToyAccount calleeAccount =
@@ -114,7 +114,7 @@ public class StaticExceptionTest extends TracerTestBase {
 
   @Test
   void staticExceptionDueToSelfDestructTest() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(0) // return at capacity
         .push(0) // return at offset
@@ -124,7 +124,7 @@ public class StaticExceptionTest extends TracerTestBase {
         .push(1000) // gas
         .op(OpCode.STATICCALL);
 
-    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram(testInfo);
     calleeProgram.push(0).op(OpCode.SELFDESTRUCT);
 
     final ToyAccount calleeAccount =
@@ -147,7 +147,7 @@ public class StaticExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(ints = {0, 1, 2, 3, 4})
   void staticExceptionDueToLogTest(int numberOfTopics) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(0) // return at capacity
         .push(0) // return at offset
@@ -157,7 +157,7 @@ public class StaticExceptionTest extends TracerTestBase {
         .push(1000) // gas
         .op(OpCode.STATICCALL);
 
-    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram(testInfo);
     for (int i = 0; i < numberOfTopics; i++) {
       calleeProgram.push(0);
     }
@@ -183,7 +183,7 @@ public class StaticExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @ValueSource(strings = {"CREATE", "CREATE2"})
   void staticExceptionDueToCreateTest(String opCodeName) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(0) // return at capacity
         .push(0) // return at offset
@@ -193,7 +193,7 @@ public class StaticExceptionTest extends TracerTestBase {
         .push(1000) // gas
         .op(OpCode.STATICCALL);
 
-    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram(testInfo);
     if (opCodeName.equals("CREATE2")) {
       calleeProgram.push(0);
     }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/CallTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/CallTest.java
@@ -94,7 +94,7 @@ public class CallTest extends TracerTestBase {
               .nonce(10)
               .address(Address.fromHexString("ca11ee"))
               .build();
-      gasCost = bytecodeRunner.runOnlyForGasCost(List.of(calleeAccount));
+      gasCost = bytecodeRunner.runOnlyForGasCost(List.of(calleeAccount), testInfo);
       // We calculate gas cost to trigger OOGX
       // We retrieve the gas cost of the transaction as it's the gas used for the static call, so
       // intrinsic gas cost already accounted
@@ -104,7 +104,7 @@ public class CallTest extends TracerTestBase {
       bytecodeRunnerStaticCall = BytecodeRunner.of(pgStaticCallToCode.compile());
       bytecodeRunnerStaticCall.run(List.of(calleeAccount, CallProviderAccount), testInfo);
     } else {
-      gasCost = bytecodeRunner.runOnlyForGasCost();
+      gasCost = bytecodeRunner.runOnlyForGasCost(testInfo);
       // We calculate gas cost to trigger OOGX
       // We retrieve the gas cost of the transaction as it's the gas used for the static call, so
       // intrinsic gas cost already accounted

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/CallTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/CallTest.java
@@ -63,7 +63,7 @@ public class CallTest extends TracerTestBase {
     // execution, even if no code is executed
     // call stipend - 1
     int cornerCase = 2299;
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     if (targetAddressExists && isWarm) {
       // Note: this is a possible way to warm the address
@@ -135,7 +135,7 @@ public class CallTest extends TracerTestBase {
 
     for (boolean roob : triggerRoob) {
       // We prepare a program with an MXPX for the opcode
-      BytecodeCompiler pg = BytecodeCompiler.newProgram();
+      BytecodeCompiler pg = BytecodeCompiler.newProgram(testInfo);
       new MxpTestUtils().triggerNonTrivialButMxpxOrRoobForOpCode(pg, roob, OpCode.CALL);
 
       // We prepare a program to static call the code account

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/CreatesTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/CreatesTest.java
@@ -56,7 +56,7 @@ public class CreatesTest extends TracerTestBase {
     BytecodeCompiler program = simpleProgramEmptyStorage(opCode);
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
-    long gasCostTx = bytecodeRunner.runOnlyForGasCost();
+    long gasCostTx = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     /*
     for CREATE/CREATE2, Static Exception happens before deployment, so we test OOGX before deployment

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/CreatesTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/CreatesTest.java
@@ -89,7 +89,7 @@ public class CreatesTest extends TracerTestBase {
 
     for (boolean roob : triggerRoob) {
       // We prepare a program with an MXPX for the opcode
-      BytecodeCompiler pg = BytecodeCompiler.newProgram();
+      BytecodeCompiler pg = BytecodeCompiler.newProgram(testInfo);
       new MxpTestUtils().triggerNonTrivialButMxpxOrRoobForOpCode(pg, roob, opCode);
 
       // We prepare a program to static call the code account

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/JumpTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/JumpTest.java
@@ -52,7 +52,7 @@ public class JumpTest extends TracerTestBase {
   @ValueSource(ints = {5, 6})
   void jumpAndOogExceptionsJump(int jumpCounter) {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(jumpCounter) // pc: 0 - 5 i/o 4, Trigger Jump Exception
             .op(OpCode.JUMP) // pc: 2
             .op(OpCode.INVALID) // pc: 3
@@ -81,7 +81,7 @@ public class JumpTest extends TracerTestBase {
   @ValueSource(ints = {6, 9})
   void jumpAndOogExceptionsJumpi(int jumpCounter) {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(1) // pc = 0, 1
             .push(jumpCounter) // pc = 2, 3, i/o 7, Trigger Jump Exception
             .op(OpCode.JUMPI) // pc = 4

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/LogsTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/LogsTest.java
@@ -84,7 +84,7 @@ public class LogsTest extends TracerTestBase {
 
     for (boolean roob : triggerRoob) {
       // We prepare a program with an MXPX for the opcode
-      BytecodeCompiler pg = BytecodeCompiler.newProgram();
+      BytecodeCompiler pg = BytecodeCompiler.newProgram(testInfo);
       new MxpTestUtils().triggerNonTrivialButMxpxOrRoobForOpCode(pg, roob, opCode);
 
       // We prepare a program to static call the code account

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/LogsTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/LogsTest.java
@@ -56,7 +56,7 @@ public class LogsTest extends TracerTestBase {
     BytecodeCompiler program = simpleProgramEmptyStorage(opCode);
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
-    long gasCostTx = bytecodeRunner.runOnlyForGasCost();
+    long gasCostTx = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     int cornerCase = -1;
     // We calculate gas cost to trigger OOGX

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/ReturnDataCopyTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/ReturnDataCopyTest.java
@@ -50,7 +50,7 @@ public class ReturnDataCopyTest extends TracerTestBase {
     BytecodeCompiler programWithoutRdcx = getProgramRDCFromStaticCallToCodeAccount(!RDCX, !MXPX);
     BytecodeRunner bytecodeRunnerWithoutRdcx = BytecodeRunner.of(programWithoutRdcx.compile());
     long gasCostWithoutRdcx =
-        bytecodeRunnerWithoutRdcx.runOnlyForGasCost(List.of(codeProviderAccount));
+        bytecodeRunnerWithoutRdcx.runOnlyForGasCost(List.of(codeProviderAccount), testInfo);
 
     // We compute the final gas cost with RDCX and OOGX trigger
     // We trigger RDCX by adding 1 to RDS

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/ReturnTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/ReturnTest.java
@@ -14,6 +14,7 @@
  */
 package net.consensys.linea.zktracer.exceptions.multiExceptions;
 
+import static net.consensys.linea.zktracer.Fork.isPostShanghai;
 import static net.consensys.linea.zktracer.Trace.EIP_3541_MARKER;
 import static net.consensys.linea.zktracer.Trace.MAX_CODE_SIZE;
 import static net.consensys.linea.zktracer.exceptions.ExceptionUtils.getPgCreateInitCodeWithReturnStartByteAndSize;
@@ -108,10 +109,13 @@ public class ReturnTest extends TracerTestBase {
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
     // We run the program with a gas cost that triggers OOGX
     // We calculate all opcodes gas before the RETURN opcode
-    // 32027L = 3L PUSH + 3L PUSH + 6L MSTORE + 3L PUSH + 3L PUSH + 3L PUSH + 32000L CREATE +
-    // ((32027-3-3-6-3-3-3-32000/64))(less than 0.5 so not adding gas) + 3L PUSH + 3L PUSH
+    // 32027L = 3L PUSH + 3L PUSH + 6L MSTORE + 3L PUSH + 3L PUSH + 3L PUSH + 32000L CREATE
+    // + (post-Shanghai) 2L INIT CODE COST
+    // + ((32027-3-3-6-3-3-3-32000/64))(less than 0.5 so not adding gas) + 3L PUSH + 3L PUSH
     // 21000L for the intrinsic transaction cost
-    bytecodeRunner.run(32027L + 21000L, testInfo);
+    var initCodeCost = isPostShanghai(testInfo.chainConfig.fork) ? 2L : 0L;
+    var gasCostBefReturn = 32027L + 21000L + initCodeCost;
+    bytecodeRunner.run(gasCostBefReturn, testInfo);
 
     // Max Code Size Exception check before OOGX in tracer
     assertEquals(
@@ -131,11 +135,14 @@ public class ReturnTest extends TracerTestBase {
         BytecodeRunner.of(programWithICPXAndMCSX.compile());
     // We run the program with a gas cost that triggers OOGX
     // We calculate all opcodes gas before the RETURN opcode
-    // 32036L = 3L PUSH + 3L PUSH + 6L MSTORE + 3L PUSH + 3L PUSH + 3L PUSH + 32000L CREATE +
-    // ((32036-3-3-6-3-3-3-32000)/64)(less than 0.5 so not adding gas) + 3L PUSH + 3L PUSH + 6L
+    // 32036L = 3L PUSH + 3L PUSH + 6L MSTORE + 3L PUSH + 3L PUSH + 3L PUSH + 32000L CREATE
+    // + (post-Shanghai) 2L INIT CODE COST
+    // + ((32036-3-3-6-3-3-3-32000)/64)(less than 0.5 so not adding gas) + 3L PUSH + 3L PUSH + 6L
     // MSTORE8 + 3L PUSH + 3L PUSH
     // 21000L for the intrinsic transaction cost
-    bytecodeRunnerWithICPXAndMCSX.run(32039L + 21000L, testInfo);
+    var initCodeCost = isPostShanghai(testInfo.chainConfig.fork) ? 2L : 0L;
+    var gasCostBefReturn = 32039L + 21000L + initCodeCost;
+    bytecodeRunnerWithICPXAndMCSX.run(gasCostBefReturn, testInfo);
 
     // Max Code Size Exception check is done prior to OOGX and Invalid Code Prefix exception in
     // tracer

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/ReturnTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/ReturnTest.java
@@ -47,7 +47,7 @@ public class ReturnTest extends TracerTestBase {
     BytecodeCompiler programWithoutICP =
         getPgCreateInitCodeWithReturnStartByteAndSize(startByte, 1);
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(programWithoutICP.compile());
-    long gascost = bytecodeRunner.runOnlyForGasCost();
+    long gascost = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     // We prepare program with Invalid Code Prefix exception
     int startByteWithICPX = EIP_3541_MARKER;

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/ReturnTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/ReturnTest.java
@@ -90,12 +90,12 @@ public class ReturnTest extends TracerTestBase {
 
   @Test
   void maxCodeSizeAndOogExceptionForCreate() {
-    BytecodeCompiler initProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler initProgram = BytecodeCompiler.newProgram(testInfo);
     initProgram.push(MAX_CODE_SIZE + 1).push(0).op(OpCode.RETURN);
     final String initProgramAsString = initProgram.compile().toString().substring(2);
     final int initProgramByteSize = initProgram.compile().size();
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push(initProgramAsString + "00".repeat(32 - initProgramByteSize))

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/SelfDestructTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/SelfDestructTest.java
@@ -48,7 +48,7 @@ public class SelfDestructTest extends TracerTestBase {
     BytecodeCompiler program = simpleProgramEmptyStorage(OpCode.SELFDESTRUCT);
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
-    long gasCostTx = bytecodeRunner.runOnlyForGasCost();
+    long gasCostTx = bytecodeRunner.runOnlyForGasCost(testInfo);
 
     int cornerCase = -1;
     // We calculate gas cost to trigger OOGX

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/SstoreTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/SstoreTest.java
@@ -68,7 +68,7 @@ public class SstoreTest extends TracerTestBase {
     BytecodeCompiler program = simpleProgramEmptyStorage(OpCode.SSTORE);
     Bytes pgCompile = program.compile();
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(pgCompile);
-    long gasCostTx = bytecodeRunner.runOnlyForGasCost();
+    long gasCostTx = bytecodeRunner.runOnlyForGasCost(testInfo);
     int cornerCase = -1;
 
     // We calculate gas cost to trigger OOGX

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/SstoreTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/SstoreTest.java
@@ -42,7 +42,7 @@ STATIC & OOGX : SSTORE
 public class SstoreTest extends TracerTestBase {
   @Test
   public void staticAndOutOfSStoreExceptions() {
-    BytecodeCompiler pg = BytecodeCompiler.newProgram();
+    BytecodeCompiler pg = BytecodeCompiler.newProgram(testInfo);
 
     pg.push(0).push(0).op(OpCode.SSTORE);
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/BalanceTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/BalanceTests.java
@@ -73,7 +73,8 @@ public class BalanceTests extends TracerTestBase {
           .address(Address.fromHexString("0xadd7e55"))
           .build();
 
-  Bytes revertByteCode = BytecodeCompiler.newProgram().push(0).push(0).op(OpCode.REVERT).compile();
+  Bytes revertByteCode =
+      BytecodeCompiler.newProgram(testInfo).push(0).push(0).op(OpCode.REVERT).compile();
 
   ToyAccount revertAccount =
       ToyAccount.builder()

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/BalanceTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/BalanceTests.java
@@ -41,23 +41,23 @@ public class BalanceTests extends TracerTestBase {
   @Test
   void unrevertedValueTransfer() {
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(accounts)
         .transaction(stopTransaction)
         .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
   void revertedValueTransferTest() {
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(accounts)
         .transaction(revertTransaction)
         .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   KeyPair keyPair = new SECP256K1().generateKeyPair();

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/CallDataTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/CallDataTests.java
@@ -50,12 +50,12 @@ public class CallDataTests extends TracerTestBase {
   void nonAlignedCallDataInCallTest() {
 
     Transaction transaction = transactionCallingCallDataCodeAccount();
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(accounts)
         .transaction(transaction)
         .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   // @Test

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/CallDataTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/CallDataTests.java
@@ -66,7 +66,7 @@ public class CallDataTests extends TracerTestBase {
       Bytes.fromHexString("abcdef01234567890000deadbeef0000aa0f517e002024aa9876543210fedcba");
 
   Bytes callDataByteCode =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .push(13) // size
           .push(29) // sourceOffset
           .push(17) // targetOffset
@@ -83,7 +83,7 @@ public class CallDataTests extends TracerTestBase {
           .compile();
 
   final Bytes callerCode =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .push(callData32)
           .push(2)
           .op(OpCode.MSTORE)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/CallTrivialCasesTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/CallTrivialCasesTest.java
@@ -28,7 +28,7 @@ public class CallTrivialCasesTest extends TracerTestBase {
   @Test
   void eoaCallScenarioTest() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(0)
             .push(0)
             .push(0)
@@ -45,7 +45,7 @@ public class CallTrivialCasesTest extends TracerTestBase {
   @Test
   void eoaCallWithCallDataAndReturnDataCapacityTest() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(0x31)
             .push(0x11)
             .push(0x22)
@@ -62,7 +62,7 @@ public class CallTrivialCasesTest extends TracerTestBase {
   @Test
   void eoaCallScenarioTestZeroCalleeGas() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(0)
             .push(0)
             .push(0)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/CodeCopyingInitializationCodeTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/CodeCopyingInitializationCodeTest.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class CodeCopyingInitializationCodeTest extends TracerTestBase {
 
   final Bytes initCodeSimple =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .op(OpCode.CODESIZE)
           .push(0)
           .push(0)
@@ -57,7 +57,7 @@ public class CodeCopyingInitializationCodeTest extends TracerTestBase {
           .compile();
 
   final Bytes initCodeWithMload =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .op(OpCode.CODESIZE)
           .push(0)
           .push(0)
@@ -67,7 +67,7 @@ public class CodeCopyingInitializationCodeTest extends TracerTestBase {
           .compile();
 
   final Bytes initCodeDeploysItself =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .op(OpCode.CODESIZE)
           .push(0)
           .push(0)
@@ -189,7 +189,7 @@ public class CodeCopyingInitializationCodeTest extends TracerTestBase {
   }
 
   private Bytes deployerOf(Bytes initCode) {
-    return BytecodeCompiler.newProgram()
+    return BytecodeCompiler.newProgram(testInfo)
         .push(initCode)
         .push(0) // offset
         .op(OpCode.MSTORE)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/CodeCopyingInitializationCodeTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/CodeCopyingInitializationCodeTest.java
@@ -180,12 +180,12 @@ public class CodeCopyingInitializationCodeTest extends TracerTestBase {
   }
 
   private void runTransaction(Transaction transaction) {
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(accounts)
         .transaction(transaction)
         .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   private Bytes deployerOf(Bytes initCode) {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/ContractModifyingStorageTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/ContractModifyingStorageTest.java
@@ -93,9 +93,12 @@ public class ContractModifyingStorageTest extends TracerTestBase {
     checkArgument(tx.isContractCreation());
 
     ToyExecutionEnvironmentV2 toyExecutionEnvironment =
-        ToyExecutionEnvironmentV2.builder().accounts(List.of(userAccount)).transaction(tx).build();
+        ToyExecutionEnvironmentV2.builder(testInfo)
+            .accounts(List.of(userAccount))
+            .transaction(tx)
+            .build();
 
-    toyExecutionEnvironment.run(testInfo);
+    toyExecutionEnvironment.run();
   }
 
   @Test
@@ -124,11 +127,14 @@ public class ContractModifyingStorageTest extends TracerTestBase {
             .build();
 
     ToyExecutionEnvironmentV2 toyExecutionEnvironment =
-        ToyExecutionEnvironmentV2.builder().accounts(List.of(userAccount)).transaction(tx).build();
+        ToyExecutionEnvironmentV2.builder(testInfo)
+            .accounts(List.of(userAccount))
+            .transaction(tx)
+            .build();
 
     // TODO: add transaction to invoke function
 
-    toyExecutionEnvironment.run(testInfo);
+    toyExecutionEnvironment.run();
   }
 
   private final Random rnd = new Random(666);
@@ -199,11 +205,11 @@ public class ContractModifyingStorageTest extends TracerTestBase {
             .value(Wei.fromEth(3))
             .build());
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(account1, account2, account3, account4, account5))
         .transactions(txList)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   // Temporary support function

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/EmptyDeploymentsInTheRootTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/EmptyDeploymentsInTheRootTest.java
@@ -254,12 +254,12 @@ public class EmptyDeploymentsInTheRootTest extends TracerTestBase {
   }
 
   private void runTransaction(Transaction transaction) {
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(accounts)
         .transaction(transaction)
         .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   /**

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/EmptyDeploymentsInTheRootTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/EmptyDeploymentsInTheRootTest.java
@@ -45,14 +45,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class EmptyDeploymentsInTheRootTest extends TracerTestBase {
 
   final Bytes initCodeEmptyDeployment =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .push(0) // size
           .push(0x0c) // offset
           .op(OpCode.RETURN)
           .compile();
 
   final Bytes initCodeNonemptyDeployment =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .op(OpCode.TIMESTAMP) // value, initially was DIFFICULTY
           .push(0) // offset
           .op(OpCode.MSTORE)
@@ -62,14 +62,14 @@ public class EmptyDeploymentsInTheRootTest extends TracerTestBase {
           .compile();
 
   final Bytes initCodeEmptyRevert =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .push(0) // size
           .push(0x0f) // offset
           .op(OpCode.REVERT)
           .compile();
 
   final Bytes initCodeNonemptyRevert =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .op(OpCode.COINBASE) // value
           .push(0) // offset
           .op(OpCode.MSTORE)
@@ -79,12 +79,12 @@ public class EmptyDeploymentsInTheRootTest extends TracerTestBase {
           .compile();
 
   final Bytes initCodeImmediateStackUnderflowException =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .op(OpCode.BLOCKHASH) // immediate SUX
           .compile();
 
   final Bytes initCodeImmediateInvalidException =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .op(OpCode.INVALID) // immediate INVALID
           .compile();
 
@@ -267,7 +267,7 @@ public class EmptyDeploymentsInTheRootTest extends TracerTestBase {
    * @return
    */
   private Bytes deployerOf(Bytes initCode) {
-    return BytecodeCompiler.newProgram()
+    return BytecodeCompiler.newProgram(testInfo)
         .push(initCode)
         .push(0) // offset
         .op(OpCode.MSTORE)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/ExtCodeHashAndAccountExistenceTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/ExtCodeHashAndAccountExistenceTests.java
@@ -34,7 +34,7 @@ public class ExtCodeHashAndAccountExistenceTests extends TracerTestBase {
   @Test
   void extcodexxxForPrecompileBeforeAndAfterTransfer() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(1)
             .op(DUP1)
             .op(EXTCODEHASH) // will return 0
@@ -62,7 +62,7 @@ public class ExtCodeHashAndAccountExistenceTests extends TracerTestBase {
   @Test
   void extcodexxxBeforeAndAfterTransfer() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(69)
             .op(DUP1)
             .op(EXTCODEHASH) // will return 0
@@ -94,7 +94,7 @@ public class ExtCodeHashAndAccountExistenceTests extends TracerTestBase {
   @Test
   void extcodexxxBeforeDuringAndAfterTrivialDeployment() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push("6ff1019c622e4641f86f4bb7232b7901b8d20db6")
             .op(DUP1)
             .op(EXTCODEHASH) // will return 0
@@ -131,7 +131,7 @@ public class ExtCodeHashAndAccountExistenceTests extends TracerTestBase {
   @Test
   void extcodexxxBeforeDuringAndAfterDeploymentDeployingEmtpyByteCode() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push("6ff1019c622e4641f86f4bb7232b7901b8d20db6")
             .op(DUP1)
             .op(EXTCODEHASH) // will return 0
@@ -182,7 +182,7 @@ public class ExtCodeHashAndAccountExistenceTests extends TracerTestBase {
   @Test
   void extcodexxxBeforeDuringAndAfterDeploymentDeployingSingleZeroByte() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push("6ff1019c622e4641f86f4bb7232b7901b8d20db6")
             .op(EXTCODEHASH) // will return 0
             .op(POP)
@@ -208,7 +208,7 @@ public class ExtCodeHashAndAccountExistenceTests extends TracerTestBase {
   @Test
   void extcodexxxOfOneself() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .op(ADDRESS)
             .op(DUP1)
             .op(EXTCODEHASH) // will return the hash of this bytecode:

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/ImmediateRevert.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/ImmediateRevert.java
@@ -27,13 +27,13 @@ public class ImmediateRevert extends TracerTestBase {
 
   @Test
   void testImmediatePop() {
-    BytecodeRunner.of(BytecodeCompiler.newProgram().op(OpCode.POP).compile()).run(testInfo);
+    BytecodeRunner.of(BytecodeCompiler.newProgram(testInfo).op(OpCode.POP).compile()).run(testInfo);
   }
 
   @Test
   void testPopWithinCreate() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(0x50) // POP
                 .push(0)
                 .op(OpCode.MSTORE8)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/JumpDestinationVettingTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/JumpDestinationVettingTest.java
@@ -40,7 +40,7 @@ public class JumpDestinationVettingTest extends TracerTestBase {
   @MethodSource("jumpDestinationVettingCases")
   void jumpDestinationVettingTest(
       int positionOfDeceptiveJumpDest, OpCode pushK, int pushKArgumentLength) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     int nTotalInvalid = 0;
     for (int i = 0; i < N_JUMPS; i++) {
       int nPartialInvalid = random.nextInt(10) + 1;

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/JumpTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/JumpTest.java
@@ -42,7 +42,7 @@ public class JumpTest extends TracerTestBase {
   @MethodSource("provideJumpScenario")
   void jumpScenarioTest(String description, String pcNew) {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(pcNew)
             .op(OpCode.JUMP)
             .op(OpCode.INVALID)
@@ -74,7 +74,7 @@ public class JumpTest extends TracerTestBase {
   @Test
   void simplestJumpiTest() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(1) // pc = 0, 1
             .push(8) // pc = 2, 3
             .op(OpCode.JUMPI) // pc = 4

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/JumpiTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/JumpiTest.java
@@ -50,7 +50,7 @@ public class JumpiTest extends TracerTestBase {
   void jumpiScenarioTest(String description, String jumpiCondition, String pcNew) {
     checkArgument(pcNew.length() <= 64, "pcNew must be at most 32 bytes long");
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(jumpiCondition)
             .push(pcNew)
             .op(OpCode.JUMP)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/KeccakTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/KeccakTests.java
@@ -27,7 +27,7 @@ public class KeccakTests extends TracerTestBase {
   @Test
   void singleEmptyKeccak() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(0) // size
                 .push(0) // offset
                 .op(OpCode.SHA3)
@@ -40,7 +40,7 @@ public class KeccakTests extends TracerTestBase {
   @Test
   void singleWordKeccakNonAligned() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
                 .push(1)
                 .op(OpCode.MSTORE)
@@ -56,7 +56,7 @@ public class KeccakTests extends TracerTestBase {
   @Test
   void singleWordKeccakAligned() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
                 .push(0)
                 .op(OpCode.MSTORE)
@@ -72,7 +72,7 @@ public class KeccakTests extends TracerTestBase {
   @Test
   void singleByteKeccak() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push("ee")
                 .push(1)
                 .op(OpCode.MSTORE8)
@@ -87,7 +87,7 @@ public class KeccakTests extends TracerTestBase {
   @Test
   void testSeveralKeccaks() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(0)
                 .push(0)
                 .op(OpCode.SHA3)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/ReturnDataCopyTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/ReturnDataCopyTest.java
@@ -30,7 +30,7 @@ public class ReturnDataCopyTest extends TracerTestBase {
   @Test
   void testReturnDataCopyFromSha256() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(
                     Bytes.fromHexString(
                         "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"))

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/SimpleGasCalculatorTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/SimpleGasCalculatorTest.java
@@ -27,7 +27,7 @@ public class SimpleGasCalculatorTest extends TracerTestBase {
   @Test
   void simpleGasCalculatorTest() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push("deadbeef") // value
                 .push(0x80) // key
                 .op(OpCode.MSTORE)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/StorageTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/StorageTest.java
@@ -29,7 +29,7 @@ public class StorageTest extends TracerTestBase {
   @Test
   void simpleSstoreSload() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(0x666) // value
                 .push(0xca7) // key
                 .op(OpCode.SSTORE)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/DoubleCall.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/DoubleCall.java
@@ -36,7 +36,7 @@ public class DoubleCall extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void doubleCallToSameAddressWontRevert(OpCode callOpCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, callOpCode, 0, Address.fromHexString(eoaAddress), 1, 0, 0, 0, 0);
     appendCall(program, callOpCode, 0, Address.fromHexString(eoaAddress), 2, 0, 0, 0, 0);
 
@@ -48,7 +48,7 @@ public class DoubleCall extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void doubleCallToSameAddressWillRevert(OpCode callOpCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, callOpCode, 0, Address.fromHexString(eoaAddress), 1, 0, 0, 0, 0);
     appendCall(program, callOpCode, 0, Address.fromHexString(eoaAddress), 2, 0, 0, 0, 0);
     program.op(REVERT); // N.B. The stack contains the two success bits
@@ -62,7 +62,7 @@ public class DoubleCall extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void doubleCallTodifferentAddressesWontRevert(OpCode callOpCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, callOpCode, 0, Address.fromHexString(eoaAddress), 1, 0, 0, 0, 0);
     appendCall(program, callOpCode, 0, Address.fromHexString(eoaAddress2), 2, 0, 0, 0, 0);
 
@@ -74,7 +74,7 @@ public class DoubleCall extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void doubleCallTodifferentAddressesWillRevert(OpCode callOpCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, callOpCode, 0, Address.fromHexString(eoaAddress), 1, 0, 0, 0, 0);
     appendCall(program, callOpCode, 0, Address.fromHexString(eoaAddress2), 2, 0, 0, 0, 0);
     program.push(13).push(71); // the stack already contains two items but why not ...

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/TrimmingTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/TrimmingTests.java
@@ -32,7 +32,7 @@ public class TrimmingTests extends TracerTestBase {
   void targetTrimming() {
 
     BytecodeCompiler bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(1)
             .push(2)
             .push(3)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/abort/BalanceAbortTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/abort/BalanceAbortTests.java
@@ -55,7 +55,7 @@ public class BalanceAbortTests extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE"})
   void insufficientBalanceAbortWarmsUpTarget(OpCode callOpCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendInsufficientBalanceCall(
         program, callOpCode, 1000, Address.fromHexString(eoaAddress), 4, 3, 2, 1);
     program
@@ -82,7 +82,7 @@ public class BalanceAbortTests extends TracerTestBase {
       names = {"CALL", "CALLCODE"})
   void insufficientBalanceAbortWillRevert(OpCode callOpCode) {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendInsufficientBalanceCall(
         program, callOpCode, 1000, Address.fromHexString(eoaAddress), 0, 0, 0, 0);
     program.push(6).push(7).op(REVERT);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/abort/CallStackDepthAbortTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/abort/CallStackDepthAbortTests.java
@@ -38,7 +38,7 @@ public class CallStackDepthAbortTests extends TracerTestBase {
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void attemptAtCallStackDepthAbortWillRevert(OpCode callOpCode) {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendRecursiveSelfCall(program, callOpCode);
     appendRevert(program, 6, 7);
 
@@ -51,7 +51,7 @@ public class CallStackDepthAbortTests extends TracerTestBase {
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void attemptAtCallStackDepthAbort(OpCode callOpCode) {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendRecursiveSelfCall(program, callOpCode);
 
     BytecodeRunner.of(program).run(testInfo);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/abort/MultiCallAbortTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/abort/MultiCallAbortTests.java
@@ -32,7 +32,7 @@ public class MultiCallAbortTests extends TracerTestBase {
 
   @Test
   void normalCallThenAbortedCallToEoaThenRevert() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, CALL, 0, Address.fromHexString(eoaAddress), 1, 0, 0, 0, 0);
     appendInsufficientBalanceCall(
         program, CALL, 1000, Address.fromHexString(eoaAddress), 0, 0, 0, 0);
@@ -43,7 +43,7 @@ public class MultiCallAbortTests extends TracerTestBase {
 
   @Test
   void abortedCallNormalCallToEoaThenRevert() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendInsufficientBalanceCall(
         program, CALL, 1000, Address.fromHexString(eoaAddress), 0, 0, 0, 0);
     appendCall(program, CALL, 0, Address.fromHexString(eoaAddress), 1, 0, 0, 0, 0);
@@ -54,7 +54,7 @@ public class MultiCallAbortTests extends TracerTestBase {
 
   @Test
   void balanceThenAbortedCallToEoaThenRevert() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program.push(eoaAddress).op(BALANCE).op(POP);
     appendInsufficientBalanceCall(
         program, CALL, 1000, Address.fromHexString(eoaAddress), 0, 0, 0, 0);
@@ -66,7 +66,7 @@ public class MultiCallAbortTests extends TracerTestBase {
 
   @Test
   void abortedCallThenBalanceToEoaThenRevert() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendInsufficientBalanceCall(
         program, CALL, 1000, Address.fromHexString(eoaAddress), 0, 0, 0, 0);
     appendCall(program, CALL, 0, Address.fromHexString(eoaAddress), 0, 0, 0, 0, 0);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/eoa/SmcCallsEoaInRoot.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/eoa/SmcCallsEoaInRoot.java
@@ -41,7 +41,7 @@ public class SmcCallsEoaInRoot extends TracerTestBase {
   @Test
   void transfersSomeValueWillRevertTest() {
 
-    BytecodeCompiler bytecode = BytecodeCompiler.newProgram();
+    BytecodeCompiler bytecode = BytecodeCompiler.newProgram(testInfo);
     appendCall(bytecode, CALL, 0, Address.fromHexString(eoaAddress), 13, 2, 3, 4, 5);
     bytecode.op(POP).push(6).push(7).op(REVERT).compile();
 
@@ -51,7 +51,7 @@ public class SmcCallsEoaInRoot extends TracerTestBase {
   @Test
   void transfersSomeValueWontRevertTest() {
 
-    BytecodeCompiler bytecode = BytecodeCompiler.newProgram();
+    BytecodeCompiler bytecode = BytecodeCompiler.newProgram(testInfo);
     appendCall(bytecode, CALL, 0, Address.fromHexString(eoaAddress), 13, 2, 3, 4, 5);
 
     BytecodeRunner.of(bytecode.compile()).run(testInfo);
@@ -60,7 +60,7 @@ public class SmcCallsEoaInRoot extends TracerTestBase {
   @Test
   void transfersAllValueWillRevertTest() {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     fullBalanceCall(program, CALL, Address.fromHexString(eoaAddress), 1, 2, 3, 4);
     program.push(6).push(7).op(REVERT);
 
@@ -70,7 +70,7 @@ public class SmcCallsEoaInRoot extends TracerTestBase {
   @Test
   void transfersAllValueWontRevertTest() {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     fullBalanceCall(program, CALL, Address.fromHexString(eoaAddress), 1, 2, 3, 4);
 
     BytecodeRunner.of(program.compile()).run(testInfo);
@@ -79,7 +79,7 @@ public class SmcCallsEoaInRoot extends TracerTestBase {
   @Test
   void transfersNoValueWillRevertTest() {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, CALL, 0, Address.fromHexString(eoaAddress), 0, 1, 2, 3, 4);
     program.op(POP).push(6).push(7).op(REVERT).compile();
 
@@ -89,7 +89,7 @@ public class SmcCallsEoaInRoot extends TracerTestBase {
   @Test
   void transfersNoValueWontRevertTest() {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, CALL, 0, Address.fromHexString(eoaAddress), 0, 1, 2, 3, 4);
 
     BytecodeRunner.of(program.compile()).run(testInfo);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/CodeExecutionMethods.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/CodeExecutionMethods.java
@@ -146,7 +146,7 @@ public class CodeExecutionMethods {
 
     foreignCodeOwner.code(foreignCode.compile());
 
-    BytecodeCompiler rootCode = BytecodeCompiler.newProgram();
+    BytecodeCompiler rootCode = BytecodeCompiler.newProgram(testInfo);
     copyForeignCodeAndRunItAsInitCode(rootCode, foreignCodeOwnerAddress);
     if (embedRevertIntoInitCode) revertWith(rootCode, 0, 0);
     root.code(rootCode.compile());
@@ -176,7 +176,7 @@ public class CodeExecutionMethods {
 
     chadPrcEnjoyer.code(providedCode.compile());
 
-    BytecodeCompiler rootCode = BytecodeCompiler.newProgram();
+    BytecodeCompiler rootCode = BytecodeCompiler.newProgram(testInfo);
     appendCallTo(rootCode, CALL, chadPrcEnjoyerAddress);
     if (revertRoot) revertWith(rootCode, 0, 0); // we let the ROOT revert
     root.code(rootCode.compile());
@@ -210,7 +210,7 @@ public class CodeExecutionMethods {
 
     // ROOT code
     int key = 65537; // 0x 01 00 01
-    BytecodeCompiler rootCode = BytecodeCompiler.newProgram();
+    BytecodeCompiler rootCode = BytecodeCompiler.newProgram(testInfo);
     copyForeignCodeAndRunItAsInitCode(rootCode, initCodeOwnerAddress);
     sstoreTopOfStackTo(rootCode, key); // store deployment address
     pushSeveral(rootCode, 0, 0, 0, 0, 0); // zero value
@@ -220,7 +220,7 @@ public class CodeExecutionMethods {
     root.code(rootCode.compile());
 
     // init code owner code
-    BytecodeCompiler initCode = BytecodeCompiler.newProgram();
+    BytecodeCompiler initCode = BytecodeCompiler.newProgram(testInfo);
     copyForeignCodeAndReturnIt(initCode, foreignCodeOwnerAddress);
     initCodeOwner.code(initCode.compile());
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/CodeExecutionMethods.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/CodeExecutionMethods.java
@@ -22,13 +22,13 @@ import static org.hyperledger.besu.datatypes.TransactionType.FRONTIER;
 
 import java.util.List;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.ToyTransaction;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
-import org.junit.jupiter.api.TestInfo;
 
 /**
  * The following class provides methods to run code in the following contexts:
@@ -94,18 +94,18 @@ public class CodeExecutionMethods {
    * @param testInfo
    */
   public static void runMessageCallTransactionWithProvidedCodeAsRootCode(
-      BytecodeCompiler rootCode, TestInfo testInfo) {
+      BytecodeCompiler rootCode, TestInfoWithChainConfig testInfo) {
 
     root.code(rootCode.compile());
 
     transaction.to(root.build());
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .transaction(transaction.build())
         .accounts(listOfAccounts())
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 
   /**
@@ -115,16 +115,16 @@ public class CodeExecutionMethods {
    * @param testInfo
    */
   public static void runDeploymentTransactionWithProvidedCodeAsInitCode(
-      BytecodeCompiler transactionInitCode, TestInfo testInfo) {
+      BytecodeCompiler transactionInitCode, TestInfoWithChainConfig testInfo) {
 
     transaction.payload(transactionInitCode.compile()); // init code
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .transaction(transaction.build())
         .accounts(listOfAccounts())
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 
   /**
@@ -140,7 +140,9 @@ public class CodeExecutionMethods {
    * @param testInfo
    */
   public static void runForeignByteCodeAsInitCode(
-      BytecodeCompiler foreignCode, boolean embedRevertIntoInitCode, TestInfo testInfo) {
+      BytecodeCompiler foreignCode,
+      boolean embedRevertIntoInitCode,
+      TestInfoWithChainConfig testInfo) {
 
     foreignCodeOwner.code(foreignCode.compile());
 
@@ -151,11 +153,11 @@ public class CodeExecutionMethods {
 
     transaction.to(root.build());
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(listOfAccounts())
         .transaction(transaction.build())
         .build()
-        .run(testInfo);
+        .run();
   }
 
   /**
@@ -170,7 +172,7 @@ public class CodeExecutionMethods {
    * @param testInfo
    */
   public static void runMessageCallToAccountEndowedWithProvidedCode(
-      BytecodeCompiler providedCode, boolean revertRoot, TestInfo testInfo) {
+      BytecodeCompiler providedCode, boolean revertRoot, TestInfoWithChainConfig testInfo) {
 
     chadPrcEnjoyer.code(providedCode.compile());
 
@@ -181,11 +183,11 @@ public class CodeExecutionMethods {
 
     transaction.to(root.build());
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(listOfAccounts())
         .transaction(transaction.build())
         .build()
-        .run(testInfo);
+        .run();
   }
 
   /**
@@ -204,7 +206,7 @@ public class CodeExecutionMethods {
    * @param testInfo
    */
   public static void runCreateDeployingForeignCodeAndCallIntoIt(
-      BytecodeCompiler foreignCode, boolean rootReverts, TestInfo testInfo) {
+      BytecodeCompiler foreignCode, boolean rootReverts, TestInfoWithChainConfig testInfo) {
 
     // ROOT code
     int key = 65537; // 0x 01 00 01
@@ -227,11 +229,11 @@ public class CodeExecutionMethods {
 
     transaction.to(root.build());
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(listOfAccounts())
         .transaction(transaction.build())
         .build()
-        .run(testInfo);
+        .run();
   }
 
   private static List<ToyAccount> listOfAccounts() {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/MemoryContents.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static net.consensys.linea.zktracer.Trace.WORD_SIZE;
 import static net.consensys.linea.zktracer.Trace.WORD_SIZE_MO;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framework.PrecompileCallMemoryContents;
 import org.apache.tuweni.bytes.Bytes;
@@ -82,7 +83,7 @@ public enum MemoryContents implements PrecompileCallMemoryContents {
    * some account whose 'byte code' is to be <b>EXTCODECOPY</b>'ed to memory and used as input to a
    * call to <b>ECADD</b>.
    */
-  public BytecodeCompiler memoryContents() {
+  public BytecodeCompiler memoryContents(TestInfoWithChainConfig testInfo) {
 
     // Note that 4 = 2 * 2. We need 4 * 32 hex characters for the data representing a point.
     String pointData =

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/MemoryContents.java
@@ -105,7 +105,7 @@ public enum MemoryContents implements PrecompileCallMemoryContents {
 
     String memoryContentsString = pointData + MAX_WORD;
 
-    BytecodeCompiler memoryContents = BytecodeCompiler.newProgram();
+    BytecodeCompiler memoryContents = BytecodeCompiler.newProgram(testInfo);
     memoryContents.immediate(Bytes.fromHexString(memoryContentsString));
 
     return memoryContents;

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/Tests.java
@@ -52,7 +52,8 @@ public class Tests extends PrecompileCallTests<CallParameters> {
             ReturnAtParameter.FULL,
             true);
 
-    BytecodeCompiler rootCode = params.customPrecompileCallsSeparatedByReturnDataWipingOperation();
+    BytecodeCompiler rootCode =
+        params.customPrecompileCallsSeparatedByReturnDataWipingOperation(testInfo);
     runMessageCallTransactionWithProvidedCodeAsRootCode(rootCode, testInfo);
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/MemoryContents.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static net.consensys.linea.zktracer.Trace.WORD_SIZE;
 import static net.consensys.linea.zktracer.instructionprocessing.callTests.prc.ecadd.MemoryContents.*;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framework.PrecompileCallMemoryContents;
 import org.apache.tuweni.bytes.Bytes;
@@ -61,7 +62,7 @@ public enum MemoryContents implements PrecompileCallMemoryContents {
     variant = !variant;
   }
 
-  public BytecodeCompiler memoryContents() {
+  public BytecodeCompiler memoryContents(TestInfoWithChainConfig testInfo) {
     int nBytes = 11;
     String pointData =
         switch (this) {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/MemoryContents.java
@@ -83,7 +83,7 @@ public enum MemoryContents implements PrecompileCallMemoryContents {
 
     String memoryContentsString = pointData + MAX_WORD;
 
-    BytecodeCompiler memoryContents = BytecodeCompiler.newProgram();
+    BytecodeCompiler memoryContents = BytecodeCompiler.newProgram(testInfo);
     memoryContents.immediate(Bytes.fromHexString(memoryContentsString));
 
     return memoryContents;

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/Tests.java
@@ -53,7 +53,8 @@ public class Tests extends PrecompileCallTests<CallParameters> {
             ReturnAtParameter.FULL,
             true);
 
-    BytecodeCompiler rootCode = params.customPrecompileCallsSeparatedByReturnDataWipingOperation();
+    BytecodeCompiler rootCode =
+        params.customPrecompileCallsSeparatedByReturnDataWipingOperation(testInfo);
     if (params.willRevert()) revertWith(rootCode, 3 * WORD_SIZE, 2 * WORD_SIZE);
 
     runMessageCallTransactionWithProvidedCodeAsRootCode(rootCode, testInfo);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecpairing/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecpairing/MemoryContents.java
@@ -87,7 +87,7 @@ public class MemoryContents implements PrecompileCallMemoryContents {
         memoryContentsBytes.size()
             == TOTAL_NUMBER_OF_PAIRS_OF_POINTS * SIZE_OF_PAIR_OF_POINTS + WORD_SIZE);
 
-    BytecodeCompiler memoryContents = BytecodeCompiler.newProgram();
+    BytecodeCompiler memoryContents = BytecodeCompiler.newProgram(testInfo);
     return memoryContents.immediate(memoryContentsBytes);
   }
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecpairing/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecpairing/MemoryContents.java
@@ -19,6 +19,7 @@ import static net.consensys.linea.zktracer.Trace.WORD_SIZE;
 import static net.consensys.linea.zktracer.instructionprocessing.callTests.prc.ecpairing.LargePoint.LARGE_POINT_AT_INFINITY;
 import static net.consensys.linea.zktracer.instructionprocessing.callTests.prc.ecpairing.SmallPoint.SMALL_POINT_AT_INFINITY;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framework.PrecompileCallMemoryContents;
 import org.apache.tuweni.bytes.Bytes;
@@ -79,7 +80,7 @@ public class MemoryContents implements PrecompileCallMemoryContents {
   }
 
   @Override
-  public BytecodeCompiler memoryContents() {
+  public BytecodeCompiler memoryContents(TestInfoWithChainConfig testInfo) {
     Bytes memoryContentsBytes =
         Bytes.fromHexString(leftPairs() + CenterPair() + rightPairs() + RETURN_DATA_STRIP);
     // TODO: replace 192 with the appropriate constant (maybe add to GlobalConstants)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/EcRecoverTuple.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/EcRecoverTuple.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static net.consensys.linea.zktracer.Trace.WORD_SIZE;
 import static net.consensys.linea.zktracer.instructionprocessing.callTests.prc.ecadd.MemoryContents.MAX_WORD;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.testing.BytecodeCompiler;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -39,7 +40,8 @@ public record EcRecoverTuple(String h, String v, String r, String s) {
    * @param changeFinalByteOfS
    * @return
    */
-  public BytecodeCompiler memoryContents(boolean changeFinalByteOfS) {
+  public BytecodeCompiler memoryContents(
+      boolean changeFinalByteOfS, TestInfoWithChainConfig testInfo) {
     Bytes hBytes = Bytes32.leftPad(Bytes.fromHexString(h));
     Bytes vBytes = Bytes32.leftPad(Bytes.fromHexString(v));
     Bytes rBytes = Bytes32.leftPad(Bytes.fromHexString(r));

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/EcRecoverTuple.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/EcRecoverTuple.java
@@ -54,7 +54,7 @@ public record EcRecoverTuple(String h, String v, String r, String s) {
 
     checkState(pointData.size() == 5 * WORD_SIZE);
 
-    BytecodeCompiler memoryContents = BytecodeCompiler.newProgram();
+    BytecodeCompiler memoryContents = BytecodeCompiler.newProgram(testInfo);
     memoryContents.immediate(pointData);
 
     return memoryContents;

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/GasStipendTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/GasStipendTests.java
@@ -45,7 +45,7 @@ public class GasStipendTests extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void zeroValueEcRecoverCallTest(OpCode callOpCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     validEcrecoverData(program);
     appendCall(
         program,
@@ -66,7 +66,7 @@ public class GasStipendTests extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void nonzeroValueEcRecoverCallTest(OpCode callOpCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     validEcrecoverData(program);
     appendCall(
         program,
@@ -87,7 +87,7 @@ public class GasStipendTests extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void nonzeroValueEcRecoverCallWillRevertTest(OpCode callOpCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     validEcrecoverData(program);
     appendCall(
         program,
@@ -109,7 +109,7 @@ public class GasStipendTests extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE"})
   void stipendCompletesGasEcRecoverCallTest(OpCode callOpCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     validEcrecoverData(program);
     appendCall(
         program,
@@ -131,7 +131,7 @@ public class GasStipendTests extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void gasFallsShortForEcRecoverTest(OpCode callOpCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     validEcrecoverData(program);
     appendCall(
         program,
@@ -152,7 +152,7 @@ public class GasStipendTests extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE"})
   void stipendFromValueFallsShortOfCompletingGasEcrecoverCallTest(OpCode callOpCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     validEcrecoverData(program);
     appendCall(
         program,

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/MemoryContents.java
@@ -18,6 +18,7 @@ import static net.consensys.linea.zktracer.Trace.WORD_SIZE;
 import static net.consensys.linea.zktracer.instructionprocessing.callTests.prc.ecadd.MemoryContents.RND;
 import static net.consensys.linea.zktracer.instructionprocessing.callTests.prc.ecadd.MemoryContents.WORD_HEX_SIZE;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framework.PrecompileCallMemoryContents;
 
@@ -122,7 +123,7 @@ public enum MemoryContents implements PrecompileCallMemoryContents {
    *
    * @return
    */
-  public BytecodeCompiler memoryContents() {
+  public BytecodeCompiler memoryContents(TestInfoWithChainConfig testInfo) {
 
     // we switch with every call
     switchVariant();
@@ -130,40 +131,49 @@ public enum MemoryContents implements PrecompileCallMemoryContents {
     switch (this) {
       case ZEROS -> {
         final String ZERO_WORD = "00".repeat(WORD_SIZE);
-        return new EcRecoverTuple(ZERO_WORD, ZERO_WORD, ZERO_WORD, ZERO_WORD).memoryContents(false);
+        return new EcRecoverTuple(ZERO_WORD, ZERO_WORD, ZERO_WORD, ZERO_WORD)
+            .memoryContents(false, testInfo);
       }
       case WELL_FORMED -> {
         return variant
-            ? VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_1.memoryContents(false)
-            : VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_2.memoryContents(false);
+            ? VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_1.memoryContents(false, testInfo)
+            : VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_2.memoryContents(false, testInfo);
       }
       case MALFORMED_AT_7f_BUT_SALVAGEABLE -> {
         return variant
-            ? VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_1.memoryContents(true)
-            : VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_2.memoryContents(true);
+            ? VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_1.memoryContents(true, testInfo)
+            : VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_2.memoryContents(true, testInfo);
       }
       case INVALID_V -> {
         return variant
-            ? INVALID_V_TUPLE_1.memoryContents(false)
-            : INVALID_V_TUPLE_2.memoryContents(false);
+            ? INVALID_V_TUPLE_1.memoryContents(false, testInfo)
+            : INVALID_V_TUPLE_2.memoryContents(false, testInfo);
       }
       case BOUNDARY_R -> {
         return variant
-            ? VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_1.replaceR(true).memoryContents(false)
-            : VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_2.replaceR(false).memoryContents(false);
+            ? VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_1
+                .replaceR(true)
+                .memoryContents(false, testInfo)
+            : VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_2
+                .replaceR(false)
+                .memoryContents(false, testInfo);
       }
       case BOUNDARY_S -> {
         return variant
-            ? VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_1.replaceS(true).memoryContents(false)
-            : VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_2.replaceS(false).memoryContents(false);
+            ? VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_1
+                .replaceS(true)
+                .memoryContents(false, testInfo)
+            : VALID_TUPLE_WHERE_THE_FINAL_BYTE_OF_S_IS_ZERO_2
+                .replaceS(false)
+                .memoryContents(false, testInfo);
       }
       case RANDOM -> {
-        return RANDOM_TUPLE.memoryContents(false);
+        return RANDOM_TUPLE.memoryContents(false, testInfo);
       }
       case MALLEABLE -> {
         return variant
-            ? EVM_CODES_EXAMPLE.memoryContents(false)
-            : EVM_CODES_EXAMPLE_MALLEABLE.memoryContents(false);
+            ? EVM_CODES_EXAMPLE.memoryContents(false, testInfo)
+            : EVM_CODES_EXAMPLE_MALLEABLE.memoryContents(false, testInfo);
       }
       default -> throw new RuntimeException("Unknown MemoryContentsParameter");
     }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/framework/PrecompileCallMemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/framework/PrecompileCallMemoryContents.java
@@ -17,17 +17,18 @@ package net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framewo
 import static net.consensys.linea.zktracer.instructionprocessing.callTests.prc.CodeExecutionMethods.memoryContentsHolder1;
 import static net.consensys.linea.zktracer.instructionprocessing.callTests.prc.CodeExecutionMethods.memoryContentsHolder2;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.testing.BytecodeCompiler;
 
 public interface PrecompileCallMemoryContents {
 
   void switchVariant();
 
-  BytecodeCompiler memoryContents();
+  BytecodeCompiler memoryContents(TestInfoWithChainConfig testInfo);
 
-  default void setCodeOfHolderAccounts() {
-    memoryContentsHolder1.code(this.memoryContents().compile());
+  default void setCodeOfHolderAccounts(TestInfoWithChainConfig testInfo) {
+    memoryContentsHolder1.code(this.memoryContents(testInfo).compile());
     this.switchVariant();
-    memoryContentsHolder2.code(this.memoryContents().compile());
+    memoryContentsHolder2.code(this.memoryContents(testInfo).compile());
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/framework/PrecompileCallParameters.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/framework/PrecompileCallParameters.java
@@ -39,7 +39,7 @@ public interface PrecompileCallParameters {
     // populate foreign accounts' byte code with call data
     this.memoryContents().setCodeOfHolderAccounts();
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     // populate memory with the data for first PRECOMPILE call
     copyForeignCodeToRam(program, memoryContentsHolderAddress1);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/framework/PrecompileCallParameters.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/framework/PrecompileCallParameters.java
@@ -19,6 +19,7 @@ import static net.consensys.linea.zktracer.instructionprocessing.callTests.prc.C
 import static net.consensys.linea.zktracer.instructionprocessing.callTests.prc.CodeExecutionMethods.memoryContentsHolderAddress2;
 import static net.consensys.linea.zktracer.opcode.OpCode.CALL;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.testing.BytecodeCompiler;
 import org.hyperledger.besu.datatypes.Address;
 
@@ -34,10 +35,11 @@ public interface PrecompileCallParameters {
    * {@link #customPrecompileCallsSeparatedByReturnDataWipingOperation} constructs the byte code for
    * the <b>happy path</b> testing of the relevant <b>PRECOMPILE</b>.
    */
-  default BytecodeCompiler customPrecompileCallsSeparatedByReturnDataWipingOperation() {
+  default BytecodeCompiler customPrecompileCallsSeparatedByReturnDataWipingOperation(
+      TestInfoWithChainConfig testInfo) {
 
     // populate foreign accounts' byte code with call data
-    this.memoryContents().setCodeOfHolderAccounts();
+    this.memoryContents().setCodeOfHolderAccounts(testInfo);
 
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/framework/PrecompileCallTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/framework/PrecompileCallTests.java
@@ -38,7 +38,7 @@ public abstract class PrecompileCallTests<T extends PrecompileCallParameters>
   public void messageCallTransactionTest(T callParameter) {
 
     BytecodeCompiler rootCode =
-        callParameter.customPrecompileCallsSeparatedByReturnDataWipingOperation();
+        callParameter.customPrecompileCallsSeparatedByReturnDataWipingOperation(testInfo);
     if (callParameter.willRevert()) revertWith(rootCode, 0, 5 * WORD_SIZE);
 
     runMessageCallTransactionWithProvidedCodeAsRootCode(rootCode, testInfo);
@@ -54,7 +54,7 @@ public abstract class PrecompileCallTests<T extends PrecompileCallParameters>
   public void deploymentTransactionTest(T callParameter) {
 
     BytecodeCompiler txInitCode =
-        callParameter.customPrecompileCallsSeparatedByReturnDataWipingOperation();
+        callParameter.customPrecompileCallsSeparatedByReturnDataWipingOperation(testInfo);
     if (callParameter.willRevert()) revertWith(txInitCode, 0, 0);
 
     runDeploymentTransactionWithProvidedCodeAsInitCode(txInitCode, testInfo);
@@ -69,7 +69,7 @@ public abstract class PrecompileCallTests<T extends PrecompileCallParameters>
   @MethodSource("parameterGeneration")
   public void messageCallFromRootTest(T callParameter) {
     BytecodeCompiler chadPrcEnjoyerCode =
-        callParameter.customPrecompileCallsSeparatedByReturnDataWipingOperation();
+        callParameter.customPrecompileCallsSeparatedByReturnDataWipingOperation(testInfo);
     runMessageCallToAccountEndowedWithProvidedCode(
         chadPrcEnjoyerCode, callParameter.willRevert(), testInfo);
   }
@@ -88,7 +88,7 @@ public abstract class PrecompileCallTests<T extends PrecompileCallParameters>
   @MethodSource("parameterGeneration")
   public void happyPathDuringCreate(T callParameter) {
     BytecodeCompiler foreignCode =
-        callParameter.customPrecompileCallsSeparatedByReturnDataWipingOperation();
+        callParameter.customPrecompileCallsSeparatedByReturnDataWipingOperation(testInfo);
     runForeignByteCodeAsInitCode(foreignCode, callParameter.willRevert(), testInfo);
   }
 
@@ -101,7 +101,7 @@ public abstract class PrecompileCallTests<T extends PrecompileCallParameters>
   @MethodSource("parameterGeneration")
   public void happyPathAfterCreate(T callParameter) {
     BytecodeCompiler chadPrcEnjoyerCode =
-        callParameter.customPrecompileCallsSeparatedByReturnDataWipingOperation();
+        callParameter.customPrecompileCallsSeparatedByReturnDataWipingOperation(testInfo);
     runCreateDeployingForeignCodeAndCallIntoIt(
         chadPrcEnjoyerCode, callParameter.willRevert(), testInfo);
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/hash/GasTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/hash/GasTests.java
@@ -45,7 +45,7 @@ public class GasTests extends TracerTestBase {
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void sha2ProvidedWithLittleToNoneGasTest(OpCode callOpCode) {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, callOpCode, 0, Address.SHA256, 1_000_000, 0, 32 * 10 + 1, 7, 32);
     program.op(RETURNDATASIZE); // should return 0
 
@@ -58,7 +58,7 @@ public class GasTests extends TracerTestBase {
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void sha2ProvidedWithLittleToNoneGasWillRevertTest(OpCode callOpCode) {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, callOpCode, 0, Address.SHA256, 1_000_000, 0, 32 * 10, 7, 32);
     program.op(RETURNDATASIZE); // should return 0
     appendRevert(program, 1, 34);
@@ -72,7 +72,7 @@ public class GasTests extends TracerTestBase {
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void sha2ProvidedWithPlentifulGasTest(OpCode callOpCode) {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, callOpCode, 1_000_000, Address.SHA256, 1_000_000, 0, 32 * 10, 7, 32);
     program.op(RETURNDATASIZE); // should return 32
     BytecodeRunner.of(program).run(testInfo);
@@ -84,7 +84,7 @@ public class GasTests extends TracerTestBase {
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void sha2ProvidedWithPlentifulGasWillRevertTest(OpCode callOpCode) {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, callOpCode, 1_000_000, Address.SHA256, 1_000_000, 0, 32 * 10, 7, 32);
     program.op(RETURNDATASIZE); // should return 32
     appendRevert(program, 1, 34);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/hash/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/hash/MemoryContents.java
@@ -16,6 +16,7 @@ package net.consensys.linea.zktracer.instructionprocessing.callTests.prc.hash;
 
 import static net.consensys.linea.zktracer.instructionprocessing.callTests.Utilities.populateMemory;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framework.PrecompileCallMemoryContents;
 
@@ -29,7 +30,7 @@ public class MemoryContents implements PrecompileCallMemoryContents {
   }
 
   @Override
-  public BytecodeCompiler memoryContents() {
+  public BytecodeCompiler memoryContents(TestInfoWithChainConfig testInfo) {
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     populateMemory(program, variant ? 6 : 12, variant ? 0x11 : 0x0a);
     return program;

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/hash/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/hash/MemoryContents.java
@@ -30,7 +30,7 @@ public class MemoryContents implements PrecompileCallMemoryContents {
 
   @Override
   public BytecodeCompiler memoryContents() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     populateMemory(program, variant ? 6 : 12, variant ? 0x11 : 0x0a);
     return program;
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/hash/Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/hash/Tests.java
@@ -88,7 +88,8 @@ public class Tests extends PrecompileCallTests<CallParameters> {
             OVERLAP,
             true);
 
-    BytecodeCompiler rootCode = params.customPrecompileCallsSeparatedByReturnDataWipingOperation();
+    BytecodeCompiler rootCode =
+        params.customPrecompileCallsSeparatedByReturnDataWipingOperation(testInfo);
     if (params.willRevert()) revertWith(rootCode, 3 * WORD_SIZE, 2 * WORD_SIZE);
 
     runMessageCallTransactionWithProvidedCodeAsRootCode(rootCode, testInfo);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/identity/Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/identity/Tests.java
@@ -66,7 +66,7 @@ public class Tests extends TracerTestBase {
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void nontrivialCallDataIdentityTest(OpCode callOpCode) {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     fullCodeCopyOf(program, byteSource);
     appendCall(
         program,

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/identity/Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/identity/Tests.java
@@ -89,11 +89,11 @@ public class Tests extends TracerTestBase {
             .to(identityCaller)
             .value(Wei.of(7_000_000_000L))
             .build();
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(byteSource, userAccount, identityCaller))
         .transaction(transaction)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   /**

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/modexp/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/modexp/MemoryContents.java
@@ -19,6 +19,7 @@ import static net.consensys.linea.zktracer.Trace.WORD_SIZE;
 
 import java.math.BigInteger;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framework.PrecompileCallMemoryContents;
 import org.apache.tuweni.bytes.Bytes;
@@ -89,7 +90,7 @@ public class MemoryContents implements PrecompileCallMemoryContents {
    *
    * @return
    */
-  public BytecodeCompiler memoryContents() {
+  public BytecodeCompiler memoryContents(TestInfoWithChainConfig testInfo) {
 
     // starting at index 2 eliminates the 0x prefix
     String byteSizes = this.bbs().substring(2) + this.ebs().substring(2) + this.mbs().substring(2);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/modexp/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/modexp/MemoryContents.java
@@ -101,7 +101,7 @@ public class MemoryContents implements PrecompileCallMemoryContents {
             + expn().substring(0, 2 * this.ebsShort())
             + mdls().substring(0, 2 * this.mbsShort());
 
-    return BytecodeCompiler.newProgram().immediate(Bytes.fromHexString(memoryContents));
+    return BytecodeCompiler.newProgram(testInfo).immediate(Bytes.fromHexString(memoryContents));
   }
 
   private String base() {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/modexp/Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/modexp/Tests.java
@@ -59,7 +59,8 @@ public class Tests extends PrecompileCallTests<CallParameters> {
             RelativeRangePosition.OVERLAP,
             true);
 
-    BytecodeCompiler rootCode = params.customPrecompileCallsSeparatedByReturnDataWipingOperation();
+    BytecodeCompiler rootCode =
+        params.customPrecompileCallsSeparatedByReturnDataWipingOperation(testInfo);
     runMessageCallTransactionWithProvidedCodeAsRootCode(rootCode, testInfo);
   }
 
@@ -82,7 +83,8 @@ public class Tests extends PrecompileCallTests<CallParameters> {
             RelativeRangePosition.OVERLAP,
             true);
 
-    BytecodeCompiler rootCode = params.customPrecompileCallsSeparatedByReturnDataWipingOperation();
+    BytecodeCompiler rootCode =
+        params.customPrecompileCallsSeparatedByReturnDataWipingOperation(testInfo);
     runMessageCallTransactionWithProvidedCodeAsRootCode(rootCode, testInfo);
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/sixtyThreeSixtyFourths/SixtyThreeSixtyFourthsTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/sixtyThreeSixtyFourths/SixtyThreeSixtyFourthsTests.java
@@ -168,7 +168,7 @@ public class SixtyThreeSixtyFourthsTests extends TracerTestBase {
     // Whenever transferValue = true, gas is enough
     // so we only test the case in which transferValue = false
 
-    final BytecodeCompiler program = BytecodeCompiler.newProgram();
+    final BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program.immediate(preCallProgram(ALTBN128_ADD, false, false, 0)).op(CALL);
 
@@ -218,7 +218,7 @@ public class SixtyThreeSixtyFourthsTests extends TracerTestBase {
       boolean transfersValue,
       boolean targetAddressExists,
       int cds) {
-    final BytecodeCompiler program = BytecodeCompiler.newProgram();
+    final BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program.immediate(preCallProgram(address, transfersValue, targetAddressExists, cds)).op(CALL);
 
     final BytecodeRunner bytecodeRunner = BytecodeRunner.of(program);
@@ -273,7 +273,7 @@ public class SixtyThreeSixtyFourthsTests extends TracerTestBase {
   // Support methods
   static Bytes preCallProgram(
       Address address, boolean transfersValue, boolean targetAddressExists, int cds) {
-    return BytecodeCompiler.newProgram()
+    return BytecodeCompiler.newProgram(testInfo)
         .immediate(expandMemoryTo2048Words())
         .immediate(targetAddressExists ? successfullySummonIntoExistence(address) : Bytes.EMPTY)
         .immediate(
@@ -289,7 +289,11 @@ public class SixtyThreeSixtyFourthsTests extends TracerTestBase {
 
   static Bytes expandMemoryTo(int words) {
     checkArgument(words >= 1);
-    return BytecodeCompiler.newProgram().push((words - 1) * WORD_SIZE).op(MLOAD).op(POP).compile();
+    return BytecodeCompiler.newProgram(testInfo)
+        .push((words - 1) * WORD_SIZE)
+        .op(MLOAD)
+        .op(POP)
+        .compile();
   }
 
   static Bytes successfullySummonIntoExistence(Address address) {
@@ -303,14 +307,14 @@ public class SixtyThreeSixtyFourthsTests extends TracerTestBase {
   }
 
   static Bytes call(Bytes gas, Address address, int cds, boolean transfersValue) {
-    return BytecodeCompiler.newProgram()
+    return BytecodeCompiler.newProgram(testInfo)
         .immediate(pushCallArguments(gas, address, cds, transfersValue))
         .op(CALL)
         .compile();
   }
 
   static Bytes pushCallArguments(Bytes gas, Address address, int cds, boolean transfersValue) {
-    return BytecodeCompiler.newProgram()
+    return BytecodeCompiler.newProgram(testInfo)
         .push(0) // returnAtCapacity
         .push(0) // returnAtOffset
         .push(cds) // callDataSize

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/sixtyThreeSixtyFourths/SixtyThreeSixtyFourthsTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/sixtyThreeSixtyFourths/SixtyThreeSixtyFourthsTests.java
@@ -140,12 +140,14 @@ public class SixtyThreeSixtyFourthsTests extends TracerTestBase {
                               false,
                               BytecodeRunner.of(preCallProgram(address, false, false, 0))
                                   .runOnlyForGasCost(
-                                      address == MODEXP ? additionalAccounts : List.of()));
+                                      address == MODEXP ? additionalAccounts : List.of(),
+                                      testInfo));
                           put(
                               true,
                               BytecodeRunner.of(preCallProgram(address, false, true, 0))
                                   .runOnlyForGasCost(
-                                      address == MODEXP ? additionalAccounts : List.of()));
+                                      address == MODEXP ? additionalAccounts : List.of(),
+                                      testInfo));
                         }
                       }));
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/smc/complexTargets/FailureWillRevertTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/smc/complexTargets/FailureWillRevertTest.java
@@ -41,7 +41,7 @@ public class FailureWillRevertTest extends TracerTestBase {
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   public void singleSelfCallFailureWillRevertTest(OpCode callOpCode) {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     sloadFrom(program, 0x00);
     addX(program, 0x01);
     duplicateTop(program);
@@ -65,7 +65,7 @@ public class FailureWillRevertTest extends TracerTestBase {
   @Test
   public void banalAdditionTest() {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     sloadFrom(program, 0x00); // puts 0 on stack
     addX(program, 0x01);
     sstoreAt(program, 0x00);
@@ -85,7 +85,7 @@ public class FailureWillRevertTest extends TracerTestBase {
   @Test
   public void banalSwapTest() {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program.push(1).push(2).op(SWAP1).push(3).op(SWAP1);
 
     BytecodeRunner.of(program).run(testInfo);
@@ -98,7 +98,7 @@ public class FailureWillRevertTest extends TracerTestBase {
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   public void thirdSelfCallBreaksTriggeringFailureWillRevertTest(OpCode callOpCode) {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     sloadFrom(program, 0x00);
     addX(program, 0x01);
     duplicateTop(program);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/smc/monoOpCodeTargets/ImmediateInvalid.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/smc/monoOpCodeTargets/ImmediateInvalid.java
@@ -31,7 +31,7 @@ public class ImmediateInvalid extends TracerTestBase {
 
   @Test
   void zeroValueTransferToInvalid() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendCall(program, CALL, 0, accountWhoseByteCodeIsASingleInvalid.getAddress(), 0, 0, 0, 0, 0);
 
@@ -40,7 +40,7 @@ public class ImmediateInvalid extends TracerTestBase {
 
   @Test
   void nonZeroValueTransferToInvalidContract() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendCall(program, CALL, 0, accountWhoseByteCodeIsASingleInvalid.getAddress(), 1, 0, 0, 0, 0);
 
@@ -49,7 +49,7 @@ public class ImmediateInvalid extends TracerTestBase {
 
   @Test
   void nonZeroValueTransferToInvalidContractRevertingTransaction() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendCall(program, CALL, 0, accountWhoseByteCodeIsASingleInvalid.getAddress(), 1, 0, 0, 0, 0);
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/smc/monoOpCodeTargets/SingleJumpDest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/smc/monoOpCodeTargets/SingleJumpDest.java
@@ -36,7 +36,7 @@ public class SingleJumpDest extends TracerTestBase {
   /** This test should trigger the <b>scenario/CALL_TO_SMC_SUCCESS_WONT_REVERT</b> scenario. */
   @Test
   void zeroValueTransferToJumpDestContract() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendCall(
         program, CALL, 10, accountWhoseByteCodeIsASingleJumpDest.getAddress(), 0, 0, 0, 0, 0);
@@ -47,7 +47,7 @@ public class SingleJumpDest extends TracerTestBase {
   /** This test should trigger the <b>scenario/CALL_TO_SMC_SUCCESS_WONT_REVERT</b> scenario. */
   @Test
   void nonZeroValueTransferToJumpDestContract() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendCall(
         program, CALL, 10, accountWhoseByteCodeIsASingleJumpDest.getAddress(), 1, 0, 0, 0, 0);
@@ -58,7 +58,7 @@ public class SingleJumpDest extends TracerTestBase {
   /** This test should trigger the <b>scenario/CALL_TO_SMC_SUCCESS_WILL_REVERT</b> scenario. */
   @Test
   void nonZeroValueTransferToJumpDestContractRevertingTransaction() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendCall(
         program, CALL, 10, accountWhoseByteCodeIsASingleJumpDest.getAddress(), 1, 0, 0, 0, 0);
@@ -75,7 +75,7 @@ public class SingleJumpDest extends TracerTestBase {
   /** This test should trigger the <b>scenario/CALL_TO_SMC_FAILURE_WONT_REVERT</b> scenario. */
   @Test
   void zeroValueTransferToJumpDestContractOogx() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendCall(program, CALL, 0, accountWhoseByteCodeIsASingleJumpDest.getAddress(), 0, 0, 0, 0, 0);
 
@@ -85,7 +85,7 @@ public class SingleJumpDest extends TracerTestBase {
   /** This test should trigger the <b>scenario/CALL_TO_SMC_FAILURE_WONT_REVERT</b> scenario. */
   @Test
   void nonZeroValueTransferToJumpDestContractOogx() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendCall(program, CALL, 0, accountWhoseByteCodeIsASingleJumpDest.getAddress(), 1, 0, 0, 0, 0);
 
@@ -95,7 +95,7 @@ public class SingleJumpDest extends TracerTestBase {
   /** This test should trigger the <b>scenario/CALL_TO_SMC_FAILURE_WILL_REVERT</b> scenario. */
   @Test
   void nonZeroValueTransferToJumpDestContractOogxAndRevertingTransaction() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendCall(program, CALL, 0, accountWhoseByteCodeIsASingleJumpDest.getAddress(), 1, 0, 0, 0, 0);
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/smc/monoOpCodeTargets/singleStop.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/smc/monoOpCodeTargets/singleStop.java
@@ -34,7 +34,7 @@ public class singleStop extends TracerTestBase {
   /** This test should trigger the <b>scenario/CALL_TO_SMC_SUCCESS_WONT_REVERT</b> scenario. */
   @Test
   void zeroValueTransferToContractThatStops() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendCall(program, CALL, 0, accountWhoseByteCodeIsASingleStop.getAddress(), 0, 0, 0, 0, 0);
 
@@ -44,7 +44,7 @@ public class singleStop extends TracerTestBase {
   /** This test should trigger the <b>scenario/CALL_TO_SMC_SUCCESS_WONT_REVERT</b> scenario. */
   @Test
   void nonZeroValueTransferToContractThatStops() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendCall(program, CALL, 0, accountWhoseByteCodeIsASingleStop.getAddress(), 1, 0, 0, 0, 0);
 
@@ -54,7 +54,7 @@ public class singleStop extends TracerTestBase {
   /** This test should trigger the <b>scenario/CALL_TO_SMC_SUCCESS_WILL_REVERT</b> scenario. */
   @Test
   void nonZeroValueTransferToContractThatStopsRevertingTransaction() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendCall(program, CALL, 0, accountWhoseByteCodeIsASingleStop.getAddress(), 1, 0, 0, 0, 0);
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/contextFamily/MessageCallTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/contextFamily/MessageCallTests.java
@@ -72,7 +72,7 @@ public class MessageCallTests extends TracerTestBase {
    */
   private ToyAccount buildRecipient(OpCode callOpCode) {
 
-    BytecodeCompiler recipientCode = BytecodeCompiler.newProgram();
+    BytecodeCompiler recipientCode = BytecodeCompiler.newProgram(testInfo);
     recipientCode.op(CALLDATASIZE);
     recipientCode.op(RETURNDATASIZE);
     recipientCode.op(CALLER);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/contextFamily/MessageCallTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/contextFamily/MessageCallTests.java
@@ -56,12 +56,12 @@ public class MessageCallTests extends TracerTestBase {
     accounts.add(allContextOpCodesSmc);
     accounts.add(recipientAccount);
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .transaction(buildTransaction(recipientAccount))
         .accounts(accounts)
         .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   /**

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/contextFamily/RootOfMessageCallTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/contextFamily/RootOfMessageCallTests.java
@@ -28,7 +28,7 @@ public class RootOfMessageCallTests extends TracerTestBase {
 
   @Test
   public void messageCallTest() {
-    BytecodeCompiler program = allContextOpCodes();
+    BytecodeCompiler program = allContextOpCodes(testInfo);
     BytecodeRunner.of(program).run(testInfo);
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/abort/Balance.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/abort/Balance.java
@@ -45,7 +45,7 @@ public class Balance extends TracerTestBase {
   void rootLevelInsufficientBalanceCreateOpcodeTest(
       CreateType createType, SizeParameter sizeParameter, OffsetParameter offsetParameter) {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     if (sizeParameter == s_MSIZE) {
       program.push(513).push(0).op(SHA3); // purely to expand memory to 0 < 512 + 32 bytes
@@ -74,7 +74,7 @@ public class Balance extends TracerTestBase {
       OffsetParameter offsetParameter,
       SizeParameter sizeParameter,
       boolean reverts) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     genericCreate(
         program,
         createType,
@@ -99,7 +99,7 @@ public class Balance extends TracerTestBase {
     final SizeParameter sizeParameter = SizeParameter.s_ZERO;
     final boolean reverts = true;
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     genericCreate(
         program,
         createType,
@@ -126,7 +126,7 @@ public class Balance extends TracerTestBase {
     SizeParameter sizeParameter = SizeParameter.s_ZERO;
     boolean reverts = true;
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     genericCreate(
         program,
         createType,
@@ -175,7 +175,7 @@ public class Balance extends TracerTestBase {
       OffsetParameter offsetParameter,
       SizeParameter sizeParameter,
       boolean reverts) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     genericCreate(
         program, createType, ValueParameter.v_ONE, offsetParameter, sizeParameter, salt01);
     genericCreate(

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/advanced/InitCodeTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/advanced/InitCodeTests.java
@@ -209,12 +209,12 @@ public class InitCodeTests extends TracerTestBase {
             List.of(0L, 0L, 0L, 0L, 0L, 0L, 2L, 0L, 0L));
 
     final ToyExecutionEnvironmentV2 toyExecutionEnvironmentV2 =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(userAccount, customCreate2Account))
             .transactions(transactions)
             .transactionProcessingResultValidator(create2Validator)
             .build();
-    toyExecutionEnvironmentV2.run(testInfo);
+    toyExecutionEnvironmentV2.run();
 
     // Final check on the deployment number of ContractC
     // At start, deploymentNumber = 0

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/advanced/StorageNoOpTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/advanced/StorageNoOpTests.java
@@ -127,11 +127,11 @@ public class StorageNoOpTests extends TracerTestBase {
             factorySmc, userAccount, List.of(deployPayload, callMainMethod), List.of(0L, 0L));
 
     final ToyExecutionEnvironmentV2 toyExecutionEnvironmentV2 =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(userAccount, factorySmc))
             .transactions(transactions)
             .build();
-    toyExecutionEnvironmentV2.run(testInfo);
+    toyExecutionEnvironmentV2.run();
   }
 
   private enum TouchStorage {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/failure/Create2InducedFailureTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/failure/Create2InducedFailureTests.java
@@ -34,7 +34,7 @@ public class Create2InducedFailureTests extends TracerTestBase {
   @Test
   void failureConditionNonceTest() {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(salt01)
         .push(0)
@@ -67,14 +67,14 @@ public class Create2InducedFailureTests extends TracerTestBase {
   @Test
   void failureConditionNonceAndCodeTest() {
 
-    BytecodeCompiler initCode = BytecodeCompiler.newProgram();
+    BytecodeCompiler initCode = BytecodeCompiler.newProgram(testInfo);
     initCode
         .push(1) // size
         .push(0)
         .op(RETURN);
     Bytes compiledInitCode = initCode.compile();
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(compiledInitCode)
         .push(8 * (32 - compiledInitCode.size()))

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/failure/CreateInducedFailureTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/failure/CreateInducedFailureTest.java
@@ -266,11 +266,11 @@ public class CreateInducedFailureTest extends TracerTestBase {
   @Test
   void complexFailureConditionTest() {
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(accounts)
         .transactions(transactions)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/failure/CreateInducedFailureTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/failure/CreateInducedFailureTest.java
@@ -78,7 +78,7 @@ public class CreateInducedFailureTest extends TracerTestBase {
   final Address targetAddress = Address.fromHexString("797add7e55");
 
   final BytecodeCompiler simpleSelfDestruct =
-      BytecodeCompiler.newProgram().op(ORIGIN).op(SELFDESTRUCT);
+      BytecodeCompiler.newProgram(testInfo).op(ORIGIN).op(SELFDESTRUCT);
 
   /**
    * Account that can only do one thing: do a <b>SELFDESTRUCT</b> sending the funds to the
@@ -93,7 +93,7 @@ public class CreateInducedFailureTest extends TracerTestBase {
           .build();
 
   final BytecodeCompiler simpleCreate =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .push(0) // empty init code
           .push(0)
           .push(1) // value
@@ -113,7 +113,7 @@ public class CreateInducedFailureTest extends TracerTestBase {
 
   /** Does a <b>DELEGATECALL</b> to an address extracted from the call data. */
   final BytecodeCompiler delegateCaller =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .push(0) // rac
           .push(0) // rao
           .push(0) // cds
@@ -125,7 +125,7 @@ public class CreateInducedFailureTest extends TracerTestBase {
 
   /** Initialization code that deploys {@link #delegateCaller}. */
   final BytecodeCompiler initCode =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .push(delegateCaller.compile())
           .push(8 * (32 - delegateCaller.compile().size()))
           .op(SHL)
@@ -158,7 +158,7 @@ public class CreateInducedFailureTest extends TracerTestBase {
    * is of no use.
    */
   final BytecodeCompiler entryPointByteCode =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .op(CALLDATASIZE) // + 1
           .op(ISZERO) // [CALLDATASIZE == 0] // + 1
           .push(emptyCallDataExecutionPathProgramCounter) // + 2

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/failure/NestedFailureTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/failure/NestedFailureTest.java
@@ -117,10 +117,10 @@ public class NestedFailureTest extends TracerTestBase {
             .gasLimit(0xffffffL)
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(userAccount, entryPointAccount, accountContainingInitCode))
         .transaction(transaction)
         .build()
-        .run(testInfo);
+        .run();
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/failure/NestedFailureTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/failure/NestedFailureTest.java
@@ -56,7 +56,7 @@ public class NestedFailureTest extends TracerTestBase {
     final String errorString = "0e7707";
     final int errorStringLengthInBytes = errorString.length() / 2;
 
-    BytecodeCompiler initCode = BytecodeCompiler.newProgram();
+    BytecodeCompiler initCode = BytecodeCompiler.newProgram(testInfo);
     callCaller(initCode, callOpCode, 0xffffff, 1, 0xa, 0xb, 0xc, 0xd);
     final int sizeUpToCall = initCode.compile().size();
     initCode
@@ -91,7 +91,7 @@ public class NestedFailureTest extends TracerTestBase {
             .balance(Wei.of(0xffffff))
             .build();
 
-    BytecodeCompiler entryPoint = BytecodeCompiler.newProgram();
+    BytecodeCompiler entryPoint = BytecodeCompiler.newProgram(testInfo);
     fullCodeCopyOf(entryPoint, accountContainingInitCode); // loading init code into memory
     entryPoint
         .push(salt02) // salt

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/failure/NoFailure.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/failure/NoFailure.java
@@ -33,7 +33,7 @@ public class NoFailure extends TracerTestBase {
   @Test
   void noFailureConditionTest() {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(salt01)
         .push(0)
@@ -56,7 +56,7 @@ public class NoFailure extends TracerTestBase {
   @Test
   void noFailureConditionDespiteNonzeroBalanceTest() {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     precomputeDeploymentAddressOfEmptyInitCodeCreate2(program, salt01);
     storeAt(program, 0xadd7);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/trivial/RootLevel.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/trivial/RootLevel.java
@@ -23,13 +23,13 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import net.consensys.linea.UnitTestWatcher;
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.BytecodeRunner;
 import net.consensys.linea.zktracer.instructionprocessing.createTests.*;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -194,7 +194,7 @@ public class RootLevel extends TracerTestBase {
     program.push(storageKey).op(SLOAD);
   }
 
-  public static void run(BytecodeCompiler program, TestInfo testInfo) {
+  public static void run(BytecodeCompiler program, TestInfoWithChainConfig testInfo) {
     BytecodeRunner.of(program).run(testInfo);
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/trivial/RootLevel.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/trivial/RootLevel.java
@@ -45,7 +45,7 @@ public class RootLevel extends TracerTestBase {
   @Test
   void basicCreate2Test() {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(0xadd7) // salt
         .push(1) // size
@@ -64,7 +64,7 @@ public class RootLevel extends TracerTestBase {
       OffsetParameter offsetParameter,
       boolean revert) {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     genericCreate(
         program, createType, valueParameter, offsetParameter, SizeParameter.s_ZERO, salt01);
 
@@ -80,7 +80,7 @@ public class RootLevel extends TracerTestBase {
   void rootLevelCreate2AndExtCodeHash(WhenToTestParameter when) {
 
     int storageKey = 0;
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     precomputeDeploymentAddressOfEmptyInitCodeCreate2(program, salt01);
     storeAt(program, storageKey);
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/Heir.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/Heir.java
@@ -39,7 +39,7 @@ public enum Heir {
 
   public static ToyAccount basicSelfDestructor(Heir heir, Optional<Address> selfDestructAddress) {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     switch (heir) {
       case HEIR_IS_ZERO:
         program.push(0);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/Heir.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/Heir.java
@@ -21,6 +21,7 @@ import static net.consensys.linea.zktracer.opcode.OpCode.SELFDESTRUCT;
 
 import java.util.Optional;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.ToyAccount;
 import org.hyperledger.besu.datatypes.Address;
@@ -37,7 +38,8 @@ public enum Heir {
 
   public static Address selfDestructorAddress = Address.fromHexString("0xFFc0deadd7");
 
-  public static ToyAccount basicSelfDestructor(Heir heir, Optional<Address> selfDestructAddress) {
+  public static ToyAccount basicSelfDestructor(
+      Heir heir, Optional<Address> selfDestructAddress, TestInfoWithChainConfig testInfo) {
 
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     switch (heir) {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/RepeatedSelfDestructsOfSameAccountTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/RepeatedSelfDestructsOfSameAccountTests.java
@@ -71,11 +71,11 @@ public class RepeatedSelfDestructsOfSameAccountTests extends TracerTestBase {
   private void run(Heir heir) {
     selfDestructorAccount = basicSelfDestructor(heir, Optional.empty());
     buildToAccount();
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(userAccount, toAccount, selfDestructorAccount))
         .transaction(transaction())
         .build()
-        .run(testInfo);
+        .run();
   }
 
   /**
@@ -221,11 +221,11 @@ public class RepeatedSelfDestructsOfSameAccountTests extends TracerTestBase {
             .gasLimit(500_000L)
             .value(Wei.of(0xeeff))
             .build();
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(userAccount, toAccount, selfDestructorAccount))
         .transaction(transaction)
         .build()
-        .run(testInfo);
+        .run();
     run(heir);
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/RepeatedSelfDestructsOfSameAccountTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/RepeatedSelfDestructsOfSameAccountTests.java
@@ -69,7 +69,7 @@ public class RepeatedSelfDestructsOfSameAccountTests extends TracerTestBase {
   }
 
   private void run(Heir heir) {
-    selfDestructorAccount = basicSelfDestructor(heir, Optional.empty());
+    selfDestructorAccount = basicSelfDestructor(heir, Optional.empty(), testInfo);
     buildToAccount();
     ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(userAccount, toAccount, selfDestructorAccount))
@@ -210,7 +210,7 @@ public class RepeatedSelfDestructsOfSameAccountTests extends TracerTestBase {
   @ParameterizedTest
   @EnumSource(Heir.class)
   public void basicSelfDestruct(Heir heir) {
-    selfDestructorAccount = basicSelfDestructor(heir, Optional.empty());
+    selfDestructorAccount = basicSelfDestructor(heir, Optional.empty(), testInfo);
     buildToAccount();
     Transaction transaction =
         ToyTransaction.builder()

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/RepeatedSelfDestructsOfSameAccountTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/RepeatedSelfDestructsOfSameAccountTests.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 public class RepeatedSelfDestructsOfSameAccountTests extends TracerTestBase {
 
   private ToyAccount toAccount;
-  BytecodeCompiler toAccountCode = BytecodeCompiler.newProgram();
+  BytecodeCompiler toAccountCode = BytecodeCompiler.newProgram(testInfo);
   private ToyAccount selfDestructorAccount;
 
   private void buildToAccount() {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/SelfdestructCoinbaseTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/SelfdestructCoinbaseTests.java
@@ -52,7 +52,7 @@ public class SelfdestructCoinbaseTests extends TracerTestBase {
   static final ToyAccount CHECKING_COINBASE =
       ToyAccount.builder()
           .code(
-              BytecodeCompiler.newProgram()
+              BytecodeCompiler.newProgram(testInfo)
                   .op(OpCode.COINBASE)
                   .op(OpCode.BALANCE)
                   .op(OpCode.POP)
@@ -99,7 +99,7 @@ public class SelfdestructCoinbaseTests extends TracerTestBase {
             .nonce(1)
             .address(Address.fromHexString("0x1122334455667788990011223344556677889900"))
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     .push(0)
                     .push(0)
                     .push(0)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/SelfdestructCoinbaseTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/SelfdestructCoinbaseTests.java
@@ -141,13 +141,13 @@ public class SelfdestructCoinbaseTests extends TracerTestBase {
       deployedAccounts.add(selfDestructorCoinbaseAccount);
     }
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(deployedAccounts)
         .transactions(List.of(selfdestruction, checkingCoinbase))
         .zkTracerValidator(zkTracer -> {})
         .coinbase(depAddress)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   private static Stream<Arguments> selfDestructCoinbaseInputs() {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/SelfdestructCoinbaseTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/SelfdestructCoinbaseTests.java
@@ -88,7 +88,8 @@ public class SelfdestructCoinbaseTests extends TracerTestBase {
         basicSelfDestructor(
             HEIR_IS_EOA,
             Optional.of(
-                (coinBaseDeployed && rootIsDeployment) ? DEFAULT_COINBASE_ADDRESS : depAddress));
+                (coinBaseDeployed && rootIsDeployment) ? DEFAULT_COINBASE_ADDRESS : depAddress),
+            testInfo);
     if (revertingTransaction) {
       setRevert(selfDestructorCoinbaseAccount);
     }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/SeveralSelfDestructsInARowModifyingStorageTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/SeveralSelfDestructsInARowModifyingStorageTests.java
@@ -42,6 +42,6 @@ public class SeveralSelfDestructsInARowModifyingStorageTests extends TracerTestB
           .balance(Wei.fromEth(1))
           .nonce(13)
           .address(modifyStorageThenSelfDestructAddress)
-          .code(SelfDestructs.storageTouchingSelfDestructorRewardsZeroAddress().compile())
+          .code(SelfDestructs.storageTouchingSelfDestructorRewardsZeroAddress(testInfo).compile())
           .build();
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/utilities/MultiOpCodeSmcs.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/utilities/MultiOpCodeSmcs.java
@@ -31,7 +31,7 @@ public class MultiOpCodeSmcs {
    */
   public static BytecodeCompiler allContextOpCodes() {
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .op(ADDRESS)
         .op(CALLDATASIZE)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/utilities/MultiOpCodeSmcs.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/utilities/MultiOpCodeSmcs.java
@@ -14,9 +14,11 @@
  */
 package net.consensys.linea.zktracer.instructionprocessing.utilities;
 
+import static net.consensys.linea.reporting.TracerTestBase.testInfo;
 import static net.consensys.linea.zktracer.instructionprocessing.utilities.Calls.*;
 import static net.consensys.linea.zktracer.opcode.OpCode.*;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.ToyAccount;
 import org.hyperledger.besu.datatypes.Address;
@@ -29,7 +31,7 @@ public class MultiOpCodeSmcs {
    *
    * @return
    */
-  public static BytecodeCompiler allContextOpCodes() {
+  public static BytecodeCompiler allContextOpCodes(TestInfoWithChainConfig testInfo) {
 
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
@@ -50,6 +52,6 @@ public class MultiOpCodeSmcs {
           .balance(Wei.fromEth(9))
           .nonce(13)
           .address(Address.fromHexString("c0de"))
-          .code(allContextOpCodes().compile())
+          .code(allContextOpCodes(testInfo).compile())
           .build();
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/utilities/SelfDestructs.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/utilities/SelfDestructs.java
@@ -88,7 +88,7 @@ public class SelfDestructs {
 
   public static BytecodeCompiler storageTouchingSelfDestructorRewardsZeroAddress() {
 
-    BytecodeCompiler selfDestructor = BytecodeCompiler.newProgram();
+    BytecodeCompiler selfDestructor = BytecodeCompiler.newProgram(testInfo);
     loadAndStoreValues(selfDestructor);
     // selfDestructWithZeroRecipient(selfDestructor);
 
@@ -97,7 +97,7 @@ public class SelfDestructs {
 
   public static BytecodeCompiler variableRecipientStorageTouchingSelfDestructor() {
 
-    BytecodeCompiler selfDestructor = BytecodeCompiler.newProgram();
+    BytecodeCompiler selfDestructor = BytecodeCompiler.newProgram(testInfo);
     loadAndStoreValues(selfDestructor);
     seldestructWithRecipientLoadedFromStorage(selfDestructor);
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/utilities/SelfDestructs.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/utilities/SelfDestructs.java
@@ -17,6 +17,7 @@ package net.consensys.linea.zktracer.instructionprocessing.utilities;
 import static net.consensys.linea.zktracer.opcode.OpCode.*;
 import static org.hyperledger.besu.datatypes.Address.ECREC;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.zktracer.opcode.OpCode;
 
@@ -86,7 +87,8 @@ public class SelfDestructs {
     return increment.sizeDelta();
   }
 
-  public static BytecodeCompiler storageTouchingSelfDestructorRewardsZeroAddress() {
+  public static BytecodeCompiler storageTouchingSelfDestructorRewardsZeroAddress(
+      TestInfoWithChainConfig testInfo) {
 
     BytecodeCompiler selfDestructor = BytecodeCompiler.newProgram(testInfo);
     loadAndStoreValues(selfDestructor);
@@ -95,7 +97,8 @@ public class SelfDestructs {
     return selfDestructor;
   }
 
-  public static BytecodeCompiler variableRecipientStorageTouchingSelfDestructor() {
+  public static BytecodeCompiler variableRecipientStorageTouchingSelfDestructor(
+      TestInfoWithChainConfig testInfo) {
 
     BytecodeCompiler selfDestructor = BytecodeCompiler.newProgram(testInfo);
     loadAndStoreValues(selfDestructor);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/zeroSize/CallArguments.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/zeroSize/CallArguments.java
@@ -40,7 +40,7 @@ public class CallArguments extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void emptyCallDataAndReturnAtCall(OpCode callOpCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     extremalCallContract(program, callOpCode, true, true);
     BytecodeRunner.of(program.compile()).run(testInfo);
   }
@@ -50,7 +50,7 @@ public class CallArguments extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void emptyReturnAtCall(OpCode callOpCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     extremalCallContract(program, callOpCode, false, true);
     BytecodeRunner.of(program.compile()).run(testInfo);
   }
@@ -60,7 +60,7 @@ public class CallArguments extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void emptyCallDataCall(OpCode callOpCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     extremalCallContract(program, callOpCode, true, false);
     BytecodeRunner.of(program.compile()).run(testInfo);
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/zeroSize/CallArgumentsMaybeRedundant.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/zeroSize/CallArgumentsMaybeRedundant.java
@@ -46,7 +46,7 @@ public class CallArgumentsMaybeRedundant extends TracerTestBase {
 
   @Test
   void zeroReturnAtCapacityTest() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(0) // return at capacity
         .push("ff".repeat(32)) // return at offset
@@ -56,7 +56,7 @@ public class CallArgumentsMaybeRedundant extends TracerTestBase {
         .push(1000) // gas
         .op(OpCode.STATICCALL);
 
-    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram(testInfo);
     calleeProgram.op(OpCode.RETURNDATASIZE).op(OpCode.CALLDATASIZE);
     // .push(0x51) // size
     // .push(0x0f) // offset
@@ -77,7 +77,7 @@ public class CallArgumentsMaybeRedundant extends TracerTestBase {
 
   @Test
   void zeroCallDataSizeTest() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(0xff) // r@c
         .push(0x7f) // r@o
@@ -89,7 +89,7 @@ public class CallArgumentsMaybeRedundant extends TracerTestBase {
         .op(OpCode.RETURNDATASIZE)
         .op(OpCode.CALLDATASIZE);
 
-    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram(testInfo);
     calleeProgram
         .op(OpCode.RETURNDATASIZE)
         .op(OpCode.CALLDATASIZE)
@@ -111,7 +111,7 @@ public class CallArgumentsMaybeRedundant extends TracerTestBase {
 
   @Test
   void zeroCallDataSizeAndReturnAtCapacityTest() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(0) // return at capacity
         .push("ff".repeat(32)) // return at offset
@@ -121,7 +121,7 @@ public class CallArgumentsMaybeRedundant extends TracerTestBase {
         .push(1000) // gas
         .op(OpCode.STATICCALL);
 
-    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram(testInfo);
     calleeProgram.push(0).push("ff".repeat(32)).op(OpCode.RETURN);
 
     final ToyAccount calleeAccount =

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/zeroSize/ReturnRevertArguments.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/zeroSize/ReturnRevertArguments.java
@@ -83,11 +83,11 @@ public class ReturnRevertArguments extends TracerTestBase {
             .payload(initCode.compile())
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(userAccount))
         .transaction(deploymentTransaction)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   /**
@@ -153,11 +153,11 @@ public class ReturnRevertArguments extends TracerTestBase {
             .value(Wei.of(1L))
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(userAccount, callerAccount, calleeAccount))
         .transaction(transaction)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   /**
@@ -214,11 +214,11 @@ public class ReturnRevertArguments extends TracerTestBase {
             .payload(payload.compile()) // here: call data, later: init code
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(userAccount, creatorAccount))
         .transaction(transaction)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   /**

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/zeroSize/ReturnRevertArguments.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/zeroSize/ReturnRevertArguments.java
@@ -50,7 +50,7 @@ public class ReturnRevertArguments extends TracerTestBase {
       value = OpCode.class,
       names = {"RETURN", "REVERT"})
   void rootContextMessageCall(OpCode opCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     zeroSizeReturnOrRevert(program, opCode);
     BytecodeRunner.of(program.compile()).run(testInfo);
   }
@@ -70,7 +70,7 @@ public class ReturnRevertArguments extends TracerTestBase {
   void rootContextDeploymentTransaction(OpCode opCode) {
     checkArgument(opCode.isAnyOf(RETURN, REVERT));
 
-    BytecodeCompiler initCode = BytecodeCompiler.newProgram();
+    BytecodeCompiler initCode = BytecodeCompiler.newProgram(testInfo);
     zeroSizeReturnOrRevert(initCode, opCode);
 
     Transaction deploymentTransaction =
@@ -108,7 +108,7 @@ public class ReturnRevertArguments extends TracerTestBase {
     checkArgument(opCode.isAnyOf(RETURN, REVERT));
 
     Address calleeAccountAddress = Address.fromHexString("ca11eec0def3fd");
-    BytecodeCompiler calleeAccountCode = BytecodeCompiler.newProgram();
+    BytecodeCompiler calleeAccountCode = BytecodeCompiler.newProgram(testInfo);
     zeroSizeReturnOrRevert(calleeAccountCode, opCode);
 
     ToyAccount calleeAccount =
@@ -120,7 +120,7 @@ public class ReturnRevertArguments extends TracerTestBase {
             .build();
 
     Address callerAccountAddress = Address.fromHexString("ca11e7c0de");
-    BytecodeCompiler callerAccountCode = BytecodeCompiler.newProgram();
+    BytecodeCompiler callerAccountCode = BytecodeCompiler.newProgram(testInfo);
     callerAccountCode
         .push(0) // r@c
         .push(0) // r@o
@@ -183,7 +183,7 @@ public class ReturnRevertArguments extends TracerTestBase {
   void nonRootContextDeployment(OpCode opCode) {
     checkArgument(opCode.isAnyOf(RETURN, REVERT));
 
-    BytecodeCompiler creatorAccountCode = BytecodeCompiler.newProgram();
+    BytecodeCompiler creatorAccountCode = BytecodeCompiler.newProgram(testInfo);
     loadTheFullCallDataToRam(creatorAccountCode, 0);
     creatorAccountCode
         .op(CALLDATASIZE) // init code size
@@ -201,7 +201,7 @@ public class ReturnRevertArguments extends TracerTestBase {
             .address(Address.fromHexString("c0dec0ffeef3fd"))
             .build();
 
-    BytecodeCompiler payload = BytecodeCompiler.newProgram();
+    BytecodeCompiler payload = BytecodeCompiler.newProgram(testInfo);
     zeroSizeReturnOrRevert(payload, opCode);
     Transaction transaction =
         ToyTransaction.builder()

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/add/AddTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/add/AddTest.java
@@ -29,7 +29,7 @@ public class AddTest extends TracerTestBase {
   @Test
   void testSmallZeroAdd() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(Bytes.of(0xF1))
                 .push(Bytes.EMPTY)
                 .op(OpCode.ADD)
@@ -40,7 +40,7 @@ public class AddTest extends TracerTestBase {
   @Test
   void testSmallZeroSub() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(Bytes.of(0xF1))
                 .push(Bytes.EMPTY)
                 .op(OpCode.SUB)
@@ -51,7 +51,7 @@ public class AddTest extends TracerTestBase {
   @Test
   void testOverflowLoAdd() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(Bytes.fromHexString("0xF0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF"))
                 .push(Bytes.fromHexString("0xE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF"))
                 .op(OpCode.ADD)
@@ -62,7 +62,7 @@ public class AddTest extends TracerTestBase {
   @Test
   void testHugeSmallAdd() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(Bytes.repeat((byte) 0xFF, 32))
                 .push(Bytes.of(2))
                 .op(OpCode.ADD)
@@ -73,7 +73,7 @@ public class AddTest extends TracerTestBase {
   @Test
   void testOverFlowHiAdd() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(
                     Bytes.concatenate(Bytes.repeat((byte) 0xFF, 16), Bytes.repeat((byte) 0x01, 16)))
                 .push(
@@ -86,7 +86,7 @@ public class AddTest extends TracerTestBase {
   @Test
   void testSmallHugeSub() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(Bytes.of(2))
                 .push(Bytes.repeat((byte) 0xFF, 32))
                 .op(OpCode.SUB)
@@ -97,7 +97,7 @@ public class AddTest extends TracerTestBase {
   @Test
   void testHugeSmallSub() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(Bytes.repeat((byte) 0xFF, 32))
                 .push(Bytes.of(2))
                 .op(OpCode.SUB)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/bin/BinTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/bin/BinTest.java
@@ -28,14 +28,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class BinTest extends TracerTestBase {
   @Test
   public void edgeCase() {
-    BytecodeRunner.of(BytecodeCompiler.newProgram().push(0xf0).push(0xf0).op(OpCode.AND).compile())
+    BytecodeRunner.of(
+            BytecodeCompiler.newProgram(testInfo).push(0xf0).push(0xf0).op(OpCode.AND).compile())
         .run(testInfo);
   }
 
   @Test
   void testSignedSignextend() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(UInt256.MAX_VALUE)
                 .push(UInt256.MAX_VALUE)
                 .op(OpCode.SIGNEXTEND)
@@ -54,7 +55,7 @@ public class BinTest extends TracerTestBase {
   @Test
   void testSignextendRef() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(0xFF)
                 .push(0)
                 .op(OpCode.SIGNEXTEND)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/blockdata/GasLimitTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/blockdata/GasLimitTest.java
@@ -42,7 +42,7 @@ public class GasLimitTest extends TracerTestBase {
   @Disabled("This test is disabled as we now enforce fixed block gas limit")
   @Test
   void legalGasLimitVariationsTest() {
-    Bytes p = BytecodeCompiler.newProgram().push(1).compile();
+    Bytes p = BytecodeCompiler.newProgram(testInfo).push(1).compile();
 
     long gasLimit = GAS_LIMIT_MINIMUM.longValueExact();
     multiBlocksTest(List.of(p, p), List.of(gasLimit, nextGasLimit(gasLimit, IN_RANGE_SAME)));
@@ -73,7 +73,7 @@ public class GasLimitTest extends TracerTestBase {
   @ParameterizedTest
   @MethodSource("blockDataVariableGasLimitTestSource")
   void variableGasLimitTest(long gasLimit, NextGasLimitScenario nextGasLimitScenario) {
-    Bytes program = BytecodeCompiler.newProgram().op(OpCode.STOP).compile();
+    Bytes program = BytecodeCompiler.newProgram(testInfo).op(OpCode.STOP).compile();
 
     multiBlocksTest(
         List.of(program, program), List.of(gasLimit, nextGasLimit(gasLimit, nextGasLimitScenario)));

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/blockhash/BlockhashTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/blockhash/BlockhashTest.java
@@ -38,7 +38,7 @@ public class BlockhashTest extends TracerTestBase {
   @Test
   void severalBlockhash() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
 
                 // arg is NUMBER - 1
                 .push(1)
@@ -131,7 +131,7 @@ public class BlockhashTest extends TracerTestBase {
   @Test
   void singleBlockhash() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
 
                 // arg of BlockHash is Blocknumber +1
                 .op(OpCode.NUMBER)
@@ -146,11 +146,12 @@ public class BlockhashTest extends TracerTestBase {
   @Test
   void blockhashArgumentUpperRangeCheckMultiBlockTest() {
     // Block 1
-    Bytes program1 = BytecodeCompiler.newProgram().op(OpCode.NUMBER).op(OpCode.BLOCKHASH).compile();
+    Bytes program1 =
+        BytecodeCompiler.newProgram(testInfo).op(OpCode.NUMBER).op(OpCode.BLOCKHASH).compile();
 
     // Block 2
     Bytes program2 =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(1)
             .op(OpCode.NUMBER)
             .op(OpCode.SUB)
@@ -162,10 +163,10 @@ public class BlockhashTest extends TracerTestBase {
 
   @Test
   void blockhashArgumentLowerRangeCheckMultiBlockTest() {
-    Bytes fillerProgram = BytecodeCompiler.newProgram().op(OpCode.COINBASE).compile();
+    Bytes fillerProgram = BytecodeCompiler.newProgram(testInfo).op(OpCode.COINBASE).compile();
 
     Bytes program0 =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(1)
             .op(OpCode.NUMBER)
             .op(OpCode.SUB)
@@ -175,7 +176,7 @@ public class BlockhashTest extends TracerTestBase {
     // Block no longer available
     // Block 1
     Bytes program1 =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(256)
             .op(OpCode.NUMBER)
             .op(OpCode.SUB)
@@ -184,7 +185,7 @@ public class BlockhashTest extends TracerTestBase {
 
     // Block 2
     Bytes program2 =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(257)
             .op(OpCode.NUMBER)
             .op(OpCode.SUB)
@@ -192,7 +193,7 @@ public class BlockhashTest extends TracerTestBase {
             .compile();
 
     Bytes program3 =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(16)
             .op(OpCode.NUMBER)
             .op(OpCode.SUB)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/ecdata/EcAddTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/ecdata/EcAddTest.java
@@ -41,7 +41,7 @@ public class EcAddTest extends TracerTestBase {
   @MethodSource("ecAddSource")
   void testEcAdd(String pX, String pY, String qX, String qY) {
     BytecodeCompiler program =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             // First place the parameters in memory
             .push(pX) // pX
             .push(0)
@@ -84,7 +84,7 @@ public class EcAddTest extends TracerTestBase {
   @Test
   void testEcAddSingleCase() {
     BytecodeCompiler program =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             // First place the parameters in memory
             .push("070375d4eec4f22aa3ad39cb40ccd73d2dbab6de316e75f81dc2948a996795d5") // pX
             .push(0)
@@ -116,7 +116,7 @@ public class EcAddTest extends TracerTestBase {
   @Test
   void testEcAddWithPointAtInfinityAsResult() {
     BytecodeCompiler program =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             // First place the parameters in memory
             .push(1) // pX
             .push(0)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/ecdata/EcRecoverTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/ecdata/EcRecoverTest.java
@@ -59,7 +59,7 @@ public class EcRecoverTest extends TracerTestBase {
       boolean expectedInternalChecksPassed,
       boolean expectedSuccessBit) {
     BytecodeCompiler program =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             // First place the parameters in memory
             .push(h)
             .push(0)
@@ -233,7 +233,7 @@ public class EcRecoverTest extends TracerTestBase {
   @Test
   void testEcRecoverInternalChecksFailSingleCase() {
     BytecodeCompiler program =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             // First place the parameters in memory
             .push("1111111111111111111111111111111111111111111111111111111111111111") // h
             .push(0)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/ecdata/ecpairing/EcPairingTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/ecdata/ecpairing/EcPairingTest.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import net.consensys.linea.UnitTestWatcher;
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.BytecodeRunner;
@@ -42,7 +43,6 @@ import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -197,7 +197,13 @@ public class EcPairingTest extends TracerTestBase {
   // testEcPairingSingleForScenarioUsingMethodSource
   // testEcPairingSingleForScenarioUsingCsv
   private static void testEcPairingSingleForScenario(
-      String Ax, String Ay, String BxIm, String BxRe, String ByIm, String ByRe, TestInfo testInfo) {
+      String Ax,
+      String Ay,
+      String BxIm,
+      String BxRe,
+      String ByIm,
+      String ByRe,
+      TestInfoWithChainConfig testInfo) {
     // small point: (Ax,Ay)
     // large point: (BxRe + i*BxIm, ByRe + i*ByIm)
     BytecodeCompiler program =

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/ecdata/ecpairing/EcPairingTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/ecdata/ecpairing/EcPairingTest.java
@@ -120,7 +120,7 @@ public class EcPairingTest extends TracerTestBase {
   @Test
   void testEcPairingWithSingleTrivialPairing() {
     BytecodeCompiler program =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(0x20) // retSize
             .push(0) // retOffset
             .push(192) // argSize
@@ -140,7 +140,7 @@ public class EcPairingTest extends TracerTestBase {
     // small point: (Ax,Ay)
     // large point: (BxRe + i*BxIm, ByRe + i*ByIm)
     BytecodeCompiler program =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             // random point in C1
             .push("26d7d8759964ac70b4d5cdf698ad5f70da246752481ea37da637551a60a2a57f") // Ax
             .push(0)
@@ -207,7 +207,7 @@ public class EcPairingTest extends TracerTestBase {
     // small point: (Ax,Ay)
     // large point: (BxRe + i*BxIm, ByRe + i*ByIm)
     BytecodeCompiler program =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             // point supposed to be in C1
             .push(Ax) // Ax
             .push(0)
@@ -282,7 +282,7 @@ public class EcPairingTest extends TracerTestBase {
 
     List<Arguments> pairings = pairingsAsStringToArgumentsList(pairingsAsString);
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     for (int i = 0; i < pairings.size(); i++) {
       Arguments pair = pairings.get(i);
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/exp/ExpTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/exp/ExpTest.java
@@ -60,7 +60,8 @@ public class ExpTest extends TracerTestBase {
 
   @Test
   void testExpLogSingleCase() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram().push(2).push(10).op(OpCode.EXP);
+    BytecodeCompiler program =
+        BytecodeCompiler.newProgram(testInfo).push(2).push(10).op(OpCode.EXP);
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
     bytecodeRunner.run(testInfo);
   }
@@ -68,7 +69,7 @@ public class ExpTest extends TracerTestBase {
   @Test
   void testModexpLogSingleCase() {
     BytecodeCompiler program =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(1) // bbs
             .push(0)
             .op(OpCode.MSTORE)
@@ -104,7 +105,8 @@ public class ExpTest extends TracerTestBase {
       })
   void testExpLogFFBlockCase(int k) {
     Bytes exponent = Bytes.fromHexString(ffBlock(k));
-    BytecodeCompiler program = BytecodeCompiler.newProgram().push(exponent).push(10).op(OpCode.EXP);
+    BytecodeCompiler program =
+        BytecodeCompiler.newProgram(testInfo).push(exponent).push(10).op(OpCode.EXP);
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
     bytecodeRunner.run(testInfo);
   }
@@ -117,7 +119,8 @@ public class ExpTest extends TracerTestBase {
       })
   void testExpLogFFAtCase(int k) {
     Bytes exponent = Bytes.fromHexString(ffAt(k));
-    BytecodeCompiler program = BytecodeCompiler.newProgram().push(exponent).push(10).op(OpCode.EXP);
+    BytecodeCompiler program =
+        BytecodeCompiler.newProgram(testInfo).push(exponent).push(10).op(OpCode.EXP);
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
     bytecodeRunner.run(testInfo);
   }
@@ -215,7 +218,7 @@ public class ExpTest extends TracerTestBase {
     final int mbs = 0;
     final int minimalValidCds = cdsCutoff + 96 + bbs;
 
-    return BytecodeCompiler.newProgram()
+    return BytecodeCompiler.newProgram(testInfo)
         .push(bbs) // bbs
         .push(0)
         .op(OpCode.MSTORE)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/ext/TestDuplicatedOperations.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/ext/TestDuplicatedOperations.java
@@ -31,7 +31,7 @@ public class TestDuplicatedOperations extends TracerTestBase {
   @Test
   void testDuplicate() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(
                     Bytes.fromHexString(
                         "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"))

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/AddressCollisionWarmingAndDeploymentTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/AddressCollisionWarmingAndDeploymentTests.java
@@ -182,13 +182,13 @@ public class AddressCollisionWarmingAndDeploymentTests extends TracerTestBase {
       accounts.add(recipientAccount);
     }
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(accounts)
         .transaction(tx)
         .coinbase(coinBaseAddress)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 
   private void appendAccessListEntry(

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/AddressCollisionWarmingAndDeploymentTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/AddressCollisionWarmingAndDeploymentTests.java
@@ -66,7 +66,7 @@ public class AddressCollisionWarmingAndDeploymentTests extends TracerTestBase {
   private static final Bytes32 STD_KEY =
       Bytes32.wrap(leftPadTo(Bytes.fromHexString("0xdeadbeef"), Bytes32.SIZE));
   private static final Bytes SSTORE_INITCODE =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .push(Bytes.fromHexString("0x7a12e0")) // value
           .push(STD_KEY.trimLeadingZeros()) // key
           .op(OpCode.SSTORE)
@@ -75,7 +75,7 @@ public class AddressCollisionWarmingAndDeploymentTests extends TracerTestBase {
   private final Bytes32 INITCODE_HASH = keccak256(SSTORE_INITCODE);
 
   private static final Bytes CREATE2_AND_SSTORE =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .push(0) // offset
           .push(SSTORE_INITCODE) // value
           .op(OpCode.MSTORE)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/CallEmptyNoStopTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/CallEmptyNoStopTest.java
@@ -76,7 +76,7 @@ public class CallEmptyNoStopTest extends TracerTestBase {
     Transaction tx =
         ToyTransaction.builder().sender(senderAccount).to(receiverAccount).keyPair(keyPair).build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, receiverAccount, emptyCodeAccount))
         .transaction(tx)
         .zkTracerValidator(
@@ -86,6 +86,6 @@ public class CallEmptyNoStopTest extends TracerTestBase {
                   .isEqualTo(11);
             })
         .build()
-        .run(testInfo);
+        .run();
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/CallEmptyNoStopTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/CallEmptyNoStopTest.java
@@ -53,7 +53,7 @@ public class CallEmptyNoStopTest extends TracerTestBase {
             .nonce(6)
             .address(Address.fromHexString("0x111111"))
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     .push(0) // retSize
                     .push(0) // retOffset
                     .push(0) // argsSize

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/MessageFrameTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/MessageFrameTest.java
@@ -37,7 +37,7 @@ public class MessageFrameTest extends TracerTestBase {
     // The pc is not updated as expected
     // We do not execute the init code of the created smart contract
     // TODO: fix this!
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program
         .push("63deadbeef000000000000000000000000000000000000000000000000000000")
@@ -57,7 +57,7 @@ public class MessageFrameTest extends TracerTestBase {
   void testCall() {
     // Interestingly for CALL the pc is updated as expected
     // We execute the bytecode of the called smart contract
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     program.push(0).push(0).push(0).push(0).push(0x01).push("ca11ee").push(0xffff).op(OpCode.CALL);
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/SimpleStorageConsistency.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/SimpleStorageConsistency.java
@@ -89,7 +89,7 @@ public class SimpleStorageConsistency extends TracerTestBase {
             .balance(Wei.fromEth(1))
             .address(receiverAddress)
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     // SLOAD initial value
                     .push(key)
                     .op(OpCode.SLOAD)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/SimpleStorageConsistency.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/SimpleStorageConsistency.java
@@ -141,11 +141,11 @@ public class SimpleStorageConsistency extends TracerTestBase {
 
     final List<Transaction> txs = List.of(simpleWarm, stupidWarm, noWarm);
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(receiverAccount, senderAccount1, senderAccount2, senderAccount3))
         .transactions(txs)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/TxFinalTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/TxFinalTest.java
@@ -48,11 +48,11 @@ public class TxFinalTest extends TracerTestBase {
       ToyAccount.builder()
           .balance(Wei.fromEth(1))
           .address(Address.fromHexString("0xdead000000000000000000000000000beef"))
-          .code(BytecodeCompiler.newProgram().push(12).push(35).op(OpCode.SGT).compile())
+          .code(BytecodeCompiler.newProgram(testInfo).push(12).push(35).op(OpCode.SGT).compile())
           .build();
 
   private static final Bytes initCode =
-      BytecodeCompiler.newProgram().push(12).push(13).push(24).op(OpCode.ADDMOD).compile();
+      BytecodeCompiler.newProgram(testInfo).push(12).push(13).push(24).op(OpCode.ADDMOD).compile();
 
   final Address depAddress =
       Address.extract(getCreateRawAddress(senderAddress, senderAccount.getNonce()));

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/TxFinalTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/TxFinalTest.java
@@ -70,13 +70,13 @@ public class TxFinalTest extends TracerTestBase {
             .value(Wei.of(1000))
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, receiverAccount))
         .transaction(tx)
         .coinbase(senderAddress)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -90,13 +90,13 @@ public class TxFinalTest extends TracerTestBase {
             .value(Wei.of(1000))
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, receiverAccount))
         .transaction(tx)
         .coinbase(receiverAccount.getAddress())
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 
   // TODO: add smcCallTripleCollision() {}, not possible before EIP-7702
@@ -114,13 +114,13 @@ public class TxFinalTest extends TracerTestBase {
             .value(Wei.of(1000))
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount))
         .transaction(tx)
         .coinbase(senderAddress)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -134,13 +134,13 @@ public class TxFinalTest extends TracerTestBase {
             .value(Wei.of(1000))
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount))
         .transaction(tx)
         .coinbase(depAddress)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
   // good luck for finding the right nonce ;) deploymentTripleCollision() {}
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/TxSkipTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/TxSkipTests.java
@@ -182,7 +182,7 @@ public class TxSkipTests extends TracerTestBase {
             deploymentWithEmptyInit,
             deploymentWithEmptyInitAndUselessAccessList);
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(
             List.of(
                 coinbaseAccount,
@@ -202,7 +202,7 @@ public class TxSkipTests extends TracerTestBase {
               // assertThat(zkTracer.getHub().lineCount()).isEqualTo(txs.size() * nbOfRowsTxSkip);
             })
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -231,12 +231,12 @@ public class TxSkipTests extends TracerTestBase {
             .gasLimit(100000L)
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(coinbaseAccount, senderAccount))
         .transaction(tx)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -256,12 +256,12 @@ public class TxSkipTests extends TracerTestBase {
             .value(Wei.of(123))
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount))
         .transaction(tx)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -288,13 +288,13 @@ public class TxSkipTests extends TracerTestBase {
             .value(Wei.of(123))
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount))
         .transaction(tx)
         .zkTracerValidator(zkTracer -> {})
         .coinbase(senderAddress)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -314,13 +314,13 @@ public class TxSkipTests extends TracerTestBase {
             .value(Wei.of(123))
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount))
         .transaction(tx)
         .zkTracerValidator(zkTracer -> {})
         .coinbase(senderAddress)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -349,13 +349,13 @@ public class TxSkipTests extends TracerTestBase {
             .value(Wei.of(123))
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, receiverAccount))
         .transaction(tx)
         .zkTracerValidator(zkTracer -> {})
         .coinbase(Address.BLAKE2B_F_COMPRESSION)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -374,13 +374,13 @@ public class TxSkipTests extends TracerTestBase {
             .gasLimit(100000L)
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount))
         .transaction(tx)
         .zkTracerValidator(zkTracer -> {})
         .coinbase(senderAddress)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -407,13 +407,13 @@ public class TxSkipTests extends TracerTestBase {
             .nonce((long) nonce)
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount))
         .transaction(tx)
         .zkTracerValidator(zkTracer -> {})
         .coinbase(depAddress)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -432,12 +432,12 @@ public class TxSkipTests extends TracerTestBase {
             .gasLimit(100000L)
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount))
         .transaction(tx)
         .zkTracerValidator(zkTracer -> {})
         .coinbase(Address.RIPEMD160)
         .build()
-        .run(testInfo);
+        .run();
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/TxWarmTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/TxWarmTest.java
@@ -108,12 +108,12 @@ public class TxWarmTest extends TracerTestBase {
             .value(Wei.of(1000))
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, receiverAccount))
         .transaction(tx)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -132,12 +132,12 @@ public class TxWarmTest extends TracerTestBase {
             .value(Wei.of(1000))
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, receiverAccount))
         .transaction(tx)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -158,12 +158,12 @@ public class TxWarmTest extends TracerTestBase {
             .value(Wei.of(1000))
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, receiverAccount))
         .transaction(tx)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -184,12 +184,12 @@ public class TxWarmTest extends TracerTestBase {
             .value(Wei.of(1000))
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, receiverAccount))
         .transaction(tx)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -215,11 +215,11 @@ public class TxWarmTest extends TracerTestBase {
             .value(Wei.of(1000))
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount))
         .transaction(tx)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/TxWarmTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/TxWarmTest.java
@@ -55,7 +55,7 @@ public class TxWarmTest extends TracerTestBase {
       ToyAccount.builder()
           .balance(Wei.fromEth(1))
           .address(Address.fromHexString("0xdead000000000000000000000000000beef"))
-          .code(BytecodeCompiler.newProgram().push(1).push(0).op(OpCode.ADD).compile())
+          .code(BytecodeCompiler.newProgram(testInfo).push(1).push(0).op(OpCode.ADD).compile())
           .build();
 
   @Test
@@ -194,7 +194,8 @@ public class TxWarmTest extends TracerTestBase {
 
   @Test
   void warmDeploymentAddress() {
-    final Bytes initCode = BytecodeCompiler.newProgram().push(1).push(0).op(OpCode.SLT).compile();
+    final Bytes initCode =
+        BytecodeCompiler.newProgram(testInfo).push(1).push(0).op(OpCode.SLT).compile();
 
     final Address depAddress =
         Address.extract(getCreateRawAddress(senderAddress, senderAccount.getNonce()));

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/ZeroSizeCallDataOrReturnDataTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/ZeroSizeCallDataOrReturnDataTest.java
@@ -30,7 +30,7 @@ public class ZeroSizeCallDataOrReturnDataTest extends TracerTestBase {
 
   @Test
   void zeroSizeHugeReturnAtOffsetTest() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(0) // return at capacity
         .push("ff".repeat(32)) // return at offset
@@ -40,7 +40,7 @@ public class ZeroSizeCallDataOrReturnDataTest extends TracerTestBase {
         .push(1000) // gas
         .op(OpCode.STATICCALL);
 
-    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram(testInfo);
     calleeProgram.op(OpCode.CALLDATASIZE);
 
     final ToyAccount calleeAccount =
@@ -57,7 +57,7 @@ public class ZeroSizeCallDataOrReturnDataTest extends TracerTestBase {
 
   @Test
   void zeroSizeHugeCallDataOffsetTest() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(0) // return at capacity
         .push(0) // return at offset
@@ -67,7 +67,7 @@ public class ZeroSizeCallDataOrReturnDataTest extends TracerTestBase {
         .push(1000) // gas
         .op(OpCode.STATICCALL);
 
-    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram(testInfo);
     calleeProgram.op(OpCode.CALLDATASIZE);
 
     final ToyAccount calleeAccount =
@@ -84,7 +84,7 @@ public class ZeroSizeCallDataOrReturnDataTest extends TracerTestBase {
 
   @Test
   void zeroSizeHugeReturnDataOffsetTest() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push(0) // return at capacity
         .push(0) // return at offset
@@ -94,7 +94,7 @@ public class ZeroSizeCallDataOrReturnDataTest extends TracerTestBase {
         .push(1000) // gas
         .op(OpCode.STATICCALL);
 
-    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram();
+    BytecodeCompiler calleeProgram = BytecodeCompiler.newProgram(testInfo);
     calleeProgram.push(0).push("ff".repeat(32)).op(OpCode.RETURN);
 
     final ToyAccount calleeAccount =

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/KeccakBlocksTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/KeccakBlocksTests.java
@@ -78,13 +78,13 @@ public class KeccakBlocksTests extends TracerTestBase {
             .build();
 
     final ToyExecutionEnvironmentV2 toyWorld =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(senderAccount, recipient))
             .transaction(tx)
             .zkTracerValidator(zkTracer -> {})
             .build();
 
-    toyWorld.run(testInfo);
+    toyWorld.run();
 
     final Keccak keccak = toyWorld.getHub().keccak();
     final L1BlockSizeOld l1BlockSize = toyWorld.getHub().l1BlockSize();

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/KeccakBlocksTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/KeccakBlocksTests.java
@@ -53,7 +53,7 @@ public class KeccakBlocksTests extends TracerTestBase {
             .balance(Wei.fromEth(1))
             .address(Address.wrap(Bytes.repeat((byte) 1, Address.SIZE)))
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     // CREATE
                     .push(0) // size
                     .push(0) // offset

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/L2L1LogsTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/L2L1LogsTests.java
@@ -81,13 +81,13 @@ public class L2L1LogsTests extends TracerTestBase {
             .build();
 
     final ToyExecutionEnvironmentV2 toyWorld =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(senderAccount, l2l1LogSMC))
             .transaction(tx)
             .zkTracerValidator(zkTracer -> {})
             .build();
 
-    toyWorld.run(testInfo);
+    toyWorld.run();
 
     final L2L1Logs l2l1Logs = toyWorld.getHub().l2L1Logs();
 
@@ -165,13 +165,13 @@ public class L2L1LogsTests extends TracerTestBase {
             .build();
 
     final ToyExecutionEnvironmentV2 toyWorld =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(senderAccount, l2l1LogSMC, LOG_ACCOUNT_AND_REVERT, LOG_ACCOUNT))
             .transaction(tx)
             .zkTracerValidator(zkTracer -> {})
             .build();
 
-    toyWorld.run(testInfo);
+    toyWorld.run();
 
     final L2L1Logs l2l1Logs = toyWorld.getHub().l2L1Logs();
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/L2L1LogsTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/limits/L2L1LogsTests.java
@@ -51,7 +51,7 @@ public class L2L1LogsTests extends TracerTestBase {
             .balance(Wei.fromEth(1))
             .address(TEST_DEFAULT.contract())
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     // LOG1 with right topic, and no data
                     .push(TEST_DEFAULT.topic()) // topic
                     .push(0) //  size
@@ -109,7 +109,7 @@ public class L2L1LogsTests extends TracerTestBase {
             .balance(Wei.fromEth(1))
             .address(Address.wrap(Bytes.repeat((byte) 1, Address.SIZE)))
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     // LOG1 with right topic, and no data
                     .push(TEST_DEFAULT.topic()) // topic
                     .push(0) //  size
@@ -123,7 +123,7 @@ public class L2L1LogsTests extends TracerTestBase {
             .balance(Wei.fromEth(1))
             .address(Address.wrap(Bytes.repeat((byte) 2, Address.SIZE)))
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     // LOG1 with right topic, and no data
                     .push(TEST_DEFAULT.topic()) // topic
                     .push(0) //  size
@@ -141,7 +141,7 @@ public class L2L1LogsTests extends TracerTestBase {
             .balance(Wei.fromEth(1))
             .address(TEST_DEFAULT.contract())
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     // LOG2 with right topic, not at the right place
                     .push(TEST_DEFAULT.topic()) // topic 2
                     .push(Bytes.of(1)) // topic 1

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mmu/MemoryTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mmu/MemoryTests.java
@@ -32,7 +32,7 @@ class MemoryTests extends TracerTestBase {
   @Test
   void successionOverlappingMstore() {
     BytecodeRunner.of(
-            newProgram()
+            newProgram(testInfo)
                 .push(Bytes.repeat((byte) 1, 32))
                 .push(0)
                 .op(OpCode.MSTORE)
@@ -50,22 +50,25 @@ class MemoryTests extends TracerTestBase {
 
   @Test
   void fastMload() {
-    BytecodeRunner.of(newProgram().push(34).push(0).op(OpCode.MLOAD).compile()).run(testInfo);
+    BytecodeRunner.of(newProgram(testInfo).push(34).push(0).op(OpCode.MLOAD).compile())
+        .run(testInfo);
   }
 
   @Test
   void alignedMstore8() {
-    BytecodeRunner.of(newProgram().push(12).push(0).op(OpCode.MSTORE8).compile()).run(testInfo);
+    BytecodeRunner.of(newProgram(testInfo).push(12).push(0).op(OpCode.MSTORE8).compile())
+        .run(testInfo);
   }
 
   @Test
   void nonAlignedMstore8() {
-    BytecodeRunner.of(newProgram().push(66872).push(35).op(OpCode.MSTORE8).compile()).run(testInfo);
+    BytecodeRunner.of(newProgram(testInfo).push(66872).push(35).op(OpCode.MSTORE8).compile())
+        .run(testInfo);
   }
 
   @Test
   void mstoreAndReturn() {
-    BytecodeCompiler program = newProgram();
+    BytecodeCompiler program = newProgram(testInfo);
     program
         .push("deadbeef11111111deadbeef22222222deadbeef00000000deadbeefcccccccc")
         .push(0x20)
@@ -78,7 +81,7 @@ class MemoryTests extends TracerTestBase {
 
   @Test
   void mstoreAndRevert() {
-    BytecodeCompiler program = newProgram();
+    BytecodeCompiler program = newProgram(testInfo);
     program
         .push("deadbeef11111111deadbeef22222222deadbeef00000000deadbeefcccccccc")
         .push(0x20)
@@ -91,7 +94,7 @@ class MemoryTests extends TracerTestBase {
 
   @Test
   void returnAfterLog2() {
-    BytecodeCompiler program = newProgram();
+    BytecodeCompiler program = newProgram(testInfo);
     program
         .push(0x01)
         .push(0x11)
@@ -121,7 +124,7 @@ class MemoryTests extends TracerTestBase {
 
   @Test
   void revertAfterLog2() {
-    BytecodeCompiler program = newProgram();
+    BytecodeCompiler program = newProgram(testInfo);
     program
         .push(0x01)
         .push(0x11)
@@ -151,7 +154,7 @@ class MemoryTests extends TracerTestBase {
 
   @Test
   void checkMSizeAfterMemoryExpansion() {
-    BytecodeCompiler program = newProgram();
+    BytecodeCompiler program = newProgram(testInfo);
     program
         .push(0xFF)
         .push(0)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mmu/RevertingLogsTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mmu/RevertingLogsTests.java
@@ -20,7 +20,6 @@ import static net.consensys.linea.zktracer.Utils.*;
 
 import java.util.List;
 
-import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
@@ -42,98 +41,92 @@ import org.junit.jupiter.api.Test;
  */
 public class RevertingLogsTests extends TracerTestBase {
 
-  private static final Bytes TOPIC_1 =
-      Bytes.fromHexString("0x000007031c100000000007031c100000000007031c100000000007031c100000");
-
-  private static final Bytes TOPIC_2 =
-      Bytes.fromHexString("0x000007031c200000000007031c200000000007031c200000000007031c200000");
-
-  private static final Bytes TOPIC_3 =
-      Bytes.fromHexString("0x000007031c300000000007031c300000000007031c300000000007031c300000");
-
-  private static final Bytes TOPIC_4 =
-      Bytes.fromHexString("0x000007031c400000000007031c400000000007031c400000000007031c400000");
-
-  private static final Bytes LOG0 =
-      newProgram(testInfo)
-          .push(18) // size
-          .push(0x1) // offset
-          .op(OpCode.LOG0)
-          .compile();
-
-  private static final Bytes LOG1 =
-      newProgram(testInfo)
-          .push(TOPIC_1)
-          .push(18) // size
-          .push(0x1) // offset
-          .op(OpCode.LOG1)
-          .compile();
-
-  private static final Bytes LOG2 =
-      newProgram(testInfo)
-          .push(TOPIC_2) // topic 2
-          .push(TOPIC_1) // topic 1
-          .push(18) // size
-          .push(0x1) // offset
-          .op(OpCode.LOG2)
-          .compile();
-
-  private static final Bytes LOG3 =
-      newProgram(testInfo)
-          .push(TOPIC_3) // topic 3
-          .push(TOPIC_2) // topic 2
-          .push(TOPIC_1) // topic 1
-          .push(18) // size
-          .push(0x1) // offset
-          .op(OpCode.LOG3)
-          .compile();
-
-  private static final Bytes LOG4 =
-      newProgram(testInfo)
-          .push(TOPIC_4) // topic 4
-          .push(TOPIC_3) // topic 3
-          .push(TOPIC_2) // topic 2
-          .push(TOPIC_1) // topic 1
-          .push(18) // size
-          .push(0x1) // offset
-          .op(OpCode.LOG4)
-          .compile();
-
-  private static Bytes SELFREVERT_LOG_BYTECODE(TestInfoWithChainConfig testInfo) {
-    return newProgram(testInfo)
-        .immediate(POPULATE_MEMORY)
-        .immediate(LOG3)
-        .immediate(REVERT)
-        .compile();
-  }
-
-  private static Bytes NON_REVERTING_LOG_BYTECODE(TestInfoWithChainConfig testInfo) {
-    return newProgram(testInfo).immediate(POPULATE_MEMORY).immediate(LOG4).compile();
-  }
-
-  private static final ToyAccount nonRevertingLogSMC =
-      ToyAccount.builder()
-          .address(Address.fromHexString("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
-          .code(NON_REVERTING_LOG_BYTECODE(testInfo))
-          .balance(Wei.of(98989898))
-          .build();
-
-  private static final ToyAccount selfRevertingLogSMC =
-      ToyAccount.builder()
-          .address(Address.fromHexString("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
-          .code(SELFREVERT_LOG_BYTECODE(testInfo))
-          .balance(Wei.of(1235678))
-          .build();
-
-  private static final ToyAccount callNonRevertLogAndSelfRevert =
-      ToyAccount.builder()
-          .address(Address.fromHexString("0xcccccccccccccccccccccccccccccccccccccccc"))
-          .code(Bytes.concatenate(call(nonRevertingLogSMC.getAddress(), false), REVERT))
-          .balance(Wei.of(10000))
-          .build();
-
   @Test
   void mixtureOfRevertedLogs() {
+
+    final Bytes TOPIC_1 =
+        Bytes.fromHexString("0x000007031c100000000007031c100000000007031c100000000007031c100000");
+
+    final Bytes TOPIC_2 =
+        Bytes.fromHexString("0x000007031c200000000007031c200000000007031c200000000007031c200000");
+
+    final Bytes TOPIC_3 =
+        Bytes.fromHexString("0x000007031c300000000007031c300000000007031c300000000007031c300000");
+
+    final Bytes TOPIC_4 =
+        Bytes.fromHexString("0x000007031c400000000007031c400000000007031c400000000007031c400000");
+
+    final Bytes LOG0 =
+        newProgram(testInfo)
+            .push(18) // size
+            .push(0x1) // offset
+            .op(OpCode.LOG0)
+            .compile();
+
+    final Bytes LOG1 =
+        newProgram(testInfo)
+            .push(TOPIC_1)
+            .push(18) // size
+            .push(0x1) // offset
+            .op(OpCode.LOG1)
+            .compile();
+
+    final Bytes LOG2 =
+        newProgram(testInfo)
+            .push(TOPIC_2) // topic 2
+            .push(TOPIC_1) // topic 1
+            .push(18) // size
+            .push(0x1) // offset
+            .op(OpCode.LOG2)
+            .compile();
+
+    final Bytes LOG3 =
+        newProgram(testInfo)
+            .push(TOPIC_3) // topic 3
+            .push(TOPIC_2) // topic 2
+            .push(TOPIC_1) // topic 1
+            .push(18) // size
+            .push(0x1) // offset
+            .op(OpCode.LOG3)
+            .compile();
+
+    final Bytes LOG4 =
+        newProgram(testInfo)
+            .push(TOPIC_4) // topic 4
+            .push(TOPIC_3) // topic 3
+            .push(TOPIC_2) // topic 2
+            .push(TOPIC_1) // topic 1
+            .push(18) // size
+            .push(0x1) // offset
+            .op(OpCode.LOG4)
+            .compile();
+
+    final Bytes SELFREVERT_LOG_BYTECODE =
+        newProgram(testInfo).immediate(POPULATE_MEMORY).immediate(LOG3).immediate(REVERT).compile();
+
+    final Bytes NON_REVERTING_LOG_BYTECODE =
+        newProgram(testInfo).immediate(POPULATE_MEMORY).immediate(LOG4).compile();
+
+    final ToyAccount nonRevertingLogSMC =
+        ToyAccount.builder()
+            .address(Address.fromHexString("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+            .code(NON_REVERTING_LOG_BYTECODE)
+            .balance(Wei.of(98989898))
+            .build();
+
+    final ToyAccount selfRevertingLogSMC =
+        ToyAccount.builder()
+            .address(Address.fromHexString("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
+            .code(SELFREVERT_LOG_BYTECODE)
+            .balance(Wei.of(1235678))
+            .build();
+
+    final ToyAccount callNonRevertLogAndSelfRevert =
+        ToyAccount.builder()
+            .address(Address.fromHexString("0xcccccccccccccccccccccccccccccccccccccccc"))
+            .code(Bytes.concatenate(call(nonRevertingLogSMC.getAddress(), false), REVERT))
+            .balance(Wei.of(10000))
+            .build();
 
     final KeyPair keyPair = new SECP256K1().generateKeyPair();
     final Address senderAddress =

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mmu/RevertingLogsTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mmu/RevertingLogsTests.java
@@ -163,7 +163,7 @@ public class RevertingLogsTests extends TracerTestBase {
             .to(recipientAccount)
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(
             List.of(
                 senderAccount,
@@ -173,6 +173,6 @@ public class RevertingLogsTests extends TracerTestBase {
                 recipientAccount))
         .transaction(tx)
         .build()
-        .run(testInfo);
+        .run();
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mmu/RevertingLogsTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mmu/RevertingLogsTests.java
@@ -20,6 +20,7 @@ import static net.consensys.linea.zktracer.Utils.*;
 
 import java.util.List;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
@@ -54,14 +55,14 @@ public class RevertingLogsTests extends TracerTestBase {
       Bytes.fromHexString("0x000007031c400000000007031c400000000007031c400000000007031c400000");
 
   private static final Bytes LOG0 =
-      newProgram()
+      newProgram(testInfo)
           .push(18) // size
           .push(0x1) // offset
           .op(OpCode.LOG0)
           .compile();
 
   private static final Bytes LOG1 =
-      newProgram()
+      newProgram(testInfo)
           .push(TOPIC_1)
           .push(18) // size
           .push(0x1) // offset
@@ -69,7 +70,7 @@ public class RevertingLogsTests extends TracerTestBase {
           .compile();
 
   private static final Bytes LOG2 =
-      newProgram()
+      newProgram(testInfo)
           .push(TOPIC_2) // topic 2
           .push(TOPIC_1) // topic 1
           .push(18) // size
@@ -78,7 +79,7 @@ public class RevertingLogsTests extends TracerTestBase {
           .compile();
 
   private static final Bytes LOG3 =
-      newProgram()
+      newProgram(testInfo)
           .push(TOPIC_3) // topic 3
           .push(TOPIC_2) // topic 2
           .push(TOPIC_1) // topic 1
@@ -88,7 +89,7 @@ public class RevertingLogsTests extends TracerTestBase {
           .compile();
 
   private static final Bytes LOG4 =
-      newProgram()
+      newProgram(testInfo)
           .push(TOPIC_4) // topic 4
           .push(TOPIC_3) // topic 3
           .push(TOPIC_2) // topic 2
@@ -98,23 +99,29 @@ public class RevertingLogsTests extends TracerTestBase {
           .op(OpCode.LOG4)
           .compile();
 
-  private static final Bytes SELFREVERT_LOG_BYTECODE =
-      newProgram().immediate(POPULATE_MEMORY).immediate(LOG3).immediate(REVERT).compile();
+  private static Bytes SELFREVERT_LOG_BYTECODE(TestInfoWithChainConfig testInfo) {
+    return newProgram(testInfo)
+        .immediate(POPULATE_MEMORY)
+        .immediate(LOG3)
+        .immediate(REVERT)
+        .compile();
+  }
 
-  private static final Bytes NON_REVERTING_LOG_BYTECODE =
-      newProgram().immediate(POPULATE_MEMORY).immediate(LOG4).compile();
+  private static Bytes NON_REVERTING_LOG_BYTECODE(TestInfoWithChainConfig testInfo) {
+    return newProgram(testInfo).immediate(POPULATE_MEMORY).immediate(LOG4).compile();
+  }
 
   private static final ToyAccount nonRevertingLogSMC =
       ToyAccount.builder()
           .address(Address.fromHexString("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
-          .code(NON_REVERTING_LOG_BYTECODE)
+          .code(NON_REVERTING_LOG_BYTECODE(testInfo))
           .balance(Wei.of(98989898))
           .build();
 
   private static final ToyAccount selfRevertingLogSMC =
       ToyAccount.builder()
           .address(Address.fromHexString("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
-          .code(SELFREVERT_LOG_BYTECODE)
+          .code(SELFREVERT_LOG_BYTECODE(testInfo))
           .balance(Wei.of(1235678))
           .build();
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mod/ModTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mod/ModTest.java
@@ -29,7 +29,7 @@ public class ModTest extends TracerTestBase {
   @Test
   void testSignedSmod() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(UInt256.MAX_VALUE)
                 .push(UInt256.MAX_VALUE)
                 .op(OpCode.SMOD)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mul/ExpExtensiveTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mul/ExpExtensiveTest.java
@@ -1784,11 +1784,11 @@ public class ExpExtensiveTest extends TracerTestBase {
   // Support methods
   private BytecodeRunner expProgramOf(String base, String exponent) {
     return BytecodeRunner.of(
-        BytecodeCompiler.newProgram().push(exponent).push(base).op(OpCode.EXP).compile());
+        BytecodeCompiler.newProgram(testInfo).push(exponent).push(base).op(OpCode.EXP).compile());
   }
 
   private BytecodeRunner expProgramOf(String base) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     for (String exponent : EXPONENTS) {
       program.push(exponent).push(base).op(OpCode.EXP);
     }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mxp/MxpTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mxp/MxpTest.java
@@ -93,7 +93,7 @@ public class MxpTest extends TracerTestBase {
   @Test
   void testMxpRandom() {
     // Testing a random program
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     final int INSTRUCTION_COUNT = 4096;
     for (int i = 0; i < INSTRUCTION_COUNT; i++) {
       boolean isHalting = i == INSTRUCTION_COUNT - 1;
@@ -106,7 +106,7 @@ public class MxpTest extends TracerTestBase {
   @Test
   void testMxpRandomTriggerMxpx() {
     // Testing a random program
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     final int INSTRUCTION_COUNT = 256;
     for (int i = 0; i < INSTRUCTION_COUNT; i++) {
       boolean isHalting = i == INSTRUCTION_COUNT - 1;
@@ -120,7 +120,7 @@ public class MxpTest extends TracerTestBase {
   @Test
   void testRandomMxpInstructionsFollowedByTriggeringRoob() {
     // Testing a random program
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     final int INSTRUCTION_COUNT = 256;
     for (int i = 0; i < INSTRUCTION_COUNT; i++) {
       boolean isHalting = i == INSTRUCTION_COUNT - 1;
@@ -132,7 +132,7 @@ public class MxpTest extends TracerTestBase {
 
   @Test
   void testSingleLog3TriggersRoob() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push("30000003333333333333000000000000" + "00000000000000000000000000000003") // topic 3
         .push("20000000000000000000222222222222" + "20000000000000000000000000000002") // topic 2
@@ -145,7 +145,7 @@ public class MxpTest extends TracerTestBase {
 
   @Test
   void testSingleUnexceptionalLog3() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program
         .push("30000003333333333333000000000000" + "00000000000000000000000000000003") // topic 3
         .push("20000000000000000000222222222222" + "20000000000000000000000000000002") // topic 2
@@ -160,7 +160,7 @@ public class MxpTest extends TracerTestBase {
   void testMxpxOrRoob() {
     final int REPETITIONS = 5;
     for (int i = 0; i < REPETITIONS; i++) {
-      BytecodeCompiler program = BytecodeCompiler.newProgram();
+      BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
       boolean isHalting = util.nextRandomInt(2) == 0;
       boolean triggerRoob = util.nextRandomInt(2) == 0;
       triggerNonTrivialButMxpxOrRoob(program, isHalting, triggerRoob);
@@ -174,7 +174,7 @@ public class MxpTest extends TracerTestBase {
     // Testing a random program that contains creates with meaning random arguments
     Bytes INIT = getRandomINITForCreate(); // This is the value given as an argument to CREATE
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     int instructionCount = 256;
     for (int i = 0; i < instructionCount; i++) {
       boolean isHalting = i == instructionCount - 1;
@@ -297,7 +297,7 @@ public class MxpTest extends TracerTestBase {
   // Support methods
   private Bytes getRandomINITForCreate() {
     final int INSTRUCTION_COUNT_INIT = 256;
-    BytecodeCompiler INIT = BytecodeCompiler.newProgram();
+    BytecodeCompiler INIT = BytecodeCompiler.newProgram(testInfo);
     for (int i = 0; i < INSTRUCTION_COUNT_INIT; i++) {
       boolean isHalting = i == INSTRUCTION_COUNT_INIT - 1;
       triggerNonTrivialOrNoop(INIT, isHalting);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mxp/MxpTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mxp/MxpTest.java
@@ -284,14 +284,14 @@ public class MxpTest extends TracerTestBase {
             contractAccountMO2);
 
     ToyExecutionEnvironmentV2 toyExecutionEnvironmentV2 =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(accounts)
             .transaction(tx)
             .transactionProcessingResultValidator(
                 TransactionProcessingResultValidator.EMPTY_VALIDATOR)
             .build();
 
-    toyExecutionEnvironmentV2.run(testInfo);
+    toyExecutionEnvironmentV2.run();
   }
 
   // Support methods

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mxp/MxpTracerTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mxp/MxpTracerTest.java
@@ -20,7 +20,6 @@ import static net.consensys.linea.zktracer.opcode.OpCode.MSTORE;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import net.consensys.linea.UnitTestWatcher;
 import net.consensys.linea.reporting.TracerTestBase;
@@ -30,8 +29,6 @@ import net.consensys.linea.zktracer.container.module.Module;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(UnitTestWatcher.class)
@@ -41,7 +38,7 @@ public class MxpTracerTest extends TracerTestBase {
   private static final Module MODULE = new Mxp();
   private static final DynamicTests DYN_TESTS = DynamicTests.forModule(MODULE);
 
-  @TestFactory
+  /*  @TestFactory
   Stream<DynamicTest> runDynamicTests() {
     return DYN_TESTS
         .testCase("non random arguments test", provideNonRandomArguments())
@@ -49,7 +46,7 @@ public class MxpTracerTest extends TracerTestBase {
         .testCase(
             "one of each type2 and type3 instruction MLOAD, MSTORE, MSTORE8", simpleType2And3Args())
         .run(testInfo);
-  }
+  }*/
 
   private List<OpcodeCall> provideNonRandomArguments() {
     return DYN_TESTS.newModuleArgumentsProvider(

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mxp/MxpTracerTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mxp/MxpTracerTest.java
@@ -20,6 +20,7 @@ import static net.consensys.linea.zktracer.opcode.OpCode.MSTORE;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import net.consensys.linea.UnitTestWatcher;
 import net.consensys.linea.reporting.TracerTestBase;
@@ -29,6 +30,8 @@ import net.consensys.linea.zktracer.container.module.Module;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(UnitTestWatcher.class)
@@ -38,7 +41,7 @@ public class MxpTracerTest extends TracerTestBase {
   private static final Module MODULE = new Mxp();
   private static final DynamicTests DYN_TESTS = DynamicTests.forModule(MODULE);
 
-  /*  @TestFactory
+  @TestFactory
   Stream<DynamicTest> runDynamicTests() {
     return DYN_TESTS
         .testCase("non random arguments test", provideNonRandomArguments())
@@ -46,7 +49,7 @@ public class MxpTracerTest extends TracerTestBase {
         .testCase(
             "one of each type2 and type3 instruction MLOAD, MSTORE, MSTORE8", simpleType2And3Args())
         .run(testInfo);
-  }*/
+  }
 
   private List<OpcodeCall> provideNonRandomArguments() {
     return DYN_TESTS.newModuleArgumentsProvider(

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mxp/SeveralKeccaks.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mxp/SeveralKeccaks.java
@@ -27,7 +27,8 @@ public class SeveralKeccaks extends TracerTestBase {
 
   @Test
   public void testMul() {
-    BytecodeRunner.of(BytecodeCompiler.newProgram().push(32).push(7).op(OpCode.MUL).compile())
+    BytecodeRunner.of(
+            BytecodeCompiler.newProgram(testInfo).push(32).push(7).op(OpCode.MUL).compile())
         .run(testInfo);
   }
 
@@ -35,7 +36,7 @@ public class SeveralKeccaks extends TracerTestBase {
   @Test
   void testIsTheBeefDeadYet() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push("deadbeef") // 4 bytes
                 .push(28 * 8)
                 .op(OpCode.SHL) //  stack = [ 0x DE AD BE EF __ ... __]
@@ -76,7 +77,7 @@ public class SeveralKeccaks extends TracerTestBase {
   @Test
   void testSeveralKeccaks() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(0)
                 .push(0)
                 .op(OpCode.SHA3) // empty hash, no memory expansion

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobCallTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobCallTest.java
@@ -201,14 +201,14 @@ public class OobCallTest extends TracerTestBase {
             .build();
 
     final ToyExecutionEnvironmentV2 toyExecutionEnvironmentV2 =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(userAccount, contractCallerAccount, contractCalleeAccount))
             .transaction(tx)
             .transactionProcessingResultValidator(
                 TransactionProcessingResultValidator.EMPTY_VALIDATOR)
             .build();
 
-    toyExecutionEnvironmentV2.run(testInfo);
+    toyExecutionEnvironmentV2.run();
 
     final Hub hub = toyExecutionEnvironmentV2.getHub();
 
@@ -254,14 +254,14 @@ public class OobCallTest extends TracerTestBase {
             .build();
 
     final ToyExecutionEnvironmentV2 toyExecutionEnvironmentV2 =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(userAccount, contractCallerAccount))
             .transaction(tx)
             .transactionProcessingResultValidator(
                 TransactionProcessingResultValidator.EMPTY_VALIDATOR)
             .build();
 
-    toyExecutionEnvironmentV2.run(testInfo);
+    toyExecutionEnvironmentV2.run();
 
     final Hub hub = toyExecutionEnvironmentV2.getHub();
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobJumpAndJumpiTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobJumpAndJumpiTest.java
@@ -49,7 +49,7 @@ public class OobJumpAndJumpiTest extends TracerTestBase {
 
   @Test
   void testJumpSequenceSuccessTrivial() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendJump(EWord.of(35), program);
     appendStop(program);
@@ -77,7 +77,7 @@ public class OobJumpAndJumpiTest extends TracerTestBase {
 
   @Test
   void testJumpSequenceSuccessBackAndForth() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendJump(EWord.of(71), program);
     appendStop(program);
@@ -105,7 +105,7 @@ public class OobJumpAndJumpiTest extends TracerTestBase {
 
   @Test
   void testJumpSequenceFailingNoJumpdestTrivial() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendJump(EWord.of(35), program);
     appendStop(program);
@@ -134,7 +134,7 @@ public class OobJumpAndJumpiTest extends TracerTestBase {
 
   @Test
   void testJumpSequenceFailingOobTrivial() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendJump(EWord.of(35), program);
     appendStop(program);
@@ -259,7 +259,7 @@ public class OobJumpAndJumpiTest extends TracerTestBase {
 
   @Test
   void testJumpiSequenceSuccessTrivial() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendJumpi(EWord.of(68), EWord.of(1), program);
     appendStop(program);
@@ -287,7 +287,7 @@ public class OobJumpAndJumpiTest extends TracerTestBase {
 
   @Test
   void testJumpiSequenceSuccessBackAndForth() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendJumpi(EWord.of(137), EWord.of(1), program);
     appendStop(program);
@@ -315,7 +315,7 @@ public class OobJumpAndJumpiTest extends TracerTestBase {
 
   @Test
   void testJumpiSequenceFailingNoJumpdestTrivial() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendJumpi(EWord.of(68), EWord.of(1), program);
     appendStop(program);
@@ -344,7 +344,7 @@ public class OobJumpAndJumpiTest extends TracerTestBase {
 
   @Test
   void testJumpiSequenceFailingOobTrivial() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendJumpi(EWord.of(68), EWord.of(1), program);
     appendStop(program);
@@ -374,7 +374,7 @@ public class OobJumpAndJumpiTest extends TracerTestBase {
 
   @Test
   void testNoJumpi() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     appendJumpi(EWord.of(68), EWord.of(0), program); // jumpCondition is 0, that means no JUMPI
     appendStop(program);
@@ -393,7 +393,7 @@ public class OobJumpAndJumpiTest extends TracerTestBase {
 
   @Test
   void testJumpiHiNonZero() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     EWord jumpCondition = EWord.of(TWO_POW_128_MINUS_ONE, BigInteger.ZERO);
     appendJumpi(EWord.of(68), jumpCondition, program);
@@ -413,7 +413,7 @@ public class OobJumpAndJumpiTest extends TracerTestBase {
 
   @Test
   void testJumpiLoNonZero() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     EWord jumpCondition = EWord.of(BigInteger.valueOf(0), TWO_POW_128_MINUS_ONE);
     appendJumpi(EWord.of(68), jumpCondition, program);
@@ -433,7 +433,7 @@ public class OobJumpAndJumpiTest extends TracerTestBase {
 
   @Test
   void testJumpiHiLoNonZero() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     EWord jumpCondition = EWord.of(TWO_POW_128_MINUS_ONE, TWO_POW_128_MINUS_ONE);
     appendJumpi(EWord.of(68), jumpCondition, program);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobRdcTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobRdcTest.java
@@ -673,7 +673,7 @@ public class OobRdcTest extends TracerTestBase {
 
   // Support methods
   BytecodeCompiler initReturnDataCopyProgram(BigInteger offset, BigInteger size) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     // Creates a constructor that creates a contract which returns 32 FF
     program
@@ -720,7 +720,7 @@ public class OobRdcTest extends TracerTestBase {
 
   BytecodeCompiler initReturnDataCopyProgramUsingIdentityPrecompile(
       BigInteger offset, BigInteger size) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     // First place the parameters in memory
     program

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobSha2RipemdIdentityTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/oob/OobSha2RipemdIdentityTest.java
@@ -192,7 +192,7 @@ public class OobSha2RipemdIdentityTest extends TracerTestBase {
     int retSize = address == Address.ID ? argSize : 32;
     int retOffset = 0;
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     // MSTORE data if argSize > 0
     if (argSize > 0) {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlpaddr/TestRlpAddress.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlpaddr/TestRlpAddress.java
@@ -55,7 +55,8 @@ public class TestRlpAddress extends TracerTestBase {
             .address(senderAddress)
             .build();
 
-    final Bytes initCode = BytecodeCompiler.newProgram().push(1).push(1).op(OpCode.SLT).compile();
+    final Bytes initCode =
+        BytecodeCompiler.newProgram(testInfo).push(1).push(1).op(OpCode.SLT).compile();
 
     final Transaction tx =
         ToyTransaction.builder()
@@ -95,7 +96,7 @@ public class TestRlpAddress extends TracerTestBase {
             .nonce(10)
             .address(contractAddress)
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
 
                     // copy the entirety of the call data to RAM
                     .op(OpCode.CALLDATASIZE)
@@ -111,7 +112,7 @@ public class TestRlpAddress extends TracerTestBase {
             .build();
 
     final Bytes initCodeReturnContractCode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(contractAddress)
             .op(OpCode.EXTCODESIZE)
             .op(OpCode.DUP1)
@@ -162,7 +163,7 @@ public class TestRlpAddress extends TracerTestBase {
             .nonce(10)
             .address(contractAddress)
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     // copy the entirety of the call data to RAM
                     .op(OpCode.CALLDATASIZE)
                     .push(0)
@@ -176,7 +177,8 @@ public class TestRlpAddress extends TracerTestBase {
                     .compile())
             .build();
 
-    final BytecodeCompiler copyAndReturnSomeForeignContractsCode = BytecodeCompiler.newProgram();
+    final BytecodeCompiler copyAndReturnSomeForeignContractsCode =
+        BytecodeCompiler.newProgram(testInfo);
     fullCopyOfForeignByteCode(copyAndReturnSomeForeignContractsCode, contractAddress);
     appendReturn(copyAndReturnSomeForeignContractsCode, 0, 0);
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlpaddr/TestRlpAddress.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlpaddr/TestRlpAddress.java
@@ -68,11 +68,11 @@ public class TestRlpAddress extends TracerTestBase {
             .payload(initCode)
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount))
         .transaction(tx)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -134,12 +134,12 @@ public class TestRlpAddress extends TracerTestBase {
             .payload(initCodeReturnContractCode)
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, contractAccount))
         .transaction(tx)
         .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -190,12 +190,12 @@ public class TestRlpAddress extends TracerTestBase {
             .payload(copyAndReturnSomeForeignContractsCode.compile())
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, callDataDeployerAccount))
         .transaction(tx)
         .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   public static void fullCopyOfForeignByteCode(BytecodeCompiler program, Address foreignAddress) {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlptxn/RlptxnTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlptxn/RlptxnTests.java
@@ -84,7 +84,7 @@ public class RlptxnTests extends TracerTestBase {
         ToyAccount.builder()
             .address(Address.wrap(Bytes.random(Address.SIZE, SEED)))
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     .op(CALLDATASIZE)
                     .push(0)
                     .push(0)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlptxn/RlptxnTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlptxn/RlptxnTests.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.rlptxn;
 
-import static net.consensys.linea.zktracer.ChainConfig.MAINNET_LONDON_TESTCONFIG;
 import static net.consensys.linea.zktracer.Trace.WORD_SIZE;
 import static net.consensys.linea.zktracer.opcode.OpCode.*;
 import static net.consensys.linea.zktracer.types.Conversions.bigIntegerToBytes;
@@ -99,7 +98,7 @@ public class RlptxnTests extends TracerTestBase {
             .balance(Wei.ONE)
             .build();
 
-    final Transaction transaction =
+    var txBuilder =
         ToyTransaction.builder()
             .sender(senderAccount)
             .gasLimit(1000000L)
@@ -108,9 +107,9 @@ public class RlptxnTests extends TracerTestBase {
             .value(Wei.of(value))
             .to(isDeployment ? null : recipientAccount)
             .payload(payload)
-            .accessList(type == FRONTIER ? null : accessList)
-            .chainId(chainLess ? null : MAINNET_LONDON_TESTCONFIG.id)
-            .build();
+            .accessList(type == FRONTIER ? null : accessList);
+
+    final Transaction transaction = chainLess ? txBuilder.chainId(null).build() : txBuilder.build();
 
     ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, recipientAccount))

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlptxn/RlptxnTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlptxn/RlptxnTests.java
@@ -15,7 +15,7 @@
 
 package net.consensys.linea.zktracer.module.rlptxn;
 
-import static net.consensys.linea.testing.ToyExecutionEnvironmentV2.UNIT_TEST_CHAIN;
+import static net.consensys.linea.zktracer.ChainConfig.MAINNET_LONDON_TESTCONFIG;
 import static net.consensys.linea.zktracer.Trace.WORD_SIZE;
 import static net.consensys.linea.zktracer.opcode.OpCode.*;
 import static net.consensys.linea.zktracer.types.Conversions.bigIntegerToBytes;
@@ -109,15 +109,15 @@ public class RlptxnTests extends TracerTestBase {
             .to(isDeployment ? null : recipientAccount)
             .payload(payload)
             .accessList(type == FRONTIER ? null : accessList)
-            .chainId(chainLess ? null : UNIT_TEST_CHAIN.id)
+            .chainId(chainLess ? null : MAINNET_LONDON_TESTCONFIG.id)
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, recipientAccount))
         .transaction(transaction)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 
   private Stream<Arguments> rlpInputs() {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rom/RomTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rom/RomTest.java
@@ -37,7 +37,7 @@ public class RomTest extends TracerTestBase {
   @ParameterizedTest
   @MethodSource("incompletePushRomTestSource")
   void incompletePushRomTest(int j, int k) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     program.incompletePush(k, "ff".repeat(j));
     BytecodeRunner.of(program.compile()).run(testInfo);
   }
@@ -62,7 +62,7 @@ public class RomTest extends TracerTestBase {
     }
     Collections.shuffle(permutationOfKAndJPairs);
 
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     for (Pair<Integer, Integer> kAndJPair : permutationOfKAndJPairs) {
       int k = kAndJPair.getFirst();
       int j = kAndJPair.getSecond();

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/romlex/FirstCfiAccountIsZeroTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/romlex/FirstCfiAccountIsZeroTests.java
@@ -69,13 +69,13 @@ public class FirstCfiAccountIsZeroTests extends TracerTestBase {
             .build();
 
     final ToyExecutionEnvironmentV2 test =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(senderAccount, recipientAccount))
             .transaction(tx)
             .zkTracerValidator(zkTracer -> {})
             .build();
 
-    test.run(testInfo);
+    test.run();
 
     checkArgument(test.getHub().romLex().lineCount() == 1);
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/romlex/FirstCfiAccountIsZeroTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/romlex/FirstCfiAccountIsZeroTests.java
@@ -49,7 +49,7 @@ public class FirstCfiAccountIsZeroTests extends TracerTestBase {
 
     // we don't care about the bytecode, we just need a contract with address 0
     final Bytes bytecode =
-        BytecodeCompiler.newProgram().push(256).push(255).op(OpCode.SAR).compile();
+        BytecodeCompiler.newProgram(testInfo).push(256).push(255).op(OpCode.SAR).compile();
 
     final ToyAccount recipientAccount =
         ToyAccount.builder()

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/romlex/NoCFIDuplicateTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/romlex/NoCFIDuplicateTests.java
@@ -49,7 +49,7 @@ public class NoCFIDuplicateTests extends TracerTestBase {
         ToyAccount.builder().balance(Wei.fromEth(0xffff)).nonce(128).address(senderAddress).build();
 
     final Bytes bytecode =
-        BytecodeCompiler.newProgram().push(256).push(255).op(OpCode.SLT).compile();
+        BytecodeCompiler.newProgram(testInfo).push(256).push(255).op(OpCode.SLT).compile();
 
     final ToyAccount recipientAccount =
         ToyAccount.builder()

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/romlex/NoCFIDuplicateTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/romlex/NoCFIDuplicateTests.java
@@ -79,13 +79,13 @@ public class NoCFIDuplicateTests extends TracerTestBase {
             .build();
 
     final ToyExecutionEnvironmentV2 test =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(senderAccount, recipientAccount))
             .transactions(List.of(tx1, tx2))
             .zkTracerValidator(zkTracer -> {})
             .build();
 
-    test.run(testInfo);
+    test.run();
 
     checkArgument(test.getHub().romLex().lineCount() == 1);
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/romlex/SeveralAccountCreationTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/romlex/SeveralAccountCreationTests.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 public class SeveralAccountCreationTests extends TracerTestBase {
 
   private static final Bytes INIT_CODE =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .push(Bytes.fromHexString("0x703eda7a")) // value
           .push(Bytes32.repeat((byte) 12)) // key
           .op(OpCode.SSTORE)
@@ -48,7 +48,7 @@ public class SeveralAccountCreationTests extends TracerTestBase {
           .compile();
 
   private static final Bytes CREATE2_INITCODE_IS_CALLDATA =
-      BytecodeCompiler.newProgram()
+      BytecodeCompiler.newProgram(testInfo)
           .immediate(POPULATE_MEMORY)
           .push(Bytes32.leftPad(Bytes.fromHexString("0x7a17"))) // salt
           .op(OpCode.MSIZE) // size

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/romlex/SeveralAccountCreationTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/romlex/SeveralAccountCreationTests.java
@@ -104,11 +104,11 @@ public class SeveralAccountCreationTests extends TracerTestBase {
             .nonce(senderAccount.getNonce() + 1)
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, create2Account, create2AndRevertAccount))
         .transactions(List.of(tx1, tx2))
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -142,10 +142,10 @@ public class SeveralAccountCreationTests extends TracerTestBase {
             .to(recipientAccout)
             .build();
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(List.of(senderAccount, recipientAccout, create2Account, create2AndRevertAccount))
         .transaction(tx)
         .build()
-        .run(testInfo);
+        .run();
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/shakira/ShakiraInputsExtensiveTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/shakira/ShakiraInputsExtensiveTests.java
@@ -65,7 +65,7 @@ public class ShakiraInputsExtensiveTests extends TracerTestBase {
   void shakiraInputTesting(final int size, final int offset, final OpCode instruction) {
     final BytecodeRunner bytecodeRunner =
         BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .op(CALLDATASIZE)
                 .push(0)
                 .push(0)
@@ -96,7 +96,7 @@ public class ShakiraInputsExtensiveTests extends TracerTestBase {
     switch (instruction) {
       case CALL, CALLCODE:
         {
-          return BytecodeCompiler.newProgram()
+          return BytecodeCompiler.newProgram(testInfo)
               .push(SEED.nextInt(WORD_SIZE))
               .push(0)
               .push(size)
@@ -109,7 +109,7 @@ public class ShakiraInputsExtensiveTests extends TracerTestBase {
         }
       case STATICCALL, DELEGATECALL:
         {
-          return BytecodeCompiler.newProgram()
+          return BytecodeCompiler.newProgram(testInfo)
               .push(SEED.nextInt(WORD_SIZE))
               .push(0)
               .push(size)
@@ -121,11 +121,11 @@ public class ShakiraInputsExtensiveTests extends TracerTestBase {
         }
       case SHA3:
         {
-          return BytecodeCompiler.newProgram().push(size).push(offset).op(SHA3).compile();
+          return BytecodeCompiler.newProgram(testInfo).push(size).push(offset).op(SHA3).compile();
         }
       case RETURN:
         {
-          return BytecodeCompiler.newProgram()
+          return BytecodeCompiler.newProgram(testInfo)
               .push(
                   rightPadTo(
                       Bytes.concatenate(
@@ -161,7 +161,7 @@ public class ShakiraInputsExtensiveTests extends TracerTestBase {
         }
       case CREATE2:
         {
-          return BytecodeCompiler.newProgram()
+          return BytecodeCompiler.newProgram(testInfo)
               .push(Bytes32.random(SEED))
               .push(size)
               .push(offset)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/shf/ShfExtensiveTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/shf/ShfExtensiveTest.java
@@ -132,7 +132,7 @@ public class ShfExtensiveTest extends TracerTestBase {
   //  Creates a program that concatenates shifts operations (with different relevant shift values)
   //  for a given value and opcode
   private BytecodeRunner shfProgramOf(String value, OpCode opCode) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     for (String shift : SHIFTS) {
       program.push(value).push(shift).op(opCode);
     }
@@ -166,7 +166,8 @@ public class ShfExtensiveTest extends TracerTestBase {
   @ParameterizedTest
   @MethodSource("shfExtensiveTestSource")
   void shfExtensiveTest(String shift, String value, OpCode opCode) {
-    BytecodeRunner.of(BytecodeCompiler.newProgram().push(value).push(shift).op(opCode).compile())
+    BytecodeRunner.of(
+            BytecodeCompiler.newProgram(testInfo).push(value).push(shift).op(opCode).compile())
         .run(testInfo);
   }
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/shf/ShfRtTracerTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/shf/ShfRtTracerTest.java
@@ -39,7 +39,7 @@ class ShfRtTracerTest extends TracerTestBase {
   @MethodSource("provideShiftOperators")
   void testFailingBlockchainBlock(final int opCodeValue) {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(Bytes32.rightPad(Bytes.fromHexString("0x08")))
                 .push(Bytes32.fromHexString("0x01"))
                 .immediate(opCodeValue)
@@ -62,7 +62,7 @@ class ShfRtTracerTest extends TracerTestBase {
         "value: " + payload[0].toShortHexString() + ", shift by: " + payload[1].toShortHexString());
 
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(payload[1])
                 .push(payload[0])
                 .op(OpCode.SAR)
@@ -73,7 +73,7 @@ class ShfRtTracerTest extends TracerTestBase {
   @Test
   void testTmp() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .immediate(Bytes32.fromHexStringLenient("0x54fda4f3c1452c8c58df4fb1e9d6de"))
                 .immediate(Bytes32.fromHexStringLenient("0xb5"))
                 .op(OpCode.SAR)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/stp/StpTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/stp/StpTest.java
@@ -74,12 +74,12 @@ public class StpTest extends TracerTestBase {
           txCall(opcode, toExists, toWarm, balance, value, gasCall, gasLimit, accounts));
     }
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(accounts)
         .transactions(transactions)
         .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   @Test
@@ -97,12 +97,12 @@ public class StpTest extends TracerTestBase {
       }
     }
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(world)
         .transactions(txList)
         .transactionProcessingResultValidator(TransactionProcessingResultValidator.EMPTY_VALIDATOR)
         .build()
-        .run(testInfo);
+        .run();
   }
 
   OpCode randOpCodeCall() {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/stp/StpTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/stp/StpTest.java
@@ -179,7 +179,7 @@ public class StpTest extends TracerTestBase {
 
   private Bytes codeCall(OpCode opcode, Address calleeAddress, BigInteger value, long gasCall) {
     return switch (opcode) {
-      case CALL, CALLCODE -> BytecodeCompiler.newProgram()
+      case CALL, CALLCODE -> BytecodeCompiler.newProgram(testInfo)
           .push(Bytes.minimalBytes(6)) // retLength
           .push(Bytes.minimalBytes(5)) // terOffset
           .push(Bytes.minimalBytes(4)) // argsLength
@@ -189,7 +189,7 @@ public class StpTest extends TracerTestBase {
           .push(longToBytes(gasCall)) // gas
           .op(opcode)
           .compile();
-      case DELEGATECALL, STATICCALL -> BytecodeCompiler.newProgram()
+      case DELEGATECALL, STATICCALL -> BytecodeCompiler.newProgram(testInfo)
           .push(Bytes.minimalBytes(5)) // retLength
           .push(Bytes.minimalBytes(4)) // terOffset
           .push(Bytes.minimalBytes(3)) // argsLength
@@ -225,7 +225,7 @@ public class StpTest extends TracerTestBase {
             .balance(Wei.ONE)
             .address(to)
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     .push(Bytes.fromHexString("0xff")) // length
                     .push(Bytes.fromHexString("0x80")) // offset
                     .push(Bytes.minimalBytes(value)) // value
@@ -267,7 +267,7 @@ public class StpTest extends TracerTestBase {
             .balance(Wei.ONE)
             .address(to)
             .code(
-                BytecodeCompiler.newProgram()
+                BytecodeCompiler.newProgram(testInfo)
                     .push(Bytes.random(32)) // salt
                     .push(Bytes.fromHexString("0xff")) // length
                     .push(Bytes.fromHexString("0x80")) // offset

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/trm/TrmTracerTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/trm/TrmTracerTest.java
@@ -129,13 +129,14 @@ public class TrmTracerTest extends TracerTestBase {
   }
 
   void nonCall(Bytes bytes) {
-    BytecodeRunner.of(BytecodeCompiler.newProgram().push(bytes).op(OpCode.EXTCODEHASH).compile())
+    BytecodeRunner.of(
+            BytecodeCompiler.newProgram(testInfo).push(bytes).op(OpCode.EXTCODEHASH).compile())
         .run(testInfo);
   }
 
   @Test
   void testTrimToUncoverATinyAddressAndQueryItsBalanceCodeHashAndCodeSize() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     List<OpCode> opCodeList = List.of(OpCode.BALANCE, OpCode.EXTCODESIZE, OpCode.EXTCODEHASH);
 
@@ -160,7 +161,7 @@ public class TrmTracerTest extends TracerTestBase {
 
   void sevenArgCall(long rawAddr) {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(Bytes.fromHexString("0xff")) // rds
                 .push(Bytes.fromHexString("0x80")) // rdo
                 .push(Bytes.fromHexString("0x44")) // cds
@@ -175,7 +176,7 @@ public class TrmTracerTest extends TracerTestBase {
 
   void sampleDelegateCall(long rawAddr) {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(Bytes.fromHexString("0xff")) // rds
                 .push(Bytes.fromHexString("0x80")) // rdo
                 .push(Bytes.fromHexString("0x44")) // cds

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/wcp/WcpEdgeCaseTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/wcp/WcpEdgeCaseTest.java
@@ -29,7 +29,7 @@ public class WcpEdgeCaseTest extends TracerTestBase {
   @Test
   void testZeroAndHugeArgs() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(Bytes.repeat((byte) 0xff, 32))
                 .push(Bytes.EMPTY)
                 .op(OpCode.SLT)
@@ -40,7 +40,7 @@ public class WcpEdgeCaseTest extends TracerTestBase {
   @Test
   void testHugeAndZeroArgs() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(Bytes.EMPTY)
                 .push(Bytes.repeat((byte) 0xff, 32))
                 .op(OpCode.SLT)
@@ -51,7 +51,7 @@ public class WcpEdgeCaseTest extends TracerTestBase {
   @Test
   void failingOnShadowNodeBlock916394() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(Bytes.EMPTY)
                 .push(
                     Bytes.concatenate(
@@ -67,7 +67,7 @@ public class WcpEdgeCaseTest extends TracerTestBase {
   @Test
   void failingOnShadowNodeBlockWhatever() {
     BytecodeRunner.of(
-            BytecodeCompiler.newProgram()
+            BytecodeCompiler.newProgram(testInfo)
                 .push(Bytes.EMPTY)
                 .push(
                     Bytes.fromHexString(

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/BlakeTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/BlakeTests.java
@@ -30,7 +30,7 @@ public class BlakeTests extends TracerTestBase {
   @Test
   void emptyBlakeTest() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(0)
             .push(0)
             .push(0)
@@ -55,7 +55,7 @@ public class BlakeTests extends TracerTestBase {
     final int round = 10;
 
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(Bytes.fromHexString("0x0badb077")) // value, some random data to hash
             .push(5) // offset
             .op(OpCode.MSTORE)
@@ -88,7 +88,7 @@ public class BlakeTests extends TracerTestBase {
   @Test
   void wrongFInputTest() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(Bytes.fromHexString("0x0badb077")) // value, some random data to hash
             .push(5) // offset
             .op(OpCode.MSTORE)
@@ -117,7 +117,7 @@ public class BlakeTests extends TracerTestBase {
   @Test
   void notEnoughGasBlakeTest() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(Bytes.fromHexString("0x0badb077")) // value, some random data to hash
             .push(5) // offset
             .op(OpCode.MSTORE)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/EcrecoverTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/EcrecoverTests.java
@@ -31,7 +31,7 @@ public class EcrecoverTests extends TracerTestBase {
   @Test
   void basicEcrecoverTest() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(0)
             .push(0)
             .push(0)
@@ -52,7 +52,7 @@ public class EcrecoverTests extends TracerTestBase {
   @Test
   void insufficientGasEcrecoverTest() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(0)
             .push(0)
             .push(0)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/LowGasStipendPrecompileCallTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/LowGasStipendPrecompileCallTests.java
@@ -115,7 +115,7 @@ public class LowGasStipendPrecompileCallTests extends TracerTestBase {
       ValueCase valueCase,
       GasCase gasCase,
       boolean modexpCostGT200OrBlake2fRoundsGT0) {
-    final BytecodeCompiler program = BytecodeCompiler.newProgram();
+    final BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     // In order to actually trigger the insufficient we need to:
     // - Set a specific callDataSize for BLAKE2F and EC_PAIRING

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/ModexpTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/ModexpTests.java
@@ -294,12 +294,12 @@ public class ModexpTests extends TracerTestBase {
 
     List<ToyAccount> accounts = List.of(userAccount, recipientAccount);
 
-    ToyExecutionEnvironmentV2.builder()
+    ToyExecutionEnvironmentV2.builder(testInfo)
         .accounts(accounts)
         .transactions(transactions)
         .zkTracerValidator(zkTracer -> {})
         .build()
-        .run(testInfo);
+        .run();
   }
 
   void appendAllZeroCallDataModexpCalls(BytecodeCompiler program, int callDataSize) {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/ModexpTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/ModexpTests.java
@@ -56,7 +56,7 @@ public class ModexpTests extends TracerTestBase {
   @Test
   void basicModexpTest() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(0)
             .push(0)
             .push(0)
@@ -81,7 +81,7 @@ public class ModexpTests extends TracerTestBase {
     final int exp = 5;
     final int mod = 7;
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(1)
             .push(BBS_MIN_OFFSET)
             .op(OpCode.MSTORE)
@@ -220,7 +220,7 @@ public class ModexpTests extends TracerTestBase {
     int baseOffset = 64 + bbs;
     int expnOffset = 64 + bbs + ebs;
     int modlOffset = 64 + bbs + ebs + mbs;
-    return BytecodeCompiler.newProgram()
+    return BytecodeCompiler.newProgram(testInfo)
         .push(byteSize(hexBase))
         .push("00")
         .op(OpCode.MSTORE) // this sets bbs = 4
@@ -245,7 +245,7 @@ public class ModexpTests extends TracerTestBase {
 
   @Test
   void variationsOnEmptyCalls() {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
 
     List<Integer> callDataSizeList = List.of(0, 1, 31, 32, 33, 63, 64, 65, 95, 96, 97, 128);
     for (int callDataSize : callDataSizeList) {
@@ -318,7 +318,7 @@ public class ModexpTests extends TracerTestBase {
   // We trigger a ModexpData MMU Call where the sourceOffset = referenceSize for the MmuCall
   void referenceSizeEqualsSourceOffset() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             // bbs = 2
             .push(Bytes32.leftPad(Bytes.of(2)))
             .push(0) // offset
@@ -353,7 +353,7 @@ public class ModexpTests extends TracerTestBase {
   // This test a modexp call with bbs > 512
   void unprovableModexp() {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             // bbs = 513
             .push(Bytes32.leftPad(Bytes.minimalBytes(513)))
             .push(0) // offset

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/PrecompileUtils.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/PrecompileUtils.java
@@ -144,7 +144,7 @@ public class PrecompileUtils extends TracerTestBase {
   }
 
   public static Bytes prepareBlake2F(int rLeadingByte, int offset) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     prepareBlake2F(program, rLeadingByte, offset);
     return program.compile();
   }
@@ -155,7 +155,7 @@ public class PrecompileUtils extends TracerTestBase {
   }
 
   static Bytes prepareSha256Ripemd160Id(int nWords, int offset) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     prepareSha256Ripemd160Id(program, nWords, offset);
     return program.compile();
   }
@@ -183,7 +183,7 @@ public class PrecompileUtils extends TracerTestBase {
   }
 
   public static Bytes prepareModexp(Bytes modexpInput, int targetOffset, Address codeOwnerAddress) {
-    BytecodeCompiler program = BytecodeCompiler.newProgram();
+    BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     prepareModexp(program, modexpInput, targetOffset, codeOwnerAddress);
     return program.compile();
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/RipTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/RipTests.java
@@ -39,7 +39,7 @@ public class RipTests extends TracerTestBase {
   @MethodSource("sizes")
   void basicRipTest(int size) {
     final Bytes bytecode =
-        BytecodeCompiler.newProgram()
+        BytecodeCompiler.newProgram(testInfo)
             .push(Bytes.fromHexString("0x0badb077")) // value, some random data to hash
             .push(5) // offset
             .op(OpCode.MSTORE)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/BlockwiseAccountTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/BlockwiseAccountTest.java
@@ -50,7 +50,7 @@ public class BlockwiseAccountTest extends TracerTestBase {
 
     // prepare a multi-block execution of transactions
     final MultiBlockExecutionEnvironment multiBlockEnv =
-        MultiBlockExecutionEnvironment.builder()
+        MultiBlockExecutionEnvironment.builder(testInfo)
             // initialize accounts
             .accounts(
                 List.of(

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/BlockwiseDeplNoTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/BlockwiseDeplNoTest.java
@@ -51,7 +51,7 @@ public class BlockwiseDeplNoTest extends TracerTestBase {
 
     // prepare a multi-block execution of transactions
     final MultiBlockExecutionEnvironment multiBlockEnv =
-        MultiBlockExecutionEnvironment.builder()
+        MultiBlockExecutionEnvironment.builder(testInfo)
             // initialize accounts
             .accounts(
                 List.of(

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/BlockwiseStorageTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/BlockwiseStorageTest.java
@@ -62,7 +62,7 @@ public class BlockwiseStorageTest extends TracerTestBase {
 
     // prepare a multi-block execution of transactions
     final MultiBlockExecutionEnvironment multiBlockEnv =
-        MultiBlockExecutionEnvironment.builder()
+        MultiBlockExecutionEnvironment.builder(testInfo)
             // initialize accounts
             .accounts(
                 List.of(

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/ConflationAccountTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/ConflationAccountTest.java
@@ -49,7 +49,7 @@ public class ConflationAccountTest extends TracerTestBase {
 
     // prepare a multi-block execution of transactions
     final MultiBlockExecutionEnvironment multiBlockEnv =
-        MultiBlockExecutionEnvironment.builder()
+        MultiBlockExecutionEnvironment.builder(testInfo)
             // initialize accounts
             .accounts(
                 List.of(

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/ConflationStorageTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/ConflationStorageTest.java
@@ -49,7 +49,7 @@ public class ConflationStorageTest extends TracerTestBase {
 
     // prepare a multi-block execution of transactions
     final MultiBlockExecutionEnvironment multiBlockEnv =
-        MultiBlockExecutionEnvironment.builder()
+        MultiBlockExecutionEnvironment.builder(testInfo)
             // initialize accounts
             .accounts(
                 List.of(

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/HubShomeiTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/HubShomeiTests.java
@@ -52,11 +52,11 @@ public class HubShomeiTests extends TracerTestBase {
   private static final Address DEFAULT =
       Address.fromHexString("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
 
-  private static final Bytes SSLOAD1 =
-      newProgram().push(key1).op(OpCode.SLOAD).op(OpCode.POP).compile();
+  private final Bytes SSLOAD1 =
+      newProgram(testInfo).push(key1).op(OpCode.SLOAD).op(OpCode.POP).compile();
 
-  private static final Bytes SSTORE1 =
-      newProgram().push(value).push(key1).op(OpCode.SSTORE).compile();
+  private final Bytes SSTORE1 =
+      newProgram(testInfo).push(value).push(key1).op(OpCode.SSTORE).compile();
 
   /**
    * In this test we have two transactions. In the first one we prewarm a storage key, we SSTORE or
@@ -110,7 +110,7 @@ public class HubShomeiTests extends TracerTestBase {
             .gasLimit(1000000L)
             .gasPrice(Wei.of(10L))
             .accessList(List.of(accessListEntry))
-            .payload(newProgram().push(1).push(1).op(OpCode.ADD).compile())
+            .payload(newProgram(testInfo).push(1).push(1).op(OpCode.ADD).compile())
             .build();
 
     final ToyExecutionEnvironmentV2 executionEnvironmentV2 =

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/HubShomeiTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/HubShomeiTests.java
@@ -114,12 +114,12 @@ public class HubShomeiTests extends TracerTestBase {
             .build();
 
     final ToyExecutionEnvironmentV2 executionEnvironmentV2 =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(senderAccount, recipientAccount))
             .transactions(List.of(tx1, tx2))
             .build();
 
-    executionEnvironmentV2.run(testInfo);
+    executionEnvironmentV2.run();
 
     final ZkTracer tracer = executionEnvironmentV2.getZkTracer();
     final Set<Address> addressSeen = tracer.getAddressesSeenByHubForRelativeBlock(1);
@@ -171,11 +171,11 @@ public class HubShomeiTests extends TracerTestBase {
             .build();
 
     final ToyExecutionEnvironmentV2 executionEnvironmentV2 =
-        ToyExecutionEnvironmentV2.builder()
+        ToyExecutionEnvironmentV2.builder(testInfo)
             .accounts(List.of(senderAccount, recipientAccount))
             .transaction(tx)
             .build();
-    executionEnvironmentV2.run(testInfo);
+    executionEnvironmentV2.run();
 
     final ZkTracer tracer = executionEnvironmentV2.getZkTracer();
     final Set<Address> addressSeen = tracer.getAddressesSeenByHubForRelativeBlock(1);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/TransactionAccountTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/TransactionAccountTest.java
@@ -54,7 +54,7 @@ public class TransactionAccountTest extends TracerTestBase {
 
     // prepare a multi-block execution of transactions
     final MultiBlockExecutionEnvironment multiBlockEnv =
-        MultiBlockExecutionEnvironment.builder()
+        MultiBlockExecutionEnvironment.builder(testInfo)
             // initialize accounts
             .accounts(
                 List.of(

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/TransactionStorageTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/TransactionStorageTest.java
@@ -52,7 +52,7 @@ public class TransactionStorageTest extends TracerTestBase {
 
     // prepare a multi-block execution of transactions
     final MultiBlockExecutionEnvironment multiBlockEnv =
-        MultiBlockExecutionEnvironment.builder()
+        MultiBlockExecutionEnvironment.builder(testInfo)
             // initialize accounts
             .accounts(
                 List.of(

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/UtilitiesTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/UtilitiesTest.java
@@ -38,7 +38,7 @@ public class UtilitiesTest extends TracerTestBase {
             // Transfers generate 3 logs, the 1s are for reverted operations
             List.of(2, 2, 3, 2, 2));
 
-    MultiBlockExecutionEnvironment.builder()
+    MultiBlockExecutionEnvironment.builder(testInfo)
         .accounts(
             List.of(
                 tc.initialAccounts[0],
@@ -110,7 +110,7 @@ public class UtilitiesTest extends TracerTestBase {
     this.tc.initializeTestContext();
     TransactionProcessingResultValidator resultValidator =
         new StateManagerTestValidator(tc.frameworkEntryPointAccount, List.of(2));
-    MultiBlockExecutionEnvironment.builder()
+    MultiBlockExecutionEnvironment.builder(testInfo)
         .accounts(
             List.of(
                 tc.initialAccounts[0],

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -148,9 +148,9 @@ tasks.test.configure {
   systemProperty("besu.traces.dir", System.getProperty("besu.traces.dir"))
   systemProperty("besu.plugins.dir", System.getProperty("besu.plugins.dir"))
 
-  def fork = System.getenv().getOrDefault("UNIT_TESTS_FORK", "LONDON").toString()
-  System.setProperty("unit.tests.fork", fork)
-  systemProperty("unit.tests.fork", fork)
+  def fork = System.getenv().getOrDefault("UNIT_REPLAY_TESTS_FORK", "LONDON").toString()
+  System.setProperty("unit.replay.tests.fork", fork)
+  systemProperty("unit.replay.tests.fork", fork)
 
   systemProperty("junit.jupiter.execution.parallel.enabled", true)
   systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
@@ -224,6 +224,11 @@ tasks.register("fastReplayTests", Test) {
     systemProperty("junit.jupiter.execution.parallel.config.fixed.parallelism",
       System.getenv().getOrDefault("REPLAY_TESTS_PARALLELISM", "1").toInteger())
   }
+
+  def fork = System.getenv().getOrDefault("UNIT_REPLAY_TESTS_FORK", "LONDON").toString()
+  System.setProperty("unit.replay.tests.fork", fork)
+  systemProperty("unit.replay.tests.fork", fork)
+
   useJUnitPlatform {
     includeTags("replay")
     excludeTags("nightly")

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -148,6 +148,9 @@ tasks.test.configure {
   systemProperty("besu.traces.dir", System.getProperty("besu.traces.dir"))
   systemProperty("besu.plugins.dir", System.getProperty("besu.plugins.dir"))
 
+  def fork = System.getenv().getOrDefault("UNIT_TESTS_FORK", "LONDON").toString()
+  System.setProperty("unit.tests.fork", fork)
+  systemProperty("unit.tests.fork", fork)
 
   systemProperty("junit.jupiter.execution.parallel.enabled", true)
   systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -148,7 +148,7 @@ tasks.test.configure {
   systemProperty("besu.traces.dir", System.getProperty("besu.traces.dir"))
   systemProperty("besu.plugins.dir", System.getProperty("besu.plugins.dir"))
 
-  def fork = System.getenv().getOrDefault("UNIT_REPLAY_TESTS_FORK", "LONDON").toString()
+  def fork = System.getenv().getOrDefault("ZKEVM_FORK", "LONDON").toString()
   System.setProperty("unit.replay.tests.fork", fork)
   systemProperty("unit.replay.tests.fork", fork)
 
@@ -225,7 +225,7 @@ tasks.register("fastReplayTests", Test) {
       System.getenv().getOrDefault("REPLAY_TESTS_PARALLELISM", "1").toInteger())
   }
 
-  def fork = System.getenv().getOrDefault("UNIT_REPLAY_TESTS_FORK", "LONDON").toString()
+  def fork = System.getenv().getOrDefault("ZKEVM_FORK", "LONDON").toString()
   System.setProperty("unit.replay.tests.fork", fork)
   systemProperty("unit.replay.tests.fork", fork)
 

--- a/testing/src/main/java/net/consensys/linea/reporting/TestInfoWithChainConfig.java
+++ b/testing/src/main/java/net/consensys/linea/reporting/TestInfoWithChainConfig.java
@@ -1,0 +1,9 @@
+package net.consensys.linea.reporting;
+
+import net.consensys.linea.zktracer.ChainConfig;
+import org.junit.jupiter.api.TestInfo;
+
+public class TestInfoWithChainConfig {
+  public TestInfo testInfo;
+  public ChainConfig chainConfig;
+}

--- a/testing/src/main/java/net/consensys/linea/reporting/TestInfoWithChainConfig.java
+++ b/testing/src/main/java/net/consensys/linea/reporting/TestInfoWithChainConfig.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package net.consensys.linea.reporting;
 
 import net.consensys.linea.zktracer.ChainConfig;

--- a/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
+++ b/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
@@ -27,14 +27,14 @@ public class TracerTestBase {
   @BeforeEach
   public void init(TestInfo testInfo) {
       TracerTestBase.testInfo.chainConfig =
-            switch (System.getProperty("unit.tests.fork")) {
+            switch (System.getProperty("unit.replay.tests.fork")) {
               case "LONDON" -> ChainConfig.MAINNET_TESTCONFIG(Fork.LONDON);
               case "PARIS" -> ChainConfig.MAINNET_TESTCONFIG(Fork.PARIS);
               case "SHANGHAI" -> ChainConfig.MAINNET_TESTCONFIG(Fork.SHANGHAI);
               case "CANCUN" -> ChainConfig.MAINNET_TESTCONFIG(Fork.CANCUN);
               case "PRAGUE" -> ChainConfig.MAINNET_TESTCONFIG(Fork.PRAGUE);
               default -> throw new IllegalArgumentException(
-                  "Unknown fork: " + System.getProperty("unit.tests.fork"));
+                  "Unknown fork: " + System.getProperty("unit.replay.tests.fork"));
             };
     TracerTestBase.testInfo.testInfo = testInfo;
   }

--- a/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
+++ b/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
@@ -14,14 +14,28 @@
  */
 package net.consensys.linea.reporting;
 
+import net.consensys.linea.zktracer.ChainConfig;
+import net.consensys.linea.zktracer.Fork;
+import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 
 public class TracerTestBase {
-  public TestInfo testInfo;
+  public static TestInfoWithChainConfig testInfo = new TestInfoWithChainConfig();
+  public Address add;
 
   @BeforeEach
   public void init(TestInfo testInfo) {
-    this.testInfo = testInfo;
+      TracerTestBase.testInfo.chainConfig =
+            switch (System.getProperty("unit.tests.fork")) {
+              case "LONDON" -> ChainConfig.MAINNET_TESTCONFIG(Fork.LONDON);
+              case "PARIS" -> ChainConfig.MAINNET_TESTCONFIG(Fork.PARIS);
+              case "SHANGHAI" -> ChainConfig.MAINNET_TESTCONFIG(Fork.SHANGHAI);
+              case "CANCUN" -> ChainConfig.MAINNET_TESTCONFIG(Fork.CANCUN);
+              case "PRAGUE" -> ChainConfig.MAINNET_TESTCONFIG(Fork.PRAGUE);
+              default -> throw new IllegalArgumentException(
+                  "Unknown fork: " + System.getProperty("unit.tests.fork"));
+            };
+    TracerTestBase.testInfo.testInfo = testInfo;
   }
 }

--- a/testing/src/main/java/net/consensys/linea/testing/BytecodeCompiler.java
+++ b/testing/src/main/java/net/consensys/linea/testing/BytecodeCompiler.java
@@ -26,6 +26,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
@@ -44,9 +45,29 @@ public class BytecodeCompiler {
    *
    * @return an instance of {@link BytecodeCompiler}
    */
-  public static BytecodeCompiler newProgram() {
-    loadOpcodes(Fork.LONDON);
-    return new BytecodeCompiler();
+  public static BytecodeCompiler newProgram(TestInfoWithChainConfig testInfo) {
+    return switch (testInfo.chainConfig.fork) {
+      case Fork.LONDON -> {
+        loadOpcodes(Fork.LONDON);
+        yield new BytecodeCompiler();
+      }
+      case PARIS -> {
+        loadOpcodes(Fork.PARIS);
+        yield new BytecodeCompiler();
+      }
+      case SHANGHAI -> {
+        loadOpcodes(Fork.SHANGHAI);
+        yield new BytecodeCompiler();
+      }
+      case CANCUN -> {
+        loadOpcodes(Fork.CANCUN);
+        yield new BytecodeCompiler();
+      }
+      case PRAGUE -> {
+        loadOpcodes(Fork.PRAGUE);
+        yield new BytecodeCompiler();
+      }
+    };
   }
 
   private static Bytes toBytes(final int x) {

--- a/testing/src/main/java/net/consensys/linea/testing/BytecodeCompiler.java
+++ b/testing/src/main/java/net/consensys/linea/testing/BytecodeCompiler.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.testing;
 
-import static net.consensys.linea.testing.ToyExecutionEnvironmentV2.UNIT_TEST_CHAIN;
 import static net.consensys.linea.zktracer.Trace.*;
 import static net.consensys.linea.zktracer.opcode.OpCodes.loadOpcodes;
 import static net.consensys.linea.zktracer.types.Conversions.bigIntegerToBytes;
@@ -27,6 +26,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -45,7 +45,7 @@ public class BytecodeCompiler {
    * @return an instance of {@link BytecodeCompiler}
    */
   public static BytecodeCompiler newProgram() {
-    loadOpcodes(UNIT_TEST_CHAIN.fork);
+    loadOpcodes(Fork.LONDON);
     return new BytecodeCompiler();
   }
 

--- a/testing/src/main/java/net/consensys/linea/testing/DynamicTests.java
+++ b/testing/src/main/java/net/consensys/linea/testing/DynamicTests.java
@@ -22,6 +22,7 @@ import java.util.Random;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.zktracer.container.module.Module;
 import net.consensys.linea.zktracer.module.add.Add;
 import net.consensys.linea.zktracer.module.ext.Ext;
@@ -33,7 +34,6 @@ import net.consensys.linea.zktracer.module.wcp.Wcp;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestInfo;
 
 /**
  * Responsible for executing JUnit 5 dynamic tests for modules with the ability to configure custom
@@ -98,7 +98,7 @@ public class DynamicTests {
    * @return a {@link Stream} of {@link DynamicTest} ran by a {@link
    *     org.junit.jupiter.api.TestFactory}
    */
-  public Stream<DynamicTest> run(TestInfo testInfo) {
+  public Stream<DynamicTest> run(TestInfoWithChainConfig testInfo) {
     return this.testCaseRegistry.stream()
         .flatMap(e -> generateTestCases(e.name(), e.arguments(), e.customAssertions(), testInfo));
   }
@@ -167,7 +167,7 @@ public class DynamicTests {
       final String testCaseName,
       final List<OpcodeCall> args,
       final BiConsumer<OpCode, List<Bytes32>> customAssertions,
-      TestInfo testInfo) {
+      TestInfoWithChainConfig testInfo) {
     return args.stream()
         .map(
             e -> {

--- a/testing/src/main/java/net/consensys/linea/testing/ModuleTests.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ModuleTests.java
@@ -33,7 +33,8 @@ public class ModuleTests {
    */
   public static void runTestWithOpCodeArgs(
       final OpCode opCode, final List<Bytes32> arguments, TestInfoWithChainConfig testInfo) {
-    Bytes bytecode = BytecodeCompiler.newProgram().opAnd32ByteArgs(opCode, arguments).compile();
+    Bytes bytecode =
+        BytecodeCompiler.newProgram(testInfo).opAnd32ByteArgs(opCode, arguments).compile();
 
     BytecodeRunner.of(bytecode).run(testInfo);
   }

--- a/testing/src/main/java/net/consensys/linea/testing/ModuleTests.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ModuleTests.java
@@ -17,10 +17,10 @@ package net.consensys.linea.testing;
 
 import java.util.List;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.TestInfo;
 
 /** Contains methods that execute module tests. */
 public class ModuleTests {
@@ -32,7 +32,7 @@ public class ModuleTests {
    * @param arguments args of the opcode for which the test should be run
    */
   public static void runTestWithOpCodeArgs(
-      final OpCode opCode, final List<Bytes32> arguments, TestInfo testInfo) {
+      final OpCode opCode, final List<Bytes32> arguments, TestInfoWithChainConfig testInfo) {
     Bytes bytecode = BytecodeCompiler.newProgram().opAnd32ByteArgs(opCode, arguments).compile();
 
     BytecodeRunner.of(bytecode).run(testInfo);

--- a/testing/src/main/java/net/consensys/linea/testing/MultiBlockExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/MultiBlockExecutionEnvironment.java
@@ -15,7 +15,8 @@
 
 package net.consensys.linea.testing;
 
-import static net.consensys.linea.zktracer.ChainConfig.MAINNET_LONDON_TESTCONFIG;
+import static net.consensys.linea.zktracer.ChainConfig.MAINNET_TESTCONFIG;
+import static net.consensys.linea.zktracer.Fork.LONDON;
 import static net.consensys.linea.zktracer.Trace.LINEA_BLOCK_GAS_LIMIT;
 
 import java.math.BigInteger;
@@ -28,11 +29,12 @@ import lombok.Builder;
 import lombok.Singular;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.blockcapture.snapshots.*;
-import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.zktracer.ChainConfig;
 import net.consensys.linea.zktracer.ZkTracer;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import org.hyperledger.besu.ethereum.core.*;
+import org.junit.jupiter.api.TestInfo;
 
 @Builder
 @Slf4j
@@ -43,10 +45,10 @@ public class MultiBlockExecutionEnvironment {
   private final List<BlockSnapshot> blocks;
 
   public static final BigInteger CHAIN_ID = BigInteger.valueOf(1337);
-  private final ZkTracer tracer =
-      new ZkTracer(
-          ChainConfig.LONDON_LINEA_CHAIN(
-              LineaL1L2BridgeSharedConfiguration.TEST_DEFAULT, CHAIN_ID));
+  private final ZkTracer tracer;
+
+  @Builder.Default public final ChainConfig testsChain = MAINNET_TESTCONFIG(LONDON);
+  public final TestInfo testInfo;
 
   /**
    * A transaction validator of each transaction; by default, it asserts that the transaction was
@@ -55,6 +57,14 @@ public class MultiBlockExecutionEnvironment {
   @Builder.Default
   private final TransactionProcessingResultValidator transactionProcessingResultValidator =
       TransactionProcessingResultValidator.DEFAULT_VALIDATOR;
+
+  public static MultiBlockExecutionEnvironment.MultiBlockExecutionEnvironmentBuilder builder(
+      TestInfoWithChainConfig testInfo) {
+    return new MultiBlockExecutionEnvironmentBuilder()
+        .tracer(new ZkTracer(testInfo.chainConfig))
+        .testsChain(testInfo.chainConfig)
+        .testInfo(testInfo.testInfo);
+  }
 
   public static class MultiBlockExecutionEnvironmentBuilder {
 
@@ -86,7 +96,7 @@ public class MultiBlockExecutionEnvironment {
         .useCoinbaseAddressFromBlockHeader(true)
         .transactionProcessingResultValidator(this.transactionProcessingResultValidator)
         .build()
-        .replay(MAINNET_LONDON_TESTCONFIG, this.buildConflationSnapshot());
+        .replay(testsChain, this.buildConflationSnapshot());
   }
 
   public Hub getHub() {

--- a/testing/src/main/java/net/consensys/linea/testing/MultiBlockExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/MultiBlockExecutionEnvironment.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.testing;
 
+import static net.consensys.linea.zktracer.ChainConfig.MAINNET_LONDON_TESTCONFIG;
 import static net.consensys.linea.zktracer.Trace.LINEA_BLOCK_GAS_LIMIT;
 
 import java.math.BigInteger;
@@ -85,7 +86,7 @@ public class MultiBlockExecutionEnvironment {
         .useCoinbaseAddressFromBlockHeader(true)
         .transactionProcessingResultValidator(this.transactionProcessingResultValidator)
         .build()
-        .replay(ToyExecutionEnvironmentV2.UNIT_TEST_CHAIN, this.buildConflationSnapshot());
+        .replay(MAINNET_LONDON_TESTCONFIG, this.buildConflationSnapshot());
   }
 
   public Hub getHub() {

--- a/testing/src/main/java/net/consensys/linea/testing/MultiBlockExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/MultiBlockExecutionEnvironment.java
@@ -34,7 +34,6 @@ import net.consensys.linea.zktracer.ChainConfig;
 import net.consensys.linea.zktracer.ZkTracer;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import org.hyperledger.besu.ethereum.core.*;
-import org.junit.jupiter.api.TestInfo;
 
 @Builder
 @Slf4j
@@ -48,7 +47,6 @@ public class MultiBlockExecutionEnvironment {
   private final ZkTracer tracer;
 
   @Builder.Default public final ChainConfig testsChain = MAINNET_TESTCONFIG(LONDON);
-  public final TestInfo testInfo;
 
   /**
    * A transaction validator of each transaction; by default, it asserts that the transaction was
@@ -62,8 +60,7 @@ public class MultiBlockExecutionEnvironment {
       TestInfoWithChainConfig testInfo) {
     return new MultiBlockExecutionEnvironmentBuilder()
         .tracer(new ZkTracer(testInfo.chainConfig))
-        .testsChain(testInfo.chainConfig)
-        .testInfo(testInfo.testInfo);
+        .testsChain(testInfo.chainConfig);
   }
 
   public static class MultiBlockExecutionEnvironmentBuilder {

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.TestInfo;
 @Builder
 @Slf4j
 public class ToyExecutionEnvironmentV2 {
-  // public final ChainConfig UNIT_TEST_CHAIN = MAINNET_TESTCONFIG(LONDON);
   @Builder.Default public final ChainConfig unitTestsChain = MAINNET_TESTCONFIG(LONDON);
   public final TestInfo testInfo;
   public static final Address DEFAULT_COINBASE_ADDRESS =

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
@@ -77,14 +77,15 @@ public class ToyExecutionEnvironmentV2 {
   @Builder.Default private final Consumer<ZkTracer> zkTracerValidator = x -> {};
 
   private ZkTracer tracer;
-    @Setter @Getter public ZkCounter zkCounter;
-    public static ToyExecutionEnvironmentV2.ToyExecutionEnvironmentV2Builder builder(
-            TestInfoWithChainConfig testInfo) {
-        return new ToyExecutionEnvironmentV2Builder()
-                .unitTestsChain(testInfo.chainConfig)
-                .testInfo(testInfo.testInfo)
-                .tracer(new ZkTracer(testInfo.chainConfig));
-    }
+  @Setter @Getter public ZkCounter zkCounter;
+
+  public static ToyExecutionEnvironmentV2.ToyExecutionEnvironmentV2Builder builder(
+      TestInfoWithChainConfig testInfo) {
+    return new ToyExecutionEnvironmentV2Builder()
+        .unitTestsChain(testInfo.chainConfig)
+        .testInfo(testInfo.testInfo)
+        .tracer(new ZkTracer(testInfo.chainConfig));
+  }
 
   public void run() {
     if (runWithBesuNode || System.getenv().containsKey("RUN_WITH_BESU_NODE")) {

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
@@ -29,6 +29,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.Singular;
 import lombok.extern.slf4j.Slf4j;
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.zktracer.ChainConfig;
 import net.consensys.linea.zktracer.ZkCounter;
 import net.consensys.linea.zktracer.ZkTracer;
@@ -44,7 +45,9 @@ import org.junit.jupiter.api.TestInfo;
 @Builder
 @Slf4j
 public class ToyExecutionEnvironmentV2 {
-  public static final ChainConfig UNIT_TEST_CHAIN = MAINNET_TESTCONFIG(LONDON);
+  // public final ChainConfig UNIT_TEST_CHAIN = MAINNET_TESTCONFIG(LONDON);
+  @Builder.Default public final ChainConfig unitTestsChain = MAINNET_TESTCONFIG(LONDON);
+  public final TestInfo testInfo;
   public static final Address DEFAULT_COINBASE_ADDRESS =
       Address.fromHexString("0xc019ba5e00000000c019ba5e00000000c019ba5e");
   public static final long DEFAULT_BLOCK_NUMBER = 6678980;
@@ -74,18 +77,24 @@ public class ToyExecutionEnvironmentV2 {
 
   @Builder.Default private final Consumer<ZkTracer> zkTracerValidator = x -> {};
 
-  private final ZkTracer tracer = new ZkTracer(UNIT_TEST_CHAIN);
+  private ZkTracer tracer;
+    @Setter @Getter public ZkCounter zkCounter;
+    public static ToyExecutionEnvironmentV2.ToyExecutionEnvironmentV2Builder builder(
+            TestInfoWithChainConfig testInfo) {
+        return new ToyExecutionEnvironmentV2Builder()
+                .unitTestsChain(testInfo.chainConfig)
+                .testInfo(testInfo.testInfo)
+                .tracer(new ZkTracer(testInfo.chainConfig));
+    }
 
-  @Setter @Getter public ZkCounter zkCounter;
-
-  public void run(TestInfo testInfo) {
+  public void run() {
     if (runWithBesuNode || System.getenv().containsKey("RUN_WITH_BESU_NODE")) {
       new BesuExecutionTools(
-              Optional.of(testInfo), UNIT_TEST_CHAIN, coinbase, accounts, transactions)
+              Optional.of(testInfo), unitTestsChain, coinbase, accounts, transactions)
           .executeTest();
     } else {
-      final ProtocolSpec protocolSpec =
-          ExecutionEnvironment.getProtocolSpec(UNIT_TEST_CHAIN.id, UNIT_TEST_CHAIN.fork);
+      ProtocolSpec protocolSpec =
+          ExecutionEnvironment.getProtocolSpec(unitTestsChain.id, unitTestsChain.fork);
       final GeneralStateTestCaseEipSpec generalStateTestCaseEipSpec =
           this.buildGeneralStateTestCaseSpec(protocolSpec);
       ToyExecutionTools.executeTest(
@@ -98,10 +107,10 @@ public class ToyExecutionEnvironmentV2 {
   }
 
   public void runForCounting() {
-    zkCounter = new ZkCounter(UNIT_TEST_CHAIN.bridgeConfiguration);
+    zkCounter = new ZkCounter(unitTestsChain.bridgeConfiguration);
 
     final ProtocolSpec protocolSpec =
-        ExecutionEnvironment.getProtocolSpec(UNIT_TEST_CHAIN.id, UNIT_TEST_CHAIN.fork);
+        ExecutionEnvironment.getProtocolSpec(unitTestsChain.id, unitTestsChain.fork);
     final GeneralStateTestCaseEipSpec generalStateTestCaseEipSpec =
         this.buildGeneralStateTestCaseSpec(protocolSpec);
     ToyExecutionTools.executeTest(
@@ -114,7 +123,7 @@ public class ToyExecutionEnvironmentV2 {
 
   public long runForGasCost() {
     final ProtocolSpec protocolSpec =
-        ExecutionEnvironment.getProtocolSpec(UNIT_TEST_CHAIN.id, UNIT_TEST_CHAIN.fork);
+        ExecutionEnvironment.getProtocolSpec(unitTestsChain.id, unitTestsChain.fork);
     final GeneralStateTestCaseEipSpec generalStateTestCaseEipSpec =
         this.buildGeneralStateTestCaseSpec(protocolSpec);
 

--- a/testing/src/main/java/net/consensys/linea/testing/ToyTransaction.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyTransaction.java
@@ -15,7 +15,7 @@
 
 package net.consensys.linea.testing;
 
-import static net.consensys.linea.zktracer.ChainConfig.MAINNET_LONDON_TESTCONFIG;
+import static net.consensys.linea.zktracer.Trace.LINEA_CHAIN_ID;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -79,7 +79,7 @@ public class ToyTransaction {
               .gasLimit(Optional.ofNullable(gasLimit).orElse(DEFAULT_GAS_LIMIT))
               .value(Optional.ofNullable(value).orElse(DEFAULT_VALUE))
               .payload(Optional.ofNullable(payload).orElse(DEFAULT_INPUT_DATA))
-              .chainId(Optional.ofNullable(chainId).orElse(MAINNET_LONDON_TESTCONFIG.id));
+              .chainId(Optional.ofNullable(chainId).orElse(BigInteger.valueOf(LINEA_CHAIN_ID)));
 
       if (transactionType == TransactionType.EIP1559) {
         builder.maxPriorityFeePerGas(

--- a/testing/src/main/java/net/consensys/linea/testing/ToyTransaction.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyTransaction.java
@@ -15,6 +15,8 @@
 
 package net.consensys.linea.testing;
 
+import static net.consensys.linea.zktracer.ChainConfig.MAINNET_LONDON_TESTCONFIG;
+
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
@@ -77,9 +79,7 @@ public class ToyTransaction {
               .gasLimit(Optional.ofNullable(gasLimit).orElse(DEFAULT_GAS_LIMIT))
               .value(Optional.ofNullable(value).orElse(DEFAULT_VALUE))
               .payload(Optional.ofNullable(payload).orElse(DEFAULT_INPUT_DATA))
-              .chainId(
-                  Optional.ofNullable(chainId)
-                      .orElse(ToyExecutionEnvironmentV2.UNIT_TEST_CHAIN.id));
+              .chainId(Optional.ofNullable(chainId).orElse(MAINNET_LONDON_TESTCONFIG.id));
 
       if (transactionType == TransactionType.EIP1559) {
         builder.maxPriorityFeePerGas(


### PR DESCRIPTION
A flow suggestion on how to run unit tests per fork 
- set an env variable `UNIT_REPLAY_TESTS_FORK`
- add a CI Action for Shanghai Unit tests that runs in // of current Unit London and Replay
- set a property `unit.replay.tests.fork` that copies the env variable or default to `LONDON` in gradle
- leverage `TracerTestBase` class setup by Gaurav and from which all tests inherit
- use gradle property set above to add a `chainConfig` to the bare `testInfo` previously available in `TracerTestBase`
- pass `testInfoWithChainConfig` (didn't rename it for now) to the `ToyExecutionEnvironment.build`
- build tracer from the fork available in the chain config