### PR TITLE
fix: weekly / nightly tests

### DIFF
--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -28,6 +28,7 @@ jobs:
           CORSET_FLAGS: disable
           GOCORSET_FLAGS: -v --ansi-escapes=false --report --mir
           NIGHTLY_TESTS_PARALLELISM: 2
+          ZKEVM_FORK: LONDON
 
       - name: Upload test report
         if: ${{ always() }}

--- a/.github/workflows/gradle-weekly-tests.yml
+++ b/.github/workflows/gradle-weekly-tests.yml
@@ -27,6 +27,7 @@ jobs:
         env:
           WEEKLY_TESTS_PARALLELISM: 32
           GOCORSET_FLAGS: -v -b1024 --ansi-escapes=false --report --hir
+          ZKEVM_FORK: LONDON
 
       - name: Upload test report
         if: always()
@@ -76,6 +77,7 @@ jobs:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           WEEKLY_TESTS_PARALLELISM: 24
           GOCORSET_FLAGS: -v -b1024 --ansi-escapes=false --report --hir
+          ZKEVM_FORK: LONDON
 
       - name: Upload prc calls test report
         if: always()


### PR DESCRIPTION
The weekly / nightly tests were failing because no ZKEVM_FORK was specified for them.  Hence, have set the fork to LONDON.