### PR TITLE
fix: weekly tests

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -9,4 +9,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@13225e50
+      run: go install github.com/consensys/go-corset/cmd/go-corset@v1.1.9

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/HubShomeiTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/HubShomeiTests.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
@@ -52,11 +53,13 @@ public class HubShomeiTests extends TracerTestBase {
   private static final Address DEFAULT =
       Address.fromHexString("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
 
-  private final Bytes SSLOAD1 =
-      newProgram(testInfo).push(key1).op(OpCode.SLOAD).op(OpCode.POP).compile();
+  private final Bytes SSLOAD1(TestInfoWithChainConfig testInfo) {
+    return newProgram(testInfo).push(key1).op(OpCode.SLOAD).op(OpCode.POP).compile();
+  }
 
-  private final Bytes SSTORE1 =
-      newProgram(testInfo).push(value).push(key1).op(OpCode.SSTORE).compile();
+  private Bytes SSTORE1(TestInfoWithChainConfig testInfo) {
+    return newProgram(testInfo).push(value).push(key1).op(OpCode.SSTORE).compile();
+  }
 
   /**
    * In this test we have two transactions. In the first one we prewarm a storage key, we SSTORE or
@@ -75,8 +78,8 @@ public class HubShomeiTests extends TracerTestBase {
 
     final Bytes code =
         switch (opcode) {
-          case SSTORE -> Bytes.concatenate(SSTORE1);
-          case SLOAD -> Bytes.concatenate(SSLOAD1);
+          case SSTORE -> Bytes.concatenate(SSTORE1(testInfo));
+          case SLOAD -> Bytes.concatenate(SSLOAD1(testInfo));
           default -> throw new IllegalStateException("Unexpected value: " + opcode);
         };
 
@@ -148,8 +151,8 @@ public class HubShomeiTests extends TracerTestBase {
 
     final Bytes code =
         switch (opcode) {
-          case SSTORE -> Bytes.concatenate(SSTORE1);
-          case SLOAD -> Bytes.concatenate(SSLOAD1);
+          case SSTORE -> Bytes.concatenate(SSTORE1(testInfo));
+          case SLOAD -> Bytes.concatenate(SSLOAD1(testInfo));
           default -> throw new IllegalStateException("Unexpected value: " + opcode);
         };
 

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -148,10 +148,6 @@ tasks.test.configure {
   systemProperty("besu.traces.dir", System.getProperty("besu.traces.dir"))
   systemProperty("besu.plugins.dir", System.getProperty("besu.plugins.dir"))
 
-  def fork = System.getenv().getOrDefault("ZKEVM_FORK", "LONDON").toString()
-  System.setProperty("unit.replay.tests.fork", fork)
-  systemProperty("unit.replay.tests.fork", fork)
-
   systemProperty("junit.jupiter.execution.parallel.enabled", true)
   systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
   systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
@@ -224,10 +220,6 @@ tasks.register("fastReplayTests", Test) {
     systemProperty("junit.jupiter.execution.parallel.config.fixed.parallelism",
       System.getenv().getOrDefault("REPLAY_TESTS_PARALLELISM", "1").toInteger())
   }
-
-  def fork = System.getenv().getOrDefault("ZKEVM_FORK", "LONDON").toString()
-  System.setProperty("unit.replay.tests.fork", fork)
-  systemProperty("unit.replay.tests.fork", fork)
 
   useJUnitPlatform {
     includeTags("replay")

--- a/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
+++ b/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
@@ -27,7 +27,7 @@ public class TracerTestBase {
   @BeforeEach
   public void init(TestInfo testInfo) {
       TracerTestBase.testInfo.chainConfig =
-            switch (System.getProperty("unit.replay.tests.fork")) {
+            switch (getForkOrDefault("LONDON")) {
               case "LONDON" -> ChainConfig.MAINNET_TESTCONFIG(Fork.LONDON);
               case "PARIS" -> ChainConfig.MAINNET_TESTCONFIG(Fork.PARIS);
               case "SHANGHAI" -> ChainConfig.MAINNET_TESTCONFIG(Fork.SHANGHAI);
@@ -37,5 +37,14 @@ public class TracerTestBase {
                   "Unknown fork: " + System.getProperty("unit.replay.tests.fork"));
             };
     TracerTestBase.testInfo.testInfo = testInfo;
+  }
+
+  private static String getForkOrDefault(String defaultFork) {
+    String fork = System.getenv("ZKEVM_FORK");
+    if(fork != null) {
+      return fork;
+    }
+    //
+    return defaultFork;
   }
 }


### PR DESCRIPTION
These are currently failing because the property `unit.replay.tests.fork` is not set.  In fact, this property is not required at all since we already have an environment variable `ZKEVM_FORK` for this purpose.  Hence, have refactored to use the environment variable directly, rather than the property.  A default is given of `LONDON` ... which may or may not be a sensible choice.