### PR TITLE
feat: restict slack notifications to arith-dev

### DIFF
--- a/.github/workflows/gradle-ethereum-tests.yml
+++ b/.github/workflows/gradle-ethereum-tests.yml
@@ -64,7 +64,7 @@ jobs:
           path: reference-tests/build/jacoco/referenceGeneralStateTests.exec
 
       - name: Failure Notification
-        if: ${{ failure() || cancelled() }}
+        if: github.ref == 'refs/head/arith-dev' && (failure() || cancelled())
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -52,7 +52,7 @@ jobs:
           path: arithmetization/build/jacoco/nightlyTests.exec
 
       - name: Failure Notification
-        if: ${{ failure() || cancelled() }}
+        if: github.ref == 'refs/head/arith-dev' && (failure() || cancelled())
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/gradle-weekly-tests.yml
+++ b/.github/workflows/gradle-weekly-tests.yml
@@ -51,7 +51,7 @@ jobs:
           path: arithmetization/build/jacoco/weeklyTests.exec
 
       - name: Failure Notification
-        if: ${{ failure() || cancelled() }}
+        if: github.ref == 'refs/head/arith-dev' && (failure() || cancelled())
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -101,7 +101,7 @@ jobs:
           path: arithmetization/build/jacoco/prcCallTests.exec
 
       - name: Failure Notification
-        if: ${{ failure() || cancelled() }}
+        if: github.ref == 'refs/head/arith-dev' && (failure() || cancelled())
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -120,7 +120,7 @@ jobs:
           JSON_REPORT: ${{ github.workspace }}/tmp/${{ steps.extract_branch.outputs.branch }}/BlockchainReferenceTestOutcome.json
 
       - name: Failure Notification
-        if: ${{ failure() || cancelled() }}
+        if: github.ref == 'refs/head/arith-dev' && (failure() || cancelled())
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This restricts slack failure or cancellation notices to those workflows running on arith-dev.  This means that workflows being run on other people's branches will not result in annoying failure notifications.