### PR TITLE
Feat: make line counter tracer selection configurable

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/plugins/AbstractLineaSharedOptionsPlugin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/AbstractLineaSharedOptionsPlugin.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedCliOptions;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
+import net.consensys.linea.plugins.config.LineaTracerSharedCliOptions;
+import net.consensys.linea.plugins.config.LineaTracerSharedConfiguration;
 import net.consensys.linea.zktracer.Fork;
 
 /** In this class we put CLI options that are shared with other plugins not defined here */
@@ -32,9 +34,11 @@ public abstract class AbstractLineaSharedOptionsPlugin extends AbstractLineaOpti
   public Map<String, LineaOptionsPluginConfiguration> getLineaPluginConfigMap() {
     final LineaL1L2BridgeSharedCliOptions l1L2BridgeCliOptions =
         LineaL1L2BridgeSharedCliOptions.create();
+    final LineaTracerSharedCliOptions tracerSharedCliOptions = LineaTracerSharedCliOptions.create();
 
     return Map.of(
-        LineaL1L2BridgeSharedCliOptions.CONFIG_KEY, l1L2BridgeCliOptions.asPluginConfig());
+        LineaL1L2BridgeSharedCliOptions.CONFIG_KEY, l1L2BridgeCliOptions.asPluginConfig(),
+        LineaTracerSharedCliOptions.CONFIG_KEY, tracerSharedCliOptions.asPluginConfig());
   }
 
   public LineaL1L2BridgeSharedConfiguration l1L2BridgeSharedConfiguration() {
@@ -46,6 +50,11 @@ public abstract class AbstractLineaSharedOptionsPlugin extends AbstractLineaOpti
       throw new IllegalStateException("L1L2 bridge configuration not provided.");
     }
     return l2L1;
+  }
+
+  public LineaTracerSharedConfiguration tracerSharedConfiguration() {
+    return (LineaTracerSharedConfiguration)
+        getConfigurationByKey(LineaTracerSharedCliOptions.CONFIG_KEY).optionsConfig();
   }
 
   public Fork fork() {

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaTracerSharedCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaTracerSharedCliOptions.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.plugins.config;
+
+import com.google.common.base.MoreObjects;
+import net.consensys.linea.plugins.LineaCliOptions;
+import picocli.CommandLine;
+
+public class LineaTracerSharedCliOptions implements LineaCliOptions {
+  public static final String CONFIG_KEY = "tracer-shared-config";
+
+  public static final String LIMITLESS_ENABLED = "--plugin-linea-limitless-enabled";
+  public static final boolean DEFAULT_LIMITLESS_ENABLED = false;
+
+  @CommandLine.Option(
+      names = {LIMITLESS_ENABLED},
+      hidden = true,
+      paramLabel = "<BOOLEAN>",
+      description =
+          "If the sequencer needs to use or not the limitless prover (default: ${DEFAULT-VALUE})")
+  private boolean limitlessEnabled = DEFAULT_LIMITLESS_ENABLED;
+
+  private LineaTracerSharedCliOptions() {}
+
+  /**
+   * Create Linea cli options.
+   *
+   * @return the Linea cli options
+   */
+  public static LineaTracerSharedCliOptions create() {
+    return new LineaTracerSharedCliOptions();
+  }
+
+  /**
+   * Linea cli options from config.
+   *
+   * @param config the config
+   * @return the Linea cli options
+   */
+  public static LineaTracerSharedCliOptions fromConfig(
+      final LineaTracerSharedConfiguration config) {
+    final LineaTracerSharedCliOptions options = create();
+    options.limitlessEnabled = config.isLimitless();
+    return options;
+  }
+
+  /**
+   * To domain object Linea factory configuration.
+   *
+   * @return the Linea factory configuration
+   */
+  @Override
+  public LineaTracerSharedConfiguration toDomainObject() {
+    return LineaTracerSharedConfiguration.builder().isLimitless(limitlessEnabled).build();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add(LIMITLESS_ENABLED, limitlessEnabled).toString();
+  }
+}

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaTracerSharedConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaTracerSharedConfiguration.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.plugins.config;
+
+import lombok.Builder;
+import net.consensys.linea.plugins.LineaOptionsConfiguration;
+
+/** The Linea tracer shared configuration. */
+@Builder(toBuilder = true)
+public record LineaTracerSharedConfiguration(boolean isLimitless)
+    implements LineaOptionsConfiguration {}

--- a/plugins/src/main/java/net/consensys/linea/plugins/rpc/batchlinecount/ConflatedLineCountsEndpointServicePlugin.java
+++ b/plugins/src/main/java/net/consensys/linea/plugins/rpc/batchlinecount/ConflatedLineCountsEndpointServicePlugin.java
@@ -66,7 +66,8 @@ public class ConflatedLineCountsEndpointServicePlugin extends AbstractLineaShare
             RequestLimiterDispatcher.SINGLE_INSTANCE_REQUEST_LIMITER_KEY);
 
     final ConflatedCountTracesV2 method =
-        new ConflatedCountTracesV2(reqLimiter, besuContext, l1L2BridgeSharedConfiguration());
+        new ConflatedCountTracesV2(
+            reqLimiter, besuContext, l1L2BridgeSharedConfiguration(), tracerSharedConfiguration());
     createAndRegister(method, rpcEndpointService);
   }
 

--- a/plugins/src/main/java/net/consensys/linea/plugins/rpc/linecounts/LineCountsEndpointServicePlugin.java
+++ b/plugins/src/main/java/net/consensys/linea/plugins/rpc/linecounts/LineCountsEndpointServicePlugin.java
@@ -60,7 +60,8 @@ public class LineCountsEndpointServicePlugin extends AbstractLineaPrivateOptions
             RequestLimiterDispatcher.SINGLE_INSTANCE_REQUEST_LIMITER_KEY);
 
     final GenerateLineCountsV2 method =
-        new GenerateLineCountsV2(reqLimiter, besuContext, l1L2BridgeSharedConfiguration());
+        new GenerateLineCountsV2(
+            reqLimiter, besuContext, l1L2BridgeSharedConfiguration(), tracerSharedConfiguration());
     createAndRegister(method, rpcEndpointService);
   }
 


### PR DESCRIPTION
Allow to choose the `ZkCounter` implementation via the CLI option `--plugin-linea-limitless-enabled=true`, by default is `false`, thus using `ZkTracer`, to allow for a smooth transition. 