### PR TITLE
Fix repository name inconsistency in contribution links

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ Contributions are welcome!
 ### Guidelines for Non-Code and other Trivial Contributions
 Please keep in mind that we do not accept non-code contributions like fixing comments, typos or some other trivial fixes. Although we appreciate the extra help, managing lots of these small contributions is unfeasible, and puts extra pressure in our continuous delivery systems (running all tests, etc). Feel free to open an issue pointing to any of those errors, and we will batch them into a single change.
 
-1. [Create an issue](https://github.com/Consensys/linea-arithmetization/issues).
+1. [Create an issue](https://github.com/Consensys/linea-tracer/issues).
 > If the proposed update requires input, also tag us for discussion.
-2. Submit the update as a pull request from your [fork of this repo](https://github.com/Consensys/linea-arithmetization/fork), and tag us for review. 
+2. Submit the update as a pull request from your [fork of this repo](https://github.com/Consensys/linea-tracer/fork), and tag us for review. 
 > Include the issue number in the pull request description and (optionally) in the branch name.
 
-Consider starting with a ["good first issue"](https://github.com/ConsenSys/linea-arithmetization/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+Consider starting with a ["good first issue"](https://github.com/ConsenSys/linea-tracer/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 Before contributing, ensure you're familiar with:
 


### PR DESCRIPTION
Changes:
- Updated the issue creation link from "linea-arithmetization" to "linea-tracer"
- Updated the fork link from "linea-arithmetization" to "linea-tracer" 

This ensures consistent repository naming throughout the documentation.