### PR TITLE
feat: update `go-corset` and `linea-constraints`

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -9,4 +9,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@v1.1.12
+      run: go install github.com/consensys/go-corset/cmd/go-corset@v1.1.13

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/ExceptionAtContextReEntryTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/ExceptionAtContextReEntryTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
  *
  * <p><b>Note.</b> All exceptions that we test are <b>stackUnderflowException</b>'s.
  */
-public class ExceptionAtContextReEntry extends TracerTestBase {
+public class ExceptionAtContextReEntryTest extends TracerTestBase {
 
   /**
    * {@link #firstInstructionAfterResumingFromUnsuccessfulMessageCallIsExceptional} tests what


### PR DESCRIPTION
This updates `go-corset` to version `1.1.13` which now supports conditional lookups.  This also updates `linea-constraints` to the latest commit where conditional lookups are used.
