### PR TITLE
fix: inherit secrets in reusable workflow

### DIFF
--- a/.github/workflows/gradle-weekly-tests.yml
+++ b/.github/workflows/gradle-weekly-tests.yml
@@ -13,20 +13,24 @@ concurrency:
 jobs:
   weekly-unit-tests-london:
     uses: ./.github/workflows/reusable-weekly-tests.yml
+    secrets: inherit
     with:
       zkevm_fork: LONDON
 
   weekly-unit-tests-shanghai:
     uses: ./.github/workflows/reusable-weekly-tests.yml
+    secrets: inherit    
     with:
       zkevm_fork: SHANGHAI
 
   weekly-prc-call-tests-london:
     uses: ./.github/workflows/reusable-weekly-prc-tests.yml
+    secrets: inherit    
     with:
       zkevm_fork: LONDON
 
   weekly-prc-call-tests-shanghai:
     uses: ./.github/workflows/reusable-weekly-prc-tests.yml
+    secrets: inherit    
     with:
       zkevm_fork: SHANGHAI

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -30,6 +30,7 @@ concurrency:
 jobs:
   blockchain-reference-tests-london:
     uses: ./.github/workflows/reusable-blockchain-tests.yml
+    secrets: inherit
     with:
       zkevm_fork: London
       test_filter: ${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}
@@ -39,6 +40,7 @@ jobs:
 
   blockchain-reference-tests-shanghai:
     uses: ./.github/workflows/reusable-blockchain-tests.yml
+    secrets: inherit    
     with:
       zkevm_fork: Shanghai
       test_filter: ${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}


### PR DESCRIPTION
Since these workflows are under our control, there is no concern with passing through secrets.  In particular, for the slack notification workflow we need the secrets.SLACK_WEBHOOK_URL to be available.