### PR TITLE
Feat/instruction decoder update cancun

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/MxpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/MxpCall.java
@@ -97,8 +97,8 @@ public abstract class MxpCall implements TraceSubFragment {
    * @return CancunMxpCall instance corresponding to the Mxp scenario
    */
   public static CancunMxpCall getCancunMxpCall(Hub hub) {
-    final OpCode opCode = hub.opCode();
-    if (opCode == OpCode.MSIZE) {
+    final OpCodeData opCodeData = hub.currentFrame().opCodeData();
+    if (opCodeData.isMSize()) {
       return new CancunMSizeMxpCall(hub);
     }
     EWord[] sizesAndOffsets = getSizesAndOffsets(hub.messageFrame());
@@ -112,7 +112,7 @@ public abstract class MxpCall implements TraceSubFragment {
     if (cancunNotMSizeNorTrivialMxpCall.mxpx) {
       return new CancunMxpxMxpCall(hub, cancunNotMSizeNorTrivialMxpCall.mxpx);
     } else {
-      if (isWordPricingOpcode(opCode)) {
+      if (opCodeData.isWordPricing()) {
         return new CancunStateUpdateWordPricingMxpCall(hub);
       }
       return new CancunStateUpdateBytePricingMxpCall(hub);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/MxpUtils.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/MxpUtils.java
@@ -24,35 +24,9 @@ import net.consensys.linea.zktracer.types.EWord;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 public class MxpUtils {
-  public static boolean isSingleOffsetOpcode(OpCode opCode) {
-    return opCode == OpCode.MLOAD
-        || opCode == OpCode.MSTORE
-        || opCode == OpCode.MSTORE8
-        || opCode == OpCode.REVERT
-        || opCode == OpCode.RETURN
-        || opCode.isLog()
-        || opCode == OpCode.SHA3
-        || opCode.isCopy()
-        || opCode.isCreate();
-  }
-
-  public static boolean isDoubleOffsetOpcode(OpCode opCode) {
-    return opCode == OpCode.MCOPY || opCode.isCall();
-  }
 
   public static boolean isWordPricingOpcode(OpCode opCode) {
     return opCode == OpCode.SHA3 || opCode.isCopy() || opCode.isCreate() || opCode == OpCode.MCOPY;
-  }
-
-  public static boolean isBytePricingOpcode(OpCode opCode) {
-    return opCode == OpCode.MSIZE
-        || opCode == OpCode.MLOAD
-        || opCode == OpCode.MSTORE
-        || opCode == OpCode.MSTORE8
-        || opCode == OpCode.REVERT
-        || opCode == OpCode.RETURN
-        || opCode.isLog()
-        || opCode.isCall();
   }
 
   /**

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/moduleCall/CancunStateUpdateMxpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/moduleCall/CancunStateUpdateMxpCall.java
@@ -16,7 +16,6 @@
 package net.consensys.linea.zktracer.module.mxp.moduleCall;
 
 import static net.consensys.linea.zktracer.Trace.GAS_CONST_G_MEMORY;
-import static net.consensys.linea.zktracer.module.mxp.MxpUtils.isDoubleOffsetOpcode;
 import static net.consensys.linea.zktracer.types.Conversions.*;
 import static net.consensys.linea.zktracer.types.Conversions.bigIntegerToBytes;
 
@@ -26,7 +25,6 @@ import net.consensys.linea.zktracer.module.euc.Euc;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.mxp.MxpExoCall;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
-import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
 
 public abstract class CancunStateUpdateMxpCall extends CancunNotMSizeNorTrivialMxpCall {
@@ -37,7 +35,6 @@ public abstract class CancunStateUpdateMxpCall extends CancunNotMSizeNorTrivialM
   }
 
   public void computeStateUpdt(Wcp wcp, Euc euc) {
-    final OpCode opCode = this.opCodeData.mnemonic();
 
     // We compute and assign the computation's result for each row
 
@@ -46,7 +43,7 @@ public abstract class CancunStateUpdateMxpCall extends CancunNotMSizeNorTrivialM
     boolean useParams2 = false; // default value if opcode is single offset
     boolean useParams1 = true;
     // we filter the row i + 7 wcp call by double_offset to prevent unnecessary comparisons
-    if (isDoubleOffsetOpcode(opCode)) {
+    if (this.opCodeData.isDoubleOffset()) {
       final BigInteger max1 =
           this.offset1.toUnsignedBigInteger().add(this.size1.toUnsignedBigInteger());
       final BigInteger max2 =

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/moduleOperation/CancunMxpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/moduleOperation/CancunMxpOperation.java
@@ -23,6 +23,7 @@ import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.module.hub.fragment.imc.MxpCall;
 import net.consensys.linea.zktracer.module.mxp.moduleCall.*;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.types.UnsignedByte;
 import org.apache.tuweni.bytes.Bytes;
 
@@ -58,22 +59,22 @@ public class CancunMxpOperation extends MxpOperation {
   }
 
   final void traceDecoder(int stamp, Trace.Mxp trace) {
-    OpCode opCode = cancunMxpCall.getOpCodeData().mnemonic();
+    OpCodeData opCodeData = cancunMxpCall.getOpCodeData();
 
     trace
         .mxpStamp(stamp)
         .cn(this.getContextNumber())
         .decoder(true)
-        .pDecoderInst(UnsignedByte.of(opCode.byteValue()))
-        .pDecoderIsMsize(opCode == OpCode.MSIZE)
-        .pDecoderIsReturn(opCode == OpCode.RETURN)
-        .pDecoderIsMcopy(opCode == OpCode.MCOPY)
-        .pDecoderIsFixedSize32(opCode == OpCode.MLOAD || opCode == OpCode.MSTORE)
-        .pDecoderIsFixedSize1(opCode == OpCode.MSTORE8)
-        .pDecoderIsSingleMaxOffset(isSingleOffsetOpcode(opCode))
-        .pDecoderIsDoubleMaxOffset(isDoubleOffsetOpcode(opCode))
-        .pDecoderIsWordPricing(isWordPricingOpcode(opCode))
-        .pDecoderIsBytePricing(isBytePricingOpcode(opCode))
+        .pDecoderInst(UnsignedByte.of(opCodeData.mnemonic().byteValue()))
+        .pDecoderIsMsize(opCodeData.isMSize())
+        .pDecoderIsReturn(opCodeData.isReturn())
+        .pDecoderIsMcopy(opCodeData.isMCopy())
+        .pDecoderIsFixedSize32(opCodeData.isFixedSize32())
+        .pDecoderIsFixedSize1(opCodeData.isFixedSize1())
+        .pDecoderIsSingleMaxOffset(opCodeData.isSingleOffset())
+        .pDecoderIsDoubleMaxOffset(opCodeData.isDoubleOffset())
+        .pDecoderIsWordPricing(opCodeData.isWordPricing())
+        .pDecoderIsBytePricing(opCodeData.isBytePricing())
         .pDecoderGword((UnsignedByte) cancunMxpCall.gWord)
         .pDecoderGbyte((UnsignedByte) cancunMxpCall.gByte)
         .fillAndValidateRow();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/CancunInstructionDecoder.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/CancunInstructionDecoder.java
@@ -33,15 +33,22 @@ public class CancunInstructionDecoder extends LondonInstructionDecoder {
   }
 
   @Override
+  protected void traceMxpFlag(OpCodeData op, Trace.Instdecoder trace) {
+    // From Cancun, we have a Mxp flag available
+    trace.mxpFlag(op.isMxp());
+  }
+
+  @Override
   protected void traceMxpScenario(OpCodeData op, Trace.Instdecoder trace) {
-    // trace.isMsize()
-    //         .isReturn()
-    //         .isMcopy()
-    //         .isFixedSize1()
-    //         .isFixedSize32()
-    //         .isSingleMaxOffset()
-    //         .isDoubleMaxOffset()
-    //         .isWordPricing()
-    //         .isBytePricing();
+    trace
+        .isMsize(op.isMSize())
+        .isReturn(op.isReturn())
+        .isMcopy(op.isMCopy())
+        .isFixedSize1(op.isFixedSize1())
+        .isFixedSize32(op.isFixedSize32())
+        .isSingleMaxOffset(op.isSingleOffset())
+        .isDoubleMaxOffset(op.isDoubleOffset())
+        .isWordPricing(op.isWordPricing())
+        .isBytePricing(op.isBytePricing());
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/InstructionDecoder.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/InstructionDecoder.java
@@ -39,7 +39,6 @@ public abstract class InstructionDecoder implements Module {
         .familyContext(op.instructionFamily() == InstructionFamily.CONTEXT)
         .familyAccount(op.instructionFamily() == InstructionFamily.ACCOUNT)
         .familyCopy(op.instructionFamily() == InstructionFamily.COPY)
-        .familyMCopy(op.instructionFamily() == InstructionFamily.MCOPY)
         .familyTransaction(op.instructionFamily() == InstructionFamily.TRANSACTION)
         .familyBatch(op.instructionFamily() == InstructionFamily.BATCH)
         .familyStackRam(op.instructionFamily() == InstructionFamily.STACK_RAM)
@@ -61,6 +60,8 @@ public abstract class InstructionDecoder implements Module {
   protected abstract void traceTransientFamily(OpCodeData op, Trace.Instdecoder trace);
 
   protected abstract void traceMcopyFamily(OpCodeData op, Trace.Instdecoder trace);
+
+  protected abstract void traceMxpFlag(OpCodeData op, Trace.Instdecoder trace);
 
   protected abstract void traceMxpScenario(OpCodeData op, Trace.Instdecoder trace);
 
@@ -88,9 +89,8 @@ public abstract class InstructionDecoder implements Module {
             UnsignedByte.of(
                 op.billing().billingRate() == BillingRate.BY_BYTE
                     ? op.billing().perUnit().cost()
-                    : 0))
-        .mxpFlag(op.isMxp());
-
+                    : 0));
+    traceMxpFlag(op, trace);
     traceMxpScenario(op, trace);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/InstructionDecoder.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/InstructionDecoder.java
@@ -39,6 +39,7 @@ public abstract class InstructionDecoder implements Module {
         .familyContext(op.instructionFamily() == InstructionFamily.CONTEXT)
         .familyAccount(op.instructionFamily() == InstructionFamily.ACCOUNT)
         .familyCopy(op.instructionFamily() == InstructionFamily.COPY)
+        .familyMCopy(op.instructionFamily() == InstructionFamily.MCOPY)
         .familyTransaction(op.instructionFamily() == InstructionFamily.TRANSACTION)
         .familyBatch(op.instructionFamily() == InstructionFamily.BATCH)
         .familyStackRam(op.instructionFamily() == InstructionFamily.STACK_RAM)

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/LondonInstructionDecoder.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/LondonInstructionDecoder.java
@@ -31,6 +31,12 @@ public class LondonInstructionDecoder extends InstructionDecoder {
   }
 
   @Override
+  protected void traceMxpFlag(OpCodeData op, Trace.Instdecoder trace) {
+    // mxp flag is determined with types label in London
+    trace.mxpFlag(op.billing().type() != MxpType.NONE);
+  }
+
+  @Override
   protected void traceMxpScenario(OpCodeData op, Trace.Instdecoder trace) {
     trace
         .mxpType1(op.billing().type() == MxpType.TYPE_1)

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
@@ -42,7 +42,6 @@ public record OpCodeData(
     int value,
     InstructionFamily instructionFamily,
     StackSettings stackSettings,
-    boolean mxpFlag,
     Billing billing) {
 
   public Billing billing() {
@@ -67,7 +66,6 @@ public record OpCodeData(
             false,
             false,
             false),
-        false,
         new Billing(GasConstants.G_ZERO, BillingRate.NONE, MxpType.NONE));
   }
 
@@ -176,6 +174,6 @@ public record OpCodeData(
 
   // Used on from Cancun and on, before ixMxp is determined by checking if there is a type
   public boolean isMxp() {
-    return mxpFlag;
+    return isMSize() || isSingleOffset() || isDoubleOffset();
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
@@ -155,15 +155,15 @@ public record OpCodeData(
         || mnemonic == OpCode.MSTORE
         || mnemonic == OpCode.MSTORE8
         || mnemonic == OpCode.REVERT
-        || this.isReturn()
-        || this.isLog()
+        || isReturn()
+        || isLog()
         || mnemonic == OpCode.SHA3
-        || this.isCopy()
-        || this.isCreate();
+        || isCopy()
+        || isCreate();
   }
 
   public boolean isDoubleOffset() {
-    return this.isMCopy() || this.isCall();
+    return isMCopy() || isCall();
   }
 
   public boolean isWordPricing() {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
@@ -42,6 +42,7 @@ public record OpCodeData(
     int value,
     InstructionFamily instructionFamily,
     StackSettings stackSettings,
+    boolean mxpFlag,
     Billing billing) {
 
   public Billing billing() {
@@ -66,6 +67,7 @@ public record OpCodeData(
             false,
             false,
             false),
+        false,
         new Billing(GasConstants.G_ZERO, BillingRate.NONE, MxpType.NONE));
   }
 
@@ -124,11 +126,56 @@ public record OpCodeData(
     return instructionFamily == INVALID;
   }
 
-  public boolean isMxp() {
-    return this.billing().type() != MxpType.NONE;
-  }
-
   public int numberOfStackRows() {
     return stackSettings.twoLineInstruction() ? 2 : 1;
+  }
+
+  public boolean isMSize() {
+    return mnemonic == OpCode.MSIZE;
+  }
+
+  public boolean isFixedSize32() {
+    return mnemonic == OpCode.MLOAD || mnemonic == OpCode.MSTORE;
+  }
+
+  public boolean isFixedSize1() {
+    return mnemonic == OpCode.MSTORE8;
+  }
+
+  public boolean isReturn() {
+    return mnemonic == OpCode.RETURN;
+  }
+
+  public boolean isMCopy() {
+    return instructionFamily == MCOPY;
+  }
+
+  public boolean isSingleOffset() {
+    return mnemonic == OpCode.MLOAD
+        || mnemonic == OpCode.MSTORE
+        || mnemonic == OpCode.MSTORE8
+        || mnemonic == OpCode.REVERT
+        || this.isReturn()
+        || this.isLog()
+        || mnemonic == OpCode.SHA3
+        || this.isCopy()
+        || this.isCreate();
+  }
+
+  public boolean isDoubleOffset() {
+    return this.isMCopy() || this.isCall();
+  }
+
+  public boolean isWordPricing() {
+    return billing().billingRate() == BillingRate.BY_WORD;
+  }
+
+  public boolean isBytePricing() {
+    return billing().billingRate() == BillingRate.BY_BYTE;
+  }
+
+  // Used on from Cancun and on, before ixMxp is determined by checking if there is a type
+  public boolean isMxp() {
+    return mxpFlag;
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/gas/Billing.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/gas/Billing.java
@@ -17,15 +17,12 @@ package net.consensys.linea.zktracer.opcode.gas;
 
 import java.util.Objects;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-
 /**
  * An ancillary class to compute gas billing of some instructions.
  *
  * @param perUnit gas cost of a unit
  * @param billingRate the unit used to bill gas
  */
-@JsonDeserialize(using = BillingDeserializer.class)
 public record Billing(GasConstants perUnit, BillingRate billingRate, MxpType type) {
   public static final Billing DEFAULT =
       new Billing(GasConstants.G_ZERO, BillingRate.NONE, MxpType.NONE);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/gas/BillingDeserializer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/gas/BillingDeserializer.java
@@ -53,7 +53,7 @@ public class BillingDeserializer extends StdDeserializer<Billing> {
                       new IllegalArgumentException(
                           "'wordPrice' is a mandatory property when declaring 'byWord' billing"));
 
-      MxpType type = extractMxpType(wordNode, "byWord");
+      MxpType type = extractMxpType(wordNode);
       GasConstants wordPrice = GasConstants.valueOf(wordPriceNode.textValue());
 
       return Billing.byWord(type, wordPrice);
@@ -62,7 +62,7 @@ public class BillingDeserializer extends StdDeserializer<Billing> {
     if (byMxp.isPresent()) {
       JsonNode mxpNode = byMxp.get();
 
-      MxpType type = extractMxpType(mxpNode, "byMxp");
+      MxpType type = extractMxpType(mxpNode);
 
       return Billing.byMxp(type);
     }
@@ -77,7 +77,7 @@ public class BillingDeserializer extends StdDeserializer<Billing> {
                       new IllegalArgumentException(
                           "'bytePrice' is a mandatory property when declaring 'byByte' billing"));
 
-      MxpType type = extractMxpType(byteNode, "byByte");
+      MxpType type = extractMxpType(byteNode);
       GasConstants bytePrice = GasConstants.valueOf(bytePriceNode.textValue());
 
       return Billing.byByte(type, bytePrice);
@@ -86,15 +86,10 @@ public class BillingDeserializer extends StdDeserializer<Billing> {
     return new Billing();
   }
 
-  private MxpType extractMxpType(JsonNode node, String billingRate) {
-    JsonNode typeNode =
-        Optional.of(node.get("type"))
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        "'mnemonic' is a mandatory property when declaring '%s' billing"
-                            .formatted(billingRate)));
+  private MxpType extractMxpType(JsonNode node) {
+    // TODO: refacto and make serializer for dependent
+    JsonNode typeNode = node.get("type");
 
-    return MxpType.valueOf(typeNode.textValue());
+    return typeNode == null ? MxpType.NONE : MxpType.valueOf(typeNode.textValue());
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/gas/BillingDeserializer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/gas/BillingDeserializer.java
@@ -26,8 +26,11 @@ import lombok.SneakyThrows;
 /** Custom Jackson deserializer for handling {@link Billing} properties. */
 public class BillingDeserializer extends StdDeserializer<Billing> {
 
-  public BillingDeserializer() {
+  private boolean withType = false;
+
+  public BillingDeserializer(boolean withType) {
     this(Billing.class);
+    this.withType = withType;
   }
 
   protected BillingDeserializer(Class<?> vc) {
@@ -53,16 +56,16 @@ public class BillingDeserializer extends StdDeserializer<Billing> {
                       new IllegalArgumentException(
                           "'wordPrice' is a mandatory property when declaring 'byWord' billing"));
 
-      MxpType type = extractMxpType(wordNode);
+      MxpType type = withType ? extractMxpType(wordNode, "byWord") : MxpType.NONE;
       GasConstants wordPrice = GasConstants.valueOf(wordPriceNode.textValue());
 
       return Billing.byWord(type, wordPrice);
     }
 
-    if (byMxp.isPresent()) {
+    if (withType && byMxp.isPresent()) {
       JsonNode mxpNode = byMxp.get();
 
-      MxpType type = extractMxpType(mxpNode);
+      MxpType type = extractMxpType(mxpNode, "byMxp");
 
       return Billing.byMxp(type);
     }
@@ -77,7 +80,7 @@ public class BillingDeserializer extends StdDeserializer<Billing> {
                       new IllegalArgumentException(
                           "'bytePrice' is a mandatory property when declaring 'byByte' billing"));
 
-      MxpType type = extractMxpType(byteNode);
+      MxpType type = withType ? extractMxpType(byteNode, "byByte") : MxpType.NONE;
       GasConstants bytePrice = GasConstants.valueOf(bytePriceNode.textValue());
 
       return Billing.byByte(type, bytePrice);
@@ -86,10 +89,15 @@ public class BillingDeserializer extends StdDeserializer<Billing> {
     return new Billing();
   }
 
-  private MxpType extractMxpType(JsonNode node) {
-    // TODO: refacto and make serializer for dependent
-    JsonNode typeNode = node.get("type");
+  private MxpType extractMxpType(JsonNode node, String billingRate) {
+    JsonNode typeNode =
+        Optional.of(node.get("type"))
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "'mnemonic' is a mandatory property when declaring '%s' billing"
+                            .formatted(billingRate)));
 
-    return typeNode == null ? MxpType.NONE : MxpType.valueOf(typeNode.textValue());
+    return MxpType.valueOf(typeNode.textValue());
   }
 }

--- a/arithmetization/src/main/resources/cancunOpcodes.yml
+++ b/arithmetization/src/main/resources/cancunOpcodes.yml
@@ -222,7 +222,6 @@ opcodes:
       alpha: 1
       delta: 2
       staticGas: G_KECCAK_256
-    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_KECCAK_256_WORD
@@ -298,7 +297,6 @@ opcodes:
       delta: 3
       staticGas: G_VERY_LOW
       flag1: true
-    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_COPY
@@ -320,7 +318,6 @@ opcodes:
       delta: 3
       staticGas: G_VERY_LOW
       flag3: true
-    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_COPY
@@ -351,7 +348,6 @@ opcodes:
       delta: 4
       staticGas: G_ZERO
       flag4: true
-    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_COPY
@@ -372,7 +368,6 @@ opcodes:
       delta: 3
       staticGas: G_VERY_LOW
       flag2: true
-    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_COPY
@@ -501,7 +496,6 @@ opcodes:
       delta: 1
       staticGas: G_VERY_LOW
       flag2: true
-    mxpFlag: true
   - mnemonic: MSTORE
     value: 0x52
     instructionFamily: STACK_RAM
@@ -511,7 +505,6 @@ opcodes:
       delta: 2
       staticGas: G_VERY_LOW
       flag3: true
-    mxpFlag: true
   - mnemonic: MSTORE8
     value: 0x53
     instructionFamily: STACK_RAM
@@ -521,7 +514,6 @@ opcodes:
       delta: 2
       staticGas: G_VERY_LOW
       flag4: true
-    mxpFlag: true
   - mnemonic: SLOAD
     value: 0x54
     instructionFamily: STORAGE
@@ -577,7 +569,6 @@ opcodes:
       delta: 0
       staticGas: G_BASE
       flag2: true
-    mxpFlag: true
   - mnemonic: GAS
     value: 0x5a
     instructionFamily: MACHINE_STATE
@@ -623,7 +614,6 @@ opcodes:
       alpha: 0
       delta: 3
       staticGas: G_VERY_LOW
-    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_COPY
@@ -1190,7 +1180,6 @@ opcodes:
       staticGas: G_LOG_0
       twoLineInstruction: true
       forbiddenInStatic: true
-    mxpFlag: true
     billing:
       byByte:
         bytePrice: G_LOG_DATA
@@ -1205,7 +1194,6 @@ opcodes:
       twoLineInstruction: true
       forbiddenInStatic: true
       flag1: true
-    mxpFlag: true
     billing:
       byByte:
         bytePrice: G_LOG_DATA
@@ -1220,7 +1208,6 @@ opcodes:
       twoLineInstruction: true
       forbiddenInStatic: true
       flag2: true
-    mxpFlag: true
     billing:
       byByte:
         bytePrice: G_LOG_DATA
@@ -1235,7 +1222,6 @@ opcodes:
       twoLineInstruction: true
       forbiddenInStatic: true
       flag3: true
-    mxpFlag: true
     billing:
       byByte:
         bytePrice: G_LOG_DATA
@@ -1250,7 +1236,6 @@ opcodes:
       twoLineInstruction: true
       forbiddenInStatic: true
       flag4: true
-    mxpFlag: true
     billing:
       byByte:
         bytePrice: G_LOG_DATA
@@ -1265,7 +1250,6 @@ opcodes:
       twoLineInstruction: true
       forbiddenInStatic: true
       flag1: true
-    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_CONST_INIT_CODE_WORD
@@ -1280,7 +1264,6 @@ opcodes:
       twoLineInstruction: true
       forbiddenInStatic: true
       flag1: true
-    mxpFlag: true
   - mnemonic: CALLCODE
     value: 0xf2
     instructionFamily: CALL
@@ -1291,7 +1274,6 @@ opcodes:
       staticGas: S_CALL
       twoLineInstruction: true
       flag2: true
-    mxpFlag: true
   - mnemonic: RETURN
     value: 0xf3
     instructionFamily: HALT
@@ -1301,7 +1283,6 @@ opcodes:
       delta: 2
       staticGas: G_ZERO
       flag1: true
-    mxpFlag: true
     billing:
       byByte:
         bytePrice: G_CODE_DEPOSIT
@@ -1315,7 +1296,6 @@ opcodes:
       staticGas: S_CALL
       twoLineInstruction: true
       flag3: true
-    mxpFlag: true
   - mnemonic: CREATE2
     value: 0xf5
     instructionFamily: CREATE
@@ -1327,7 +1307,6 @@ opcodes:
       twoLineInstruction: true
       forbiddenInStatic: true
       flag2: true
-    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_CONST_INIT_CODE_WORD_CREATE2
@@ -1341,7 +1320,6 @@ opcodes:
       staticGas: S_CALL
       twoLineInstruction: true
       flag4: true
-    mxpFlag: true
   - mnemonic: REVERT
     value: 0xfd
     instructionFamily: HALT
@@ -1351,7 +1329,6 @@ opcodes:
       delta: 2
       staticGas: G_ZERO
       flag2: true
-    mxpFlag: true
   - mnemonic: INVALID
     value: 0xfe
     instructionFamily: INVALID

--- a/arithmetization/src/main/resources/cancunOpcodes.yml
+++ b/arithmetization/src/main/resources/cancunOpcodes.yml
@@ -224,7 +224,6 @@ opcodes:
       staticGas: G_KECCAK_256
     billing:
       byWord:
-        type: TYPE_4
         wordPrice: G_KECCAK_256_WORD
   - mnemonic: ADDRESS
     value: 0x30
@@ -300,7 +299,6 @@ opcodes:
       flag1: true
     billing:
       byWord:
-        type: TYPE_4
         wordPrice: G_COPY
   - mnemonic: CODESIZE
     value: 0x38
@@ -322,7 +320,6 @@ opcodes:
       flag3: true
     billing:
       byWord:
-        type: TYPE_4
         wordPrice: G_COPY
   - mnemonic: GASPRICE
     value: 0x3a
@@ -353,7 +350,6 @@ opcodes:
       flag4: true
     billing:
       byWord:
-        type: TYPE_4
         wordPrice: G_COPY
   - mnemonic: RETURNDATASIZE
     value: 0x3d
@@ -374,7 +370,6 @@ opcodes:
       flag2: true
     billing:
       byWord:
-        type: TYPE_4
         wordPrice: G_COPY
   - mnemonic: EXTCODEHASH
     value: 0x3f
@@ -503,7 +498,6 @@ opcodes:
       flag2: true
     billing:
       byMxp:
-        type: TYPE_2
   - mnemonic: MSTORE
     value: 0x52
     instructionFamily: STACK_RAM
@@ -515,7 +509,6 @@ opcodes:
       flag3: true
     billing:
       byMxp:
-        type: TYPE_2
   - mnemonic: MSTORE8
     value: 0x53
     instructionFamily: STACK_RAM
@@ -527,7 +520,6 @@ opcodes:
       flag4: true
     billing:
       byMxp:
-        type: TYPE_3
   - mnemonic: SLOAD
     value: 0x54
     instructionFamily: STORAGE
@@ -585,7 +577,6 @@ opcodes:
       flag2: true
     billing:
       byMxp:
-        type: TYPE_1
   - mnemonic: GAS
     value: 0x5a
     instructionFamily: MACHINE_STATE
@@ -633,7 +624,6 @@ opcodes:
       staticGas: G_VERY_LOW
     billing:
       byWord:
-        type: TYPE_4
         wordPrice: G_COPY
   - mnemonic: PUSH0
     value: 0x5f
@@ -1200,7 +1190,6 @@ opcodes:
       forbiddenInStatic: true
     billing:
       byByte:
-        type: TYPE_4
         bytePrice: G_LOG_DATA
   - mnemonic: LOG1
     value: 0xa1
@@ -1215,7 +1204,6 @@ opcodes:
       flag1: true
     billing:
       byByte:
-        type: TYPE_4
         bytePrice: G_LOG_DATA
   - mnemonic: LOG2
     value: 0xa2
@@ -1230,7 +1218,6 @@ opcodes:
       flag2: true
     billing:
       byByte:
-        type: TYPE_4
         bytePrice: G_LOG_DATA
   - mnemonic: LOG3
     value: 0xa3
@@ -1245,7 +1232,6 @@ opcodes:
       flag3: true
     billing:
       byByte:
-        type: TYPE_4
         bytePrice: G_LOG_DATA
   - mnemonic: LOG4
     value: 0xa4
@@ -1260,7 +1246,6 @@ opcodes:
       flag4: true
     billing:
       byByte:
-        type: TYPE_4
         bytePrice: G_LOG_DATA
   - mnemonic: CREATE
     value: 0xf0
@@ -1275,7 +1260,6 @@ opcodes:
       flag1: true
     billing:
       byWord:
-        type: TYPE_4
         wordPrice: G_CONST_INIT_CODE_WORD
   - mnemonic: CALL
     value: 0xf1
@@ -1290,7 +1274,6 @@ opcodes:
       flag1: true
     billing:
       byMxp:
-        type: TYPE_5
   - mnemonic: CALLCODE
     value: 0xf2
     instructionFamily: CALL
@@ -1303,7 +1286,6 @@ opcodes:
       flag2: true
     billing:
       byMxp:
-        type: TYPE_5
   - mnemonic: RETURN
     value: 0xf3
     instructionFamily: HALT
@@ -1315,7 +1297,6 @@ opcodes:
       flag1: true
     billing:
       byByte:
-        type: TYPE_4
         bytePrice: G_CODE_DEPOSIT
   - mnemonic: DELEGATECALL
     value: 0xf4
@@ -1329,7 +1310,6 @@ opcodes:
       flag3: true
     billing:
       byMxp:
-        type: TYPE_5
   - mnemonic: CREATE2
     value: 0xf5
     instructionFamily: CREATE
@@ -1343,7 +1323,6 @@ opcodes:
       flag2: true
     billing:
       byWord:
-        type: TYPE_4
         wordPrice: G_CONST_INIT_CODE_WORD_CREATE2
   - mnemonic: STATICCALL
     value: 0xfa
@@ -1357,7 +1336,6 @@ opcodes:
       flag4: true
     billing:
       byMxp:
-        type: TYPE_5
   - mnemonic: REVERT
     value: 0xfd
     instructionFamily: HALT
@@ -1369,7 +1347,6 @@ opcodes:
       flag2: true
     billing:
       byMxp:
-        type: TYPE_4
   - mnemonic: INVALID
     value: 0xfe
     instructionFamily: INVALID

--- a/arithmetization/src/main/resources/cancunOpcodes.yml
+++ b/arithmetization/src/main/resources/cancunOpcodes.yml
@@ -222,6 +222,7 @@ opcodes:
       alpha: 1
       delta: 2
       staticGas: G_KECCAK_256
+    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_KECCAK_256_WORD
@@ -297,6 +298,7 @@ opcodes:
       delta: 3
       staticGas: G_VERY_LOW
       flag1: true
+    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_COPY
@@ -318,6 +320,7 @@ opcodes:
       delta: 3
       staticGas: G_VERY_LOW
       flag3: true
+    mxpFlagFlag: true
     billing:
       byWord:
         wordPrice: G_COPY
@@ -348,6 +351,7 @@ opcodes:
       delta: 4
       staticGas: G_ZERO
       flag4: true
+    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_COPY
@@ -368,6 +372,7 @@ opcodes:
       delta: 3
       staticGas: G_VERY_LOW
       flag2: true
+    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_COPY
@@ -496,8 +501,7 @@ opcodes:
       delta: 1
       staticGas: G_VERY_LOW
       flag2: true
-    billing:
-      byMxp:
+    mxpFlag: true
   - mnemonic: MSTORE
     value: 0x52
     instructionFamily: STACK_RAM
@@ -507,8 +511,7 @@ opcodes:
       delta: 2
       staticGas: G_VERY_LOW
       flag3: true
-    billing:
-      byMxp:
+    mxpFlag: true
   - mnemonic: MSTORE8
     value: 0x53
     instructionFamily: STACK_RAM
@@ -518,8 +521,7 @@ opcodes:
       delta: 2
       staticGas: G_VERY_LOW
       flag4: true
-    billing:
-      byMxp:
+    mxpFlag: true
   - mnemonic: SLOAD
     value: 0x54
     instructionFamily: STORAGE
@@ -575,8 +577,7 @@ opcodes:
       delta: 0
       staticGas: G_BASE
       flag2: true
-    billing:
-      byMxp:
+    mxpFlag: true
   - mnemonic: GAS
     value: 0x5a
     instructionFamily: MACHINE_STATE
@@ -622,6 +623,7 @@ opcodes:
       alpha: 0
       delta: 3
       staticGas: G_VERY_LOW
+    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_COPY
@@ -1188,6 +1190,7 @@ opcodes:
       staticGas: G_LOG_0
       twoLineInstruction: true
       forbiddenInStatic: true
+    mxpFlag: true
     billing:
       byByte:
         bytePrice: G_LOG_DATA
@@ -1202,6 +1205,7 @@ opcodes:
       twoLineInstruction: true
       forbiddenInStatic: true
       flag1: true
+    mxpFlag: true
     billing:
       byByte:
         bytePrice: G_LOG_DATA
@@ -1216,6 +1220,7 @@ opcodes:
       twoLineInstruction: true
       forbiddenInStatic: true
       flag2: true
+    mxpFlag: true
     billing:
       byByte:
         bytePrice: G_LOG_DATA
@@ -1230,6 +1235,7 @@ opcodes:
       twoLineInstruction: true
       forbiddenInStatic: true
       flag3: true
+    mxpFlag: true
     billing:
       byByte:
         bytePrice: G_LOG_DATA
@@ -1244,6 +1250,7 @@ opcodes:
       twoLineInstruction: true
       forbiddenInStatic: true
       flag4: true
+    mxpFlag: true
     billing:
       byByte:
         bytePrice: G_LOG_DATA
@@ -1258,6 +1265,7 @@ opcodes:
       twoLineInstruction: true
       forbiddenInStatic: true
       flag1: true
+    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_CONST_INIT_CODE_WORD
@@ -1272,8 +1280,7 @@ opcodes:
       twoLineInstruction: true
       forbiddenInStatic: true
       flag1: true
-    billing:
-      byMxp:
+    mxpFlag: true
   - mnemonic: CALLCODE
     value: 0xf2
     instructionFamily: CALL
@@ -1284,8 +1291,7 @@ opcodes:
       staticGas: S_CALL
       twoLineInstruction: true
       flag2: true
-    billing:
-      byMxp:
+    mxpFlag: true
   - mnemonic: RETURN
     value: 0xf3
     instructionFamily: HALT
@@ -1295,6 +1301,7 @@ opcodes:
       delta: 2
       staticGas: G_ZERO
       flag1: true
+    mxpFlag: true
     billing:
       byByte:
         bytePrice: G_CODE_DEPOSIT
@@ -1308,8 +1315,7 @@ opcodes:
       staticGas: S_CALL
       twoLineInstruction: true
       flag3: true
-    billing:
-      byMxp:
+    mxpFlag: true
   - mnemonic: CREATE2
     value: 0xf5
     instructionFamily: CREATE
@@ -1321,6 +1327,7 @@ opcodes:
       twoLineInstruction: true
       forbiddenInStatic: true
       flag2: true
+    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_CONST_INIT_CODE_WORD_CREATE2
@@ -1334,8 +1341,7 @@ opcodes:
       staticGas: S_CALL
       twoLineInstruction: true
       flag4: true
-    billing:
-      byMxp:
+    mxpFlag: true
   - mnemonic: REVERT
     value: 0xfd
     instructionFamily: HALT
@@ -1345,8 +1351,7 @@ opcodes:
       delta: 2
       staticGas: G_ZERO
       flag2: true
-    billing:
-      byMxp:
+    mxpFlag: true
   - mnemonic: INVALID
     value: 0xfe
     instructionFamily: INVALID

--- a/arithmetization/src/main/resources/cancunOpcodes.yml
+++ b/arithmetization/src/main/resources/cancunOpcodes.yml
@@ -320,7 +320,7 @@ opcodes:
       delta: 3
       staticGas: G_VERY_LOW
       flag3: true
-    mxpFlagFlag: true
+    mxpFlag: true
     billing:
       byWord:
         wordPrice: G_COPY


### PR DESCRIPTION
Closes #2111 
Closes #2124 

- remove types1/2/etc from Cancun
- replaced by isMxp() method to determine Mxp
- fill the instruction decoder columns
- use new OpCodeData methods in Mxp module as well
- make Billing deserializer fork dependent