### PR TITLE
chore: update actions, pin to sha, add dependabot

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -18,10 +18,13 @@ runs:
   steps:
       - name: Setup upterm session
         if: ${{ inputs.enable-ssh == 'true' }}
-        uses: lhotari/action-upterm@v1
+        uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 #v1
 
       - name: Install Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: '1.23.5'
+          cache-dependency-path: "**/*.sum"
 
       - name: Get Submodules
         shell: bash

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -21,14 +21,14 @@ runs:
         uses: lhotari/action-upterm@v1
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
 
       - name: Get Submodules
         shell: bash
         run: git submodule update --init --recursive linea-constraints
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: 21
           distribution: temurin

--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -5,7 +5,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install Go
-      uses: actions/setup-go@v5.1.0
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
 
     - name: Install Go Corset
       shell: bash

--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -6,6 +6,9 @@ runs:
   steps:
     - name: Install Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      with:
+        go-version: '1.23.5'
+        cache-dependency-path: "**/*.sum"
 
     - name: Install Go Corset
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[dependabot] "
+      include: "scope"

--- a/.github/workflows/gradle-besu-node-tests.yml
+++ b/.github/workflows/gradle-besu-node-tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: false
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload proof request and conflation files
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: traces-proof-requests-${{ github.sha }}
           path: arithmetization/build/besu/traces/**/*

--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
 
@@ -32,28 +32,28 @@ jobs:
 
       - name: Upload test report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: nightly-tests-report-LONDON
           path: arithmetization/build/reports/tests/**/*
 
       - name: Upload jacoco nightly tests coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jacoco-nightly-tests-coverage-report-LONDON
           path: arithmetization/build/reports/jacoco/jacocoNightlyTestsReport/**/*
 
       - name: Upload jacoco nightly tests exec file
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jacoco-nightly-tests-exec-file-LONDON
           path: arithmetization/build/jacoco/nightlyTests.exec
 
       - name: Failure Notification
         if: github.ref == 'refs/heads/arith-dev' && (failure() || cancelled())
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger

--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: false
 
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/actions/setup-environment
 
       - name: Set up GCC
-        uses: egor-tensin/setup-gcc@v1
+        uses: egor-tensin/setup-gcc@eaa888eb19115a521fa72b65cd94fe1f25bbcaac #v1.3
 
       - name: Build without tests
         run: ./gradlew build -x test -x spotlessCheck
@@ -42,7 +42,7 @@ jobs:
           JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false
 
       - name: Store distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: distributions
           path: arithmetization/build/libs
@@ -82,7 +82,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: false
 
@@ -102,21 +102,21 @@ jobs:
 
       - name: Upload test report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: replay-tests-report
           path: arithmetization/build/reports/tests/**/*
 
       - name: Upload jacoco fast replay tests coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jacoco-fast-replay-tests-coverage-report
           path: arithmetization/build/reports/jacoco/jacocoFastReplayTestsReport/**/*
 
       - name: Upload jacoco fast replay tests exec file
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jacoco-fast-replay-tests-exec-file
           path: arithmetization/build/jacoco/fastReplayTests.exec

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -6,5 +6,5 @@ jobs:
     name: "Validation"
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
     steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: gradle/actions/wrapper-validation@ac638b010cf58a27ee6c972d7336334ccaf61c96 #v4.4.1

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -17,14 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: false
 
       - name: Setup Environment
         # setup go-corset
         uses: ./.github/actions/setup-environment
-        
+
       - name: Configure Tag
         id: config
         # set tag to use in subsequent steps.
@@ -40,7 +40,7 @@ jobs:
       - name: Upload Assets
         run: |
           gh release upload ${{ steps.config.outputs.TAG }} $jar_asset
-          gh release upload ${{ steps.config.outputs.TAG }} $zip_asset          
+          gh release upload ${{ steps.config.outputs.TAG }} $zip_asset
         env:
           jar_asset: ${{ github.workspace }}/plugins/build/libs/linea-tracer-${{ steps.config.outputs.TAG }}.jar
           zip_asset: ${{ github.workspace }}/plugins/build/distributions/linea-tracer-${{ steps.config.outputs.TAG }}.zip
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/reusable-blockchain-tests.yml
+++ b/.github/workflows/reusable-blockchain-tests.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
       - name: get-branch-name
@@ -45,7 +45,7 @@ jobs:
           JAVA_OPTS: -Dorg.gradle.daemon=false
 
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
         if: ${{ inputs.failed_module != '' }}
         with:
           name: failedBlockchainReferenceTests.json
@@ -74,28 +74,28 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: failedBlockchainReferenceTests-${{ inputs.zkevm_fork }}.json
           path: ${{ github.workspace }}/tmp/${{ steps.extract_branch.outputs.branch }}/
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: blockchain-refrence-tests-report-${{ inputs.zkevm_fork }}
           path: reference-tests/build/reports/tests/**/*
 
       - name: Upload jacoco blockchain tests coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jacoco-blockchain-tests-coverage-report-${{ inputs.zkevm_fork }}
           path: reference-tests/build/reports/jacoco/jacocoReferenceBlockchainTestsReport/**/*
 
       - name: Upload jacoco blockchain tests exec file
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jacoco-blockchain-tests-exec-file-${{ inputs.zkevm_fork }}
           path: reference-tests/build/jacoco/referenceBlockchainTests.exec
@@ -118,7 +118,7 @@ jobs:
 
       - name: Failure Notification
         if: github.ref == 'refs/heads/arith-dev' && (failure() || cancelled())
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: false
 
@@ -38,21 +38,21 @@ jobs:
 
       - name: Upload test report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: unit-tests-report-${{ inputs.zkevm_fork }}
           path: arithmetization/build/reports/tests/**/*
 
       - name: Upload jacoco unit tests coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jacoco-unit-tests-coverage-report-${{ inputs.zkevm_fork }}
           path: arithmetization/build/reports/jacoco/test/**/*
 
       - name: Upload jacoco unit tests exec file
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jacoco-unit-tests-exec-file-${{ inputs.zkevm_fork }}
           path: arithmetization/build/jacoco/test.exec

--- a/.github/workflows/reusable-weekly-prc-tests.yml
+++ b/.github/workflows/reusable-weekly-prc-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
 
@@ -32,28 +32,28 @@ jobs:
 
       - name: Upload prc calls test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: prc-call-tests-report-${{ inputs.zkevm_fork }}
           path: arithmetization/build/reports/tests/**/*
 
       - name: Upload jacoco weekly prc-call tests coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jacoco-prc-call-tests-coverage-report-${{ inputs.zkevm_fork }}
           path: arithmetization/build/reports/jacoco/jacocoPrcCallTestsReport/**/*
 
       - name: Upload jacoco weekly prc-call tests exec file
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jacoco-prc-call-tests-exec-file-${{ inputs.zkevm_fork }}
           path: arithmetization/build/jacoco/prcCallTests.exec
 
       - name: Failure Notification
         if: github.ref == 'refs/heads/arith-dev' && (failure() || cancelled())
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger

--- a/.github/workflows/reusable-weekly-tests.yml
+++ b/.github/workflows/reusable-weekly-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
 
@@ -31,28 +31,28 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: weekly-tests-report-${{ inputs.zkevm_fork }}
           path: arithmetization/build/reports/tests/**/*
 
       - name: Upload jacoco weekly tests coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jacoco-weekly-tests-coverage-report-${{ inputs.zkevm_fork }}
           path: arithmetization/build/reports/jacoco/jacocoWeeklyTestsReport/**/*
 
       - name: Upload jacoco weekly tests exec file
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jacoco-weekly-tests-exec-file-${{ inputs.zkevm_fork }}
           path: arithmetization/build/jacoco/weeklyTests.exec
 
       - name: Failure Notification
         if: github.ref == 'refs/heads/arith-dev' && (failure() || cancelled())
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger

--- a/.github/workflows/validate-one-blockchain-test.yml
+++ b/.github/workflows/validate-one-blockchain-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
 


### PR DESCRIPTION
>Pinning version of actions and language versions, this prevents supply chain attacks and breaking changes in actions/caching/etc, so they are the same every run, instead of latest of that version

> Dependabot will update the action if needed, but for this example v4 is  v.4.2.1 of 3 weeks ago was originally v4.0.0, then v4.0.1 , v4.1.0  etc...