### PR TITLE
temp: disable cancun unit tests with identified root causes pending m…

### DIFF
--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleMultiBlockTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ExampleMultiBlockTest.java
@@ -46,6 +46,7 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.evm.log.Log;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.web3j.abi.EventEncoder;
@@ -57,6 +58,9 @@ import org.web3j.abi.datatypes.generated.Uint256;
 @ExtendWith(UnitTestWatcher.class)
 class ExampleMultiBlockTest extends TracerTestBase {
 
+  // TODO: enable back when this issue is fixed
+  // https://github.com/Consensys/linea-tracer/issues/2193
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   void test() {
     final ToyAccount receiverAccount =

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfGasExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfGasExceptionTest.java
@@ -32,6 +32,7 @@ import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.BytecodeRunner;
 import net.consensys.linea.testing.ToyAccount;
+import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.opcode.OpCodes;
@@ -53,6 +54,12 @@ public class OutOfGasExceptionTest extends TracerTestBase {
   void outOfGasExceptionWithEmptyAccountsAndNoMemoryExpansionCostTest(int opcode, int cornerCase) {
     // Ensure opcodes relevant to the given fork are loaded.
     loadOpcodes(fork);
+    // TODO: enable SELFDESTRUCT for Cancun again after fixing the issue
+    // https://github.com/Consensys/linea-tracer/issues/2159
+    // PR https://github.com/Consensys/linea-tracer/pull/2184
+    if (fork == Fork.CANCUN && opcode == OpCode.SELFDESTRUCT.byteValue()) {
+      return;
+    }
     //
     OpCodeData opCodeData = OpCodes.of(opcode);
     // Only test opcodes which do not cause memory expansion.

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfGasExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfGasExceptionTest.java
@@ -57,7 +57,7 @@ public class OutOfGasExceptionTest extends TracerTestBase {
     // TODO: enable SELFDESTRUCT for Cancun again after fixing the issue
     // https://github.com/Consensys/linea-tracer/issues/2159
     // PR https://github.com/Consensys/linea-tracer/pull/2184
-    if (fork == Fork.CANCUN && opcode == OpCode.SELFDESTRUCT.byteValue()) {
+    if (fork == Fork.CANCUN && opcode == 255) {
       return;
     }
     //

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/StackUnderflowExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/StackUnderflowExceptionTest.java
@@ -25,6 +25,7 @@ import net.consensys.linea.UnitTestWatcher;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.BytecodeRunner;
+import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.opcode.OpCodes;
@@ -40,6 +41,12 @@ public class StackUnderflowExceptionTest extends TracerTestBase {
   @MethodSource("stackUnderflowExceptionSource")
   void stackUnderflowExceptionTest(
       OpCode opCode, int nPushes, boolean triggersStackUnderflowExceptions) {
+    // TODO: enable SELFDESTRUCT for Cancun again after fixing the issue
+    // https://github.com/Consensys/linea-tracer/issues/2159
+    // PR https://github.com/Consensys/linea-tracer/pull/2184
+    if (fork == Fork.CANCUN && opCode == OpCode.SELFDESTRUCT && !triggersStackUnderflowExceptions) {
+      return;
+    }
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     for (int i = 0; i < nPushes; i++) {
       program.push(0);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/advanced/InitCodeTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/advanced/InitCodeTests.java
@@ -36,10 +36,14 @@ import org.hyperledger.besu.crypto.Hash;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.web3j.abi.EventEncoder;
 
+// TODO: enable again once this issue is done :
+// https://github.com/Consensys/linea-tracer/issues/2190
+@Tag("disabled-for-cancun-temporarily")
 @ExtendWith(UnitTestWatcher.class)
 public class InitCodeTests extends TracerTestBase {
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/advanced/StorageNoOpTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/createTests/advanced/StorageNoOpTests.java
@@ -26,10 +26,12 @@ import net.consensys.linea.testing.SmartContractUtils;
 import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.generated.Factory;
+import net.consensys.linea.zktracer.Fork;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -68,6 +70,10 @@ public class StorageNoOpTests extends TracerTestBase {
           .code(SmartContractUtils.getSolidityContractRuntimeByteCode(Factory.class))
           .build();
 
+  // TODO: enable for Cancun again after fixing the issue
+  // https://github.com/Consensys/linea-tracer/issues/2159
+  // PR https://github.com/Consensys/linea-tracer/pull/2184
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   public void simpleTest() {
 
@@ -87,6 +93,14 @@ public class StorageNoOpTests extends TracerTestBase {
           SelfDestruct selfdestruct,
           Revert revert) {
 
+    // TODO: enable for Cancun again after fixing the issue
+    // https://github.com/Consensys/linea-tracer/issues/2159
+    // PR https://github.com/Consensys/linea-tracer/pull/2184
+    if (fork == Fork.CANCUN
+        && selfdestruct == SelfDestruct.SELF_DESTRUCT
+        && revert == Revert.DONT_REVERT) {
+      return;
+    }
     testBody(touchStorage, modifyStorage, selfdestruct, revert);
   }
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/RepeatedSelfDestructsOfSameAccountTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/RepeatedSelfDestructsOfSameAccountTests.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.TransactionType;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -322,6 +323,10 @@ public class RepeatedSelfDestructsOfSameAccountTests extends TracerTestBase {
     run(testInfo, heir);
   }
 
+  // TODO: enable for Cancun again after fixing the issue
+  // https://github.com/Consensys/linea-tracer/issues/2159
+  // PR https://github.com/Consensys/linea-tracer/pull/2184
+  @Tag("disabled-for-cancun-temporarily")
   @ParameterizedTest
   @EnumSource(Heir.class)
   public void basicSelfDestruct(Heir heir) {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/SelfdestructCoinbaseTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/selfdestructTests/SelfdestructCoinbaseTests.java
@@ -30,6 +30,7 @@ import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.ToyTransaction;
+import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.crypto.KeyPair;
@@ -56,6 +57,16 @@ public class SelfdestructCoinbaseTests extends TracerTestBase {
       boolean recipientCoinbaseCollision,
       boolean coinBaseDeployed,
       boolean revertingTransaction) {
+
+    // TODO: enable SELFDESTRUCT for Cancun again after fixing the issue
+    // https://github.com/Consensys/linea-tracer/issues/2159
+    // PR https://github.com/Consensys/linea-tracer/pull/2184
+    if (fork == Fork.CANCUN
+        && !rootIsDeployment
+        && recipientCoinbaseCollision
+        && coinBaseDeployed) {
+      return;
+    }
 
     final ToyAccount CHECKING_COINBASE =
         ToyAccount.builder()

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/blockhash/BlockhashTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/blockhash/BlockhashTest.java
@@ -29,6 +29,7 @@ import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.BytecodeRunner;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -161,6 +162,9 @@ public class BlockhashTest extends TracerTestBase {
     multiBlocksTest(List.of(program1, program2));
   }
 
+  // TODO: enable this test once this fix is merged
+  // https://github.com/Consensys/linea-tracer/pull/2189
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   void blockhashArgumentLowerRangeCheckMultiBlockTest() {
     Bytes fillerProgram = BytecodeCompiler.newProgram(testInfo).op(OpCode.COINBASE).compile();

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/TxSkipTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/hub/TxSkipTests.java
@@ -34,12 +34,16 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.TransactionType;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(UnitTestWatcher.class)
 public class TxSkipTests extends TracerTestBase {
 
+  // TODO: enable back when this issue is fixed
+  // https://github.com/Consensys/linea-tracer/issues/2193
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   void testUselessAccessListForTxSkip() {
     final ToyAccount receiverAccount =

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/stp/StpTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/stp/StpTest.java
@@ -40,6 +40,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.TransactionType;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -56,6 +57,9 @@ public class StpTest extends TracerTestBase {
 
   private final long SENDER_BALANCE = 0xFFFFFFFFFFFFL;
 
+  // TODO: enable this test once this fix is merged
+  // https://github.com/Consensys/linea-tracer/pull/2189
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   void testCall() {
     List<ToyAccount> accounts = new ArrayList<>();
@@ -82,6 +86,9 @@ public class StpTest extends TracerTestBase {
         .run();
   }
 
+  // TODO: enable this test once this fix is merged
+  // https://github.com/Consensys/linea-tracer/pull/2189
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   void testCreate() {
     List<ToyAccount> world = new ArrayList<>();

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/trm/TrmTracerTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/trm/TrmTracerTest.java
@@ -86,6 +86,8 @@ public class TrmTracerTest extends TracerTestBase {
               + "00000000"
               + "00000000");
 
+  // TODO: enable for Cancun once KZG precomp has been added to address precomp list
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   void testNonCallTinyParamLessThan16() {
     for (int tiny = 0; tiny < 16; tiny++) {
@@ -100,6 +102,8 @@ public class TrmTracerTest extends TracerTestBase {
     }
   }
 
+  // TODO: enable for Cancun once KZG precomp has been added to address precomp list
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   void testNonCallAddressParameterTinyAfterTrimming() {
     for (int tiny = 0; tiny < 16; tiny++) {
@@ -139,6 +143,8 @@ public class TrmTracerTest extends TracerTestBase {
         .run(testInfo);
   }
 
+  // TODO: enable for Cancun once KZG precomp has been added to address precomp list
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   void testTrimToUncoverATinyAddressAndQueryItsBalanceCodeHashAndCodeSize() {
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/trm/TrmTracerTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/trm/TrmTracerTest.java
@@ -24,6 +24,7 @@ import net.consensys.linea.testing.BytecodeRunner;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -114,6 +115,8 @@ public class TrmTracerTest extends TracerTestBase {
     nonCall(RANDOM_STRING_FROM_THE_INTERNET);
   }
 
+  // TODO: enable for Cancun once KZG precomp has been added to address precomp list
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   void testSevenArgCall() {
     for (int addr = 0; addr < 16; addr++) {
@@ -121,6 +124,8 @@ public class TrmTracerTest extends TracerTestBase {
     }
   }
 
+  // TODO: enable for Cancun once KZG precomp has been added to address precomp list
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   void testSampleDelegateCall() {
     for (long addr = 0; addr < 16; addr++) {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/RipTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/RipTests.java
@@ -41,6 +41,7 @@ public class RipTests extends TracerTestBase {
   void basicRipTest(int size) {
 
     // TODO: reenable for Cancun once fix is merged
+    // https://github.com/Consensys/linea-constraints/pull/730
     if (fork == Fork.CANCUN && size == HUGE_SIZE) {
       return;
     }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/RipTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/RipTests.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.BytecodeRunner;
+import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -38,6 +39,12 @@ public class RipTests extends TracerTestBase {
   @ParameterizedTest
   @MethodSource("sizes")
   void basicRipTest(int size) {
+
+    // TODO: reenable for Cancun once fix is merged
+    if (fork == Fork.CANCUN && size == HUGE_SIZE) {
+      return;
+    }
+
     final Bytes bytecode =
         BytecodeCompiler.newProgram(testInfo)
             .push(Bytes.fromHexString("0x0badb077")) // value, some random data to hash

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/BlockwiseDeplNoTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/BlockwiseDeplNoTest.java
@@ -29,11 +29,13 @@ import net.consensys.linea.zktracer.module.hub.fragment.TraceFragment;
 import net.consensys.linea.zktracer.module.hub.fragment.account.AccountFragment;
 import net.consensys.linea.zktracer.module.hub.section.TraceSection;
 import org.hyperledger.besu.datatypes.Address;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 public class BlockwiseDeplNoTest extends TracerTestBase {
   TestContext tc;
 
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   void testBlockwiseDeplNo() {
     // initialize the test context

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/ConflationAccountTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/ConflationAccountTest.java
@@ -27,11 +27,13 @@ import net.consensys.linea.testing.TransactionProcessingResultValidator;
 import net.consensys.linea.zktracer.module.hub.fragment.account.AccountFragment;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 public class ConflationAccountTest extends TracerTestBase {
   TestContext tc;
 
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   void testConflationMapAccount() {
     // initialize the test context

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/ConflationStorageTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/ConflationStorageTest.java
@@ -27,11 +27,13 @@ import net.consensys.linea.zktracer.module.hub.fragment.storage.StorageFragment;
 import net.consensys.linea.zktracer.types.EWord;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Address;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 public class ConflationStorageTest extends TracerTestBase {
   TestContext tc;
 
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   void testConflationMapStorage() {
     // initialize the test context

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/UtilitiesTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/UtilitiesTest.java
@@ -21,11 +21,16 @@ import java.util.List;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.MultiBlockExecutionEnvironment;
 import net.consensys.linea.testing.TransactionProcessingResultValidator;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 public class UtilitiesTest extends TracerTestBase {
   TestContext tc;
 
+  // TODO: enable SELFDESTRUCT for Cancun again after fixing the issue
+  // https://github.com/Consensys/linea-tracer/issues/2159
+  // PR https://github.com/Consensys/linea-tracer/pull/2184
+  @Tag("disabled-for-cancun-temporarily")
   @Test
   void testBuildingBlockOperations() {
     // initialize the test context

--- a/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
+++ b/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
@@ -30,7 +30,7 @@ public class TracerTestBase {
   @BeforeEach
   public void init(TestInfo testInfo) {
       TracerTestBase.testInfo.chainConfig =
-              switch (getForkOrDefault("CANCUN")) {
+              switch (getForkOrDefault("LONDON")) {
               case "LONDON" -> ChainConfig.MAINNET_TESTCONFIG(LONDON);
               case "PARIS" -> ChainConfig.MAINNET_TESTCONFIG(PARIS);
               case "SHANGHAI" -> ChainConfig.MAINNET_TESTCONFIG(SHANGHAI);

--- a/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
+++ b/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
@@ -30,7 +30,7 @@ public class TracerTestBase {
   @BeforeEach
   public void init(TestInfo testInfo) {
       TracerTestBase.testInfo.chainConfig =
-              switch (getForkOrDefault("LONDON")) {
+              switch (getForkOrDefault("CANCUN")) {
               case "LONDON" -> ChainConfig.MAINNET_TESTCONFIG(LONDON);
               case "PARIS" -> ChainConfig.MAINNET_TESTCONFIG(PARIS);
               case "SHANGHAI" -> ChainConfig.MAINNET_TESTCONFIG(SHANGHAI);


### PR DESCRIPTION
…erge

I am disabling Cancun unit tests that have identified root causes that have pending PRs to be merged to have Cancun pass and identify new tests that are breaking with new PR more easily

Root causes are mainly 
- the selfdestruct bug flagged in an issue, pending PR https://github.com/Consensys/linea-tracer/pull/2184
- a comparison method fix in InstructionByteStringPrefix https://github.com/Consensys/linea-tracer/pull/2189/files
- merging KZG PR to have precomp section added in list + isAddressWarm PR https://github.com/Consensys/linea-tracer/pull/2152
- look up edge case, either change spec or tracer https://github.com/Consensys/linea-specification/issues/233
- Advanced create test 1 transaction, issue opened https://github.com/Consensys/linea-tracer/issues/2190
- constraint PR for resA and resB in mxp https://github.com/Consensys/linea-constraints/pull/730