### PR TITLE
fix: resA and resB in mxp to bytes

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/moduleOperation/CancunMxpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/moduleOperation/CancunMxpOperation.java
@@ -16,7 +16,6 @@
 package net.consensys.linea.zktracer.module.mxp.moduleOperation;
 
 import static net.consensys.linea.zktracer.module.mxp.MxpUtils.*;
-import static net.consensys.linea.zktracer.types.Conversions.bytesToLong;
 
 import lombok.Getter;
 import net.consensys.linea.zktracer.Trace;
@@ -139,7 +138,7 @@ public class CancunMxpOperation extends MxpOperation {
           .pComputationArg2Hi(cancunMxpCall.exoCalls[i].arg2Hi())
           .pComputationArg2Lo(cancunMxpCall.exoCalls[i].arg2Lo())
           .pComputationResA(cancunMxpCall.exoCalls[i].resultA())
-          .pComputationResB(bytesToLong(cancunMxpCall.exoCalls[i].resultB()))
+          .pComputationResB(cancunMxpCall.exoCalls[i].resultB())
           .fillAndValidateRow();
     }
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/moduleOperation/CancunMxpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/moduleOperation/CancunMxpOperation.java
@@ -138,7 +138,7 @@ public class CancunMxpOperation extends MxpOperation {
           .pComputationArg1Lo(cancunMxpCall.exoCalls[i].arg1Lo())
           .pComputationArg2Hi(cancunMxpCall.exoCalls[i].arg2Hi())
           .pComputationArg2Lo(cancunMxpCall.exoCalls[i].arg2Lo())
-          .pComputationResA(bytesToLong(cancunMxpCall.exoCalls[i].resultA()))
+          .pComputationResA(cancunMxpCall.exoCalls[i].resultA())
           .pComputationResB(bytesToLong(cancunMxpCall.exoCalls[i].resultB()))
           .fillAndValidateRow();
     }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/RipTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/RipTests.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.BytecodeRunner;
-import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -39,13 +38,6 @@ public class RipTests extends TracerTestBase {
   @ParameterizedTest
   @MethodSource("sizes")
   void basicRipTest(int size) {
-
-    // TODO: reenable for Cancun once fix is merged
-    // https://github.com/Consensys/linea-constraints/pull/730
-    if (fork == Fork.CANCUN && size == HUGE_SIZE) {
-      return;
-    }
-
     final Bytes bytecode =
         BytecodeCompiler.newProgram(testInfo)
             .push(Bytes.fromHexString("0x0badb077")) // value, some random data to hash


### PR DESCRIPTION
- update constraints with fix
- reenable failing Cancun unit test