### PR TITLE
fix: ensure loadOpcodes() called by BlockCapturer

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/blockcapture/BlockCapturer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/blockcapture/BlockCapturer.java
@@ -21,7 +21,9 @@ import java.util.Set;
 import com.google.gson.Gson;
 import net.consensys.linea.blockcapture.reapers.Reaper;
 import net.consensys.linea.zktracer.ConflationAwareOperationTracer;
+import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodes;
 import net.consensys.linea.zktracer.types.AddressUtils;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -52,6 +54,15 @@ public class BlockCapturer implements ConflationAwareOperationTracer {
    * minimal required information to replay the conflation.
    */
   private WorldUpdater worldUpdater;
+
+  /**
+   * Construct a BlockCapturer instance for a specific fork.  This is necessary to ensure opcodes are loaded before
+   * hand.
+   * @param fork
+   */
+  public BlockCapturer(Fork fork) {
+    OpCodes.loadOpcodes(fork);
+  }
 
   /**
    * Must be called **before** any tracing activity.

--- a/arithmetization/src/main/java/net/consensys/linea/blockcapture/BlockCapturer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/blockcapture/BlockCapturer.java
@@ -56,8 +56,9 @@ public class BlockCapturer implements ConflationAwareOperationTracer {
   private WorldUpdater worldUpdater;
 
   /**
-   * Construct a BlockCapturer instance for a specific fork.  This is necessary to ensure opcodes are loaded before
-   * hand.
+   * Construct a BlockCapturer instance for a specific fork. This is necessary to ensure opcodes are
+   * loaded before hand.
+   *
    * @param fork
    */
   public BlockCapturer(Fork fork) {

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/capture/CaptureToFile.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/capture/CaptureToFile.java
@@ -18,23 +18,25 @@ package net.consensys.linea.plugins.rpc.capture;
 import com.google.common.base.Stopwatch;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.blockcapture.BlockCapturer;
+import net.consensys.linea.zktracer.Fork;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.TraceService;
 import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
 
 /**
- * Sets up an RPC endpoint for generating conflated file trace. This class provides an RPC endpoint
- * named 'generateConflatedTracesToFileV0' under the 'rollup' namespace. When this endpoint is
- * called, it triggers the execution of the 'execute' method, which generates conflated file traces
- * based on the provided request parameters and writes them to a file.
+ * Sets up an RPC endpoint for capturing a replay file.  This includes all information needed to replay a
+ * given conflation of blocks.  For example, it includes the values of all storage locations read whilst executing
+ * the conflation, the balances of all accounts accessed, etc.
  */
 @Slf4j
 public class CaptureToFile {
   private final ServiceManager besuContext;
   private TraceService traceService;
+  private final Fork fork;
 
-  public CaptureToFile(final ServiceManager besuContext) {
+  public CaptureToFile(final ServiceManager besuContext, Fork fork) {
     this.besuContext = besuContext;
+    this.fork = fork;
   }
 
   public String getNamespace() {
@@ -59,7 +61,7 @@ public class CaptureToFile {
     CaptureParams params = CaptureParams.createTraceParams(request.getParams());
     final long fromBlock = params.fromBlock();
     final long toBlock = params.toBlock();
-    final BlockCapturer tracer = new BlockCapturer();
+    final BlockCapturer tracer = new BlockCapturer(this.fork);
 
     Stopwatch sw = Stopwatch.createStarted();
     traceService.trace(

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/capture/CaptureToFile.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/capture/CaptureToFile.java
@@ -24,9 +24,9 @@ import org.hyperledger.besu.plugin.services.TraceService;
 import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
 
 /**
- * Sets up an RPC endpoint for capturing a replay file.  This includes all information needed to replay a
- * given conflation of blocks.  For example, it includes the values of all storage locations read whilst executing
- * the conflation, the balances of all accounts accessed, etc.
+ * Sets up an RPC endpoint for capturing a replay file. This includes all information needed to
+ * replay a given conflation of blocks. For example, it includes the values of all storage locations
+ * read whilst executing the conflation, the balances of all accounts accessed, etc.
  */
 @Slf4j
 public class CaptureToFile {

--- a/plugins/src/main/java/net/consensys/linea/plugins/rpc/capture/CaptureEndpointServicePlugin.java
+++ b/plugins/src/main/java/net/consensys/linea/plugins/rpc/capture/CaptureEndpointServicePlugin.java
@@ -43,7 +43,7 @@ public class CaptureEndpointServicePlugin extends AbstractLineaRequiredPlugin {
    */
   @Override
   public void doRegister(final ServiceManager context) {
-    CaptureToFile method = new CaptureToFile(context);
+    CaptureToFile method = new CaptureToFile(context, fork());
 
     RpcEndpointService service = BesuServiceProvider.getRpcEndpointService(context);
     createAndRegister(method, service);

--- a/testing/src/main/java/net/consensys/linea/testing/ReplayExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ReplayExecutionEnvironment.java
@@ -173,7 +173,7 @@ public class ReplayExecutionEnvironment {
     if (debugBlockCapturer) {
       // Initialise world state from conflation
       MutableWorldState world = initWorld(conflation);
-      capturer = new BlockCapturer();
+      capturer = new BlockCapturer(chain.fork);
       capturer.setWorld(world.updater());
       // Sequence zktracer and capturer
       tracer = ConflationAwareOperationTracer.sequence(tracer, capturer);


### PR DESCRIPTION
This ensures that the BlockCapturer calls `OpCodes.loadOpcodes()` with the fork before it starts capturing.  Previously, this did not occur and it resulted in exceptions arising during tracing.

At this stage, there remains an outstanding issue that the fork is currently fixed on LONDON, and is not determined from BESU.  That is a separate issue to be fix.