### PR TITLE
feat: refactor `OpCodes` API

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -15,7 +15,6 @@
 package net.consensys.linea.zktracer;
 
 import static net.consensys.linea.zktracer.ChainConfig.FORK_LINEA_CHAIN;
-import static net.consensys.linea.zktracer.opcode.OpCodes.loadOpcodes;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -84,7 +83,6 @@ public class ZkTracer implements LineCountingTracer {
    * @param chain
    */
   public ZkTracer(ChainConfig chain) {
-    loadOpcodes(chain.fork);
     this.chain = chain;
     this.hub =
         switch (chain.fork) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/CancunHub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/CancunHub.java
@@ -88,7 +88,7 @@ public class CancunHub extends ShanghaiHub {
 
   @Override
   protected InstructionDecoder setInstructionDecoder() {
-    return new CancunInstructionDecoder();
+    return new CancunInstructionDecoder(this.getOpcodes());
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/CancunHub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/CancunHub.java
@@ -88,7 +88,7 @@ public class CancunHub extends ShanghaiHub {
 
   @Override
   protected InstructionDecoder setInstructionDecoder() {
-    return new CancunInstructionDecoder(this.getOpcodes());
+    return new CancunInstructionDecoder(this.opCodes());
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -112,6 +112,7 @@ import net.consensys.linea.zktracer.module.txndata.module.TxnData;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
+import net.consensys.linea.zktracer.opcode.OpCodes;
 import net.consensys.linea.zktracer.opcode.gas.projector.GasProjector;
 import net.consensys.linea.zktracer.runtime.callstack.CallFrame;
 import net.consensys.linea.zktracer.runtime.callstack.CallFrameType;
@@ -139,8 +140,10 @@ import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 @Slf4j
 @Accessors(fluent = true)
 public abstract class Hub implements Module {
-
+  /** Active fork for this hub. */
   public final Fork fork;
+
+  private final OpCodes opcodes;
 
   /** The {@link GasCalculator} used in this version of the arithmetization */
   public final GasCalculator gasCalculator = setGasCalculator();
@@ -371,6 +374,7 @@ public abstract class Hub implements Module {
 
   public Hub(final ChainConfig chain) {
     fork = chain.fork;
+    opcodes = OpCodes.load(fork);
     checkState(chain.id.signum() >= 0);
     Address l2l1ContractAddress = chain.bridgeConfiguration.contract();
     final Bytes l2l1Topic = chain.bridgeConfiguration.topic();
@@ -611,7 +615,7 @@ public abstract class Hub implements Module {
 
     // internal transaction (CALL) or internal deployment (CREATE)
     if (frame.getDepth() > 0) {
-      final OpCode currentOpCode = callStack.currentCallFrame().opCode();
+      final OpCodeData currentOpCode = opcodes.of(callStack.currentCallFrame().opCode());
       final boolean isDeployment = frame.getType() == CONTRACT_CREATION;
 
       checkState(currentOpCode.isCall() || currentOpCode.isCreate());
@@ -685,7 +689,7 @@ public abstract class Hub implements Module {
     }
 
     defers.resolveUponContextExit(this, this.currentFrame());
-    if (this.currentFrame().opCode() == REVERT || Exceptions.any(pch.exceptions())) {
+    if (this.opCode() == REVERT || Exceptions.any(pch.exceptions())) {
       defers.resolveUponRollback(this, frame, this.currentFrame());
     }
 
@@ -739,7 +743,7 @@ public abstract class Hub implements Module {
 
     defers.resolvePostExecution(this, frame, operationResult);
 
-    if (isExceptional() || !opCode().isCallOrCreate()) {
+    if (isExceptional() || !opCodeData().isCallOrCreate()) {
       this.unlatchStack(frame, currentSection);
     }
   }
@@ -851,12 +855,27 @@ public abstract class Hub implements Module {
     return state.stamps().hub();
   }
 
+  /**
+   * Return information about the opcode being executed in the current call frame.
+   *
+   * @return
+   */
   public OpCodeData opCodeData() {
-    return this.currentFrame().opCodeData();
+    return opcodes.of(this.currentFrame().opCode());
+  }
+
+  /**
+   * Return information about the opcode being executed in a given message frame.
+   *
+   * @param frame
+   * @return
+   */
+  public OpCodeData opCodeData(MessageFrame frame) {
+    return opcodes.of(frame.getCurrentOperation().getOpcode());
   }
 
   public OpCode opCode() {
-    return this.currentFrame().opCode();
+    return opCodeData().mnemonic();
   }
 
   public TraceSection currentTraceSection() {
@@ -984,14 +1003,14 @@ public abstract class Hub implements Module {
       case MCOPY -> setMcopySection(this);
       case TRANSACTION -> new TransactionSection(this);
       case STACK_RAM -> {
-        switch (this.currentFrame().opCode()) {
+        switch (this.opCode()) {
           case CALLDATALOAD -> new CallDataLoadSection(this);
           case MLOAD, MSTORE, MSTORE8 -> new StackRamSection(this);
           default -> throw new IllegalStateException("unexpected STACK_RAM opcode");
         }
       }
       case STORAGE -> {
-        switch (this.currentFrame().opCode()) {
+        switch (this.opCode()) {
           case SSTORE -> new SstoreSection(this, frame.getWorldUpdater());
           case SLOAD -> new SloadSection(this, frame.getWorldUpdater());
           default -> throw new IllegalStateException("invalid operation in family STORAGE");
@@ -1101,4 +1120,9 @@ public abstract class Hub implements Module {
   protected abstract void traceSystemFinalTransaction();
 
   protected abstract void setSelfdestructSection(Hub hub, final MessageFrame frame);
+
+  /** Provides access to fork-specific opcode information. */
+  public OpCodes getOpcodes() {
+    return opcodes;
+  }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -143,7 +143,8 @@ public abstract class Hub implements Module {
   /** Active fork for this hub. */
   public final Fork fork;
 
-  private final OpCodes opcodes;
+  /** Active opcode information for this hub. */
+  @Getter private final OpCodes opCodes;
 
   /** The {@link GasCalculator} used in this version of the arithmetization */
   public final GasCalculator gasCalculator = setGasCalculator();
@@ -374,7 +375,7 @@ public abstract class Hub implements Module {
 
   public Hub(final ChainConfig chain) {
     fork = chain.fork;
-    opcodes = OpCodes.load(fork);
+    opCodes = OpCodes.load(fork);
     checkState(chain.id.signum() >= 0);
     Address l2l1ContractAddress = chain.bridgeConfiguration.contract();
     final Bytes l2l1Topic = chain.bridgeConfiguration.topic();
@@ -615,7 +616,7 @@ public abstract class Hub implements Module {
 
     // internal transaction (CALL) or internal deployment (CREATE)
     if (frame.getDepth() > 0) {
-      final OpCodeData currentOpCode = opcodes.of(callStack.currentCallFrame().opCode());
+      final OpCodeData currentOpCode = opCodes.of(callStack.currentCallFrame().opCode());
       final boolean isDeployment = frame.getType() == CONTRACT_CREATION;
 
       checkState(currentOpCode.isCall() || currentOpCode.isCreate());
@@ -861,7 +862,7 @@ public abstract class Hub implements Module {
    * @return
    */
   public OpCodeData opCodeData() {
-    return opcodes.of(this.currentFrame().opCode());
+    return opCodes.of(this.currentFrame().opCode());
   }
 
   /**
@@ -871,7 +872,7 @@ public abstract class Hub implements Module {
    * @return
    */
   public OpCodeData opCodeData(MessageFrame frame) {
-    return opcodes.of(frame.getCurrentOperation().getOpcode());
+    return opCodes.of(frame.getCurrentOperation().getOpcode());
   }
 
   public OpCode opCode() {
@@ -1120,9 +1121,4 @@ public abstract class Hub implements Module {
   protected abstract void traceSystemFinalTransaction();
 
   protected abstract void setSelfdestructSection(Hub hub, final MessageFrame frame);
-
-  /** Provides access to fork-specific opcode information. */
-  public OpCodes getOpcodes() {
-    return opcodes;
-  }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/LondonHub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/LondonHub.java
@@ -92,7 +92,7 @@ public class LondonHub extends Hub {
 
   @Override
   protected InstructionDecoder setInstructionDecoder() {
-    return new LondonInstructionDecoder();
+    return new LondonInstructionDecoder(this.getOpcodes());
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/LondonHub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/LondonHub.java
@@ -92,7 +92,7 @@ public class LondonHub extends Hub {
 
   @Override
   protected InstructionDecoder setInstructionDecoder() {
-    return new LondonInstructionDecoder(this.getOpcodes());
+    return new LondonInstructionDecoder(this.opCodes());
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
@@ -39,6 +39,7 @@ import net.consensys.linea.zktracer.module.hub.signals.TracedException;
 import net.consensys.linea.zktracer.module.hub.state.State;
 import net.consensys.linea.zktracer.opcode.InstructionFamily;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.opcode.gas.projector.GasProjection;
 import net.consensys.linea.zktracer.runtime.callstack.CallFrame;
 import net.consensys.linea.zktracer.runtime.callstack.CallStack;
@@ -110,7 +111,7 @@ public class CommonFragmentValues {
     this.gasNext = isExec ? computeGasNext(exceptions) : 0;
     this.gasCostExcluduingDeploymentCost = isExec ? computeGasCostExcludingDeploymentCost() : 0;
 
-    final InstructionFamily instructionFamily = hub.opCode().getData().instructionFamily();
+    final InstructionFamily instructionFamily = hub.opCodeData().instructionFamily();
     this.contextMayChange =
         hubProcessingPhase == HubProcessingPhase.TX_EXEC
             && ((instructionFamily == CALL
@@ -129,7 +130,7 @@ public class CommonFragmentValues {
       return;
     }
 
-    final OpCode opCode = hub.opCode();
+    final OpCodeData opCode = hub.opCodeData();
 
     if (Exceptions.staticFault(exceptions)) {
       checkArgument(opCode.mayTriggerStaticException());
@@ -138,13 +139,13 @@ public class CommonFragmentValues {
     }
 
     // RETURNDATACOPY opcode specific exception
-    if (opCode == OpCode.RETURNDATACOPY && Exceptions.returnDataCopyFault(exceptions)) {
+    if (opCode.mnemonic() == OpCode.RETURNDATACOPY && Exceptions.returnDataCopyFault(exceptions)) {
       setTracedException(TracedException.RETURN_DATA_COPY_FAULT);
       return;
     }
 
     // SSTORE opcode specific exception
-    if (opCode == OpCode.SSTORE && Exceptions.outOfSStore(exceptions)) {
+    if (opCode.mnemonic() == OpCode.SSTORE && Exceptions.outOfSStore(exceptions)) {
       setTracedException(TracedException.OUT_OF_SSTORE);
       return;
     }
@@ -152,7 +153,7 @@ public class CommonFragmentValues {
     // For RETURN, in case none of the above exceptions is the traced one,
     // we have a complex logic to determine the traced exception that is
     // implemented in the instruction processing
-    if (opCode == OpCode.RETURN) {
+    if (opCode.mnemonic() == OpCode.RETURN) {
       return;
     }
 
@@ -187,7 +188,7 @@ public class CommonFragmentValues {
   }
 
   static int computePcNew(final Hub hub, final int pc, boolean stackException, boolean isExec) {
-    final OpCode opCode = hub.opCode();
+    final OpCodeData opCode = hub.opCodeData();
     if (!isExec || stackException) {
       return 0;
     }
@@ -222,7 +223,7 @@ public class CommonFragmentValues {
     }
 
     throw new RuntimeException(
-        "Instruction not covered " + opCode.getData().mnemonic() + " unable to compute pcNew.");
+        "Instruction not covered " + opCode.mnemonic() + " unable to compute pcNew.");
   }
 
   public long computeGasRemaining() {
@@ -243,11 +244,13 @@ public class CommonFragmentValues {
   }
 
   private long computeGasCost() {
-    return hub.gasProjector.of(hub.messageFrame(), hub.opCode()).upfrontGasCost();
+    return hub.gasProjector.of(hub.messageFrame(), hub.opCodeData()).upfrontGasCost();
   }
 
   private long computeGasCostExcludingDeploymentCost() {
-    return hub.gasProjector.of(hub.messageFrame(), hub.opCode()).gasCostExcludingDeploymentCost();
+    return hub.gasProjector
+        .of(hub.messageFrame(), hub.opCodeData())
+        .gasCostExcludingDeploymentCost();
   }
 
   /**
@@ -297,11 +300,11 @@ public class CommonFragmentValues {
   }
 
   public void payGasPaidOutOfPocket(Hub hub) {
-    this.gasNext -= hub.gasProjector.of(hub.messageFrame(), hub.opCode()).gasPaidOutOfPocket();
+    this.gasNext -= hub.gasProjector.of(hub.messageFrame(), hub.opCodeData()).gasPaidOutOfPocket();
   }
 
   public void collectChildStipend(Hub hub) {
-    this.gasNext += hub.gasProjector.of(hub.messageFrame(), hub.opCode()).stipend();
+    this.gasNext += hub.gasProjector.of(hub.messageFrame(), hub.opCodeData()).stipend();
   }
 
   public long gasCostToTrace() {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
@@ -207,11 +207,11 @@ public class CommonFragmentValues {
       final int attemptedPcNew =
           codeSize.compareTo(prospectivePcNew) > 0 ? prospectivePcNew.intValueExact() : 0;
 
-      if (opCode.equals(OpCode.JUMP)) {
+      if (opCode.mnemonic().equals(OpCode.JUMP)) {
         return attemptedPcNew;
       }
 
-      if (opCode.equals(OpCode.JUMPI)) {
+      if (opCode.mnemonic().equals(OpCode.JUMPI)) {
         final BigInteger condition =
             hub.currentFrame().frame().getStackItem(1).toUnsignedBigInteger();
         if (!condition.equals(BigInteger.ZERO)) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/MxpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/MxpCall.java
@@ -70,7 +70,7 @@ public abstract class MxpCall implements TraceSubFragment {
     // set memorySizeInWords
     this.memorySizeInWords = this.hub.messageFrame().memoryWordSize();
     // set sizes and offsets
-    EWord[] sizesAndOffsets = getSizesAndOffsets(frame);
+    EWord[] sizesAndOffsets = getSizesAndOffsets(frame, this.opCodeData);
     this.size1 = sizesAndOffsets[0];
     this.offset1 = sizesAndOffsets[1];
     this.size2 = sizesAndOffsets[2];
@@ -97,11 +97,11 @@ public abstract class MxpCall implements TraceSubFragment {
    * @return CancunMxpCall instance corresponding to the Mxp scenario
    */
   public static CancunMxpCall getCancunMxpCall(Hub hub) {
-    final OpCodeData opCodeData = hub.currentFrame().opCodeData();
+    final OpCodeData opCodeData = hub.opCodeData();
     if (opCodeData.isMSize()) {
       return new CancunMSizeMxpCall(hub);
     }
-    EWord[] sizesAndOffsets = getSizesAndOffsets(hub.messageFrame());
+    EWord[] sizesAndOffsets = getSizesAndOffsets(hub.messageFrame(), opCodeData);
     EWord size1 = sizesAndOffsets[0];
     EWord size2 = sizesAndOffsets[2];
     if (size1.isZero() && size2.isZero()) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/StpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/StpCall.java
@@ -49,7 +49,7 @@ import org.hyperledger.besu.evm.internal.Words;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 public class StpCall implements TraceSubFragment {
   @EqualsAndHashCode.Include final long memoryExpansionGas;
-  @EqualsAndHashCode.Include OpCodeData opCode;
+  @EqualsAndHashCode.Include OpCode opCode;
   @EqualsAndHashCode.Include long gasActual;
   @EqualsAndHashCode.Include EWord gas; // for CALL's only
   @EqualsAndHashCode.Include EWord value;
@@ -59,15 +59,17 @@ public class StpCall implements TraceSubFragment {
   @EqualsAndHashCode.Include boolean outOfGasException;
   @EqualsAndHashCode.Include long gasPaidOutOfPocket;
   @EqualsAndHashCode.Include long stipend;
+  private final OpCodeData opCodeData;
 
   public StpCall(Hub hub, MessageFrame frame, long memoryExpansionGas) {
-    this.opCode = hub.opCodeData();
-    checkArgument(this.opCode.isCall() || this.opCode.isCreate());
+    this.opCode = hub.opCode();
+    this.opCodeData = hub.opCodeData();
+    checkArgument(this.opCodeData.isCall() || this.opCodeData.isCreate());
 
     this.memoryExpansionGas = memoryExpansionGas;
     this.gasActual = frame.getRemainingGas();
 
-    if (this.opCode.isCall()) {
+    if (this.opCodeData.isCall()) {
       this.stpCallForCalls(hub);
     } else {
       this.stpCallForCreates(frame);
@@ -80,7 +82,7 @@ public class StpCall implements TraceSubFragment {
     final Address to = Words.toAddress(frame.getStackItem(1));
     final Account toAccount = frame.getWorldUpdater().get(to);
     this.gas = EWord.of(frame.getStackItem(0));
-    this.value = opCode.callHasValueArgument() ? EWord.of(frame.getStackItem(2)) : ZERO;
+    this.value = opCodeData.callHasValueArgument() ? EWord.of(frame.getStackItem(2)) : ZERO;
     this.exists =
         switch (hub.opCode()) {
           case CALL -> toAccount != null && !toAccount.isEmpty();
@@ -96,11 +98,11 @@ public class StpCall implements TraceSubFragment {
   }
 
   private boolean nonzeroValueTransfer() {
-    return opCode.callHasValueArgument() && !value.isZero();
+    return opCodeData.callHasValueArgument() && !value.isZero();
   }
 
   private boolean callWouldLeadToAccountCreation() {
-    return (opCode.mnemonic() == OpCode.CALL) && nonzeroValueTransfer() && !exists;
+    return (opCode == OpCode.CALL) && nonzeroValueTransfer() && !exists;
   }
 
   private long gasPaidOutOfPocketForCalls() {
@@ -155,7 +157,7 @@ public class StpCall implements TraceSubFragment {
   public Trace.Hub trace(Trace.Hub trace) {
     return trace
         .pMiscStpFlag(true)
-        .pMiscStpInstruction(opCode.mnemonic().unsignedByteValue())
+        .pMiscStpInstruction(opCode.unsignedByteValue())
         .pMiscStpGasHi(gas.hi())
         .pMiscStpGasLo(gas.lo())
         .pMiscStpValueHi(value.hi())
@@ -170,7 +172,7 @@ public class StpCall implements TraceSubFragment {
   }
 
   public int compareTo(StpCall stpCall) {
-    final int opCodeComp = opCode.mnemonic().compareTo(stpCall.opCode.mnemonic());
+    final int opCodeComp = opCode.compareTo(stpCall.opCode);
     if (opCodeComp != 0) {
       return opCodeComp;
     }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/StpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/StpCall.java
@@ -35,6 +35,7 @@ import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.fragment.TraceSubFragment;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.types.EWord;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -48,7 +49,7 @@ import org.hyperledger.besu.evm.internal.Words;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 public class StpCall implements TraceSubFragment {
   @EqualsAndHashCode.Include final long memoryExpansionGas;
-  @EqualsAndHashCode.Include OpCode opCode;
+  @EqualsAndHashCode.Include OpCodeData opCode;
   @EqualsAndHashCode.Include long gasActual;
   @EqualsAndHashCode.Include EWord gas; // for CALL's only
   @EqualsAndHashCode.Include EWord value;
@@ -60,7 +61,7 @@ public class StpCall implements TraceSubFragment {
   @EqualsAndHashCode.Include long stipend;
 
   public StpCall(Hub hub, MessageFrame frame, long memoryExpansionGas) {
-    this.opCode = hub.opCode();
+    this.opCode = hub.opCodeData();
     checkArgument(this.opCode.isCall() || this.opCode.isCreate());
 
     this.memoryExpansionGas = memoryExpansionGas;
@@ -99,7 +100,7 @@ public class StpCall implements TraceSubFragment {
   }
 
   private boolean callWouldLeadToAccountCreation() {
-    return (opCode == OpCode.CALL) && nonzeroValueTransfer() && !exists;
+    return (opCode.mnemonic() == OpCode.CALL) && nonzeroValueTransfer() && !exists;
   }
 
   private long gasPaidOutOfPocketForCalls() {
@@ -154,7 +155,7 @@ public class StpCall implements TraceSubFragment {
   public Trace.Hub trace(Trace.Hub trace) {
     return trace
         .pMiscStpFlag(true)
-        .pMiscStpInstruction(opCode.unsignedByteValue())
+        .pMiscStpInstruction(opCode.mnemonic().unsignedByteValue())
         .pMiscStpGasHi(gas.hi())
         .pMiscStpGasLo(gas.lo())
         .pMiscStpValueHi(value.hi())
@@ -169,7 +170,7 @@ public class StpCall implements TraceSubFragment {
   }
 
   public int compareTo(StpCall stpCall) {
-    final int opCodeComp = opCode.compareTo(stpCall.opCode);
+    final int opCodeComp = opCode.mnemonic().compareTo(stpCall.opCode.mnemonic());
     if (opCodeComp != 0) {
       return opCodeComp;
     }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/opcodes/CallOobCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/opcodes/CallOobCall.java
@@ -30,7 +30,7 @@ import net.consensys.linea.zktracer.module.hub.fragment.imc.oob.OobCall;
 import net.consensys.linea.zktracer.module.mod.Mod;
 import net.consensys.linea.zktracer.module.oob.OobExoCall;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
-import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.types.EWord;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.account.Account;
@@ -53,7 +53,7 @@ public class CallOobCall extends OobCall {
   @Override
   public void setInputData(MessageFrame frame, Hub hub) {
     final Account callerAccount = frame.getWorldUpdater().get(frame.getRecipientAddress());
-    final OpCode opCode = OpCode.of(frame.getCurrentOperation().getOpcode());
+    final OpCodeData opCode = hub.opCodeData(frame);
 
     // DELEGATECALL, STATICCALL can't trasfer value,
     // CALL, CALLCODE may transfer value

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/opcodes/create/CreateOobCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/opcodes/create/CreateOobCall.java
@@ -61,7 +61,7 @@ public abstract class CreateOobCall extends OobCall {
   @Override
   public void setInputData(MessageFrame frame, Hub hub) {
     final Account creatorAccount = frame.getWorldUpdater().get(frame.getRecipientAddress());
-    final Address deploymentAddress = getDeploymentAddress(frame);
+    final Address deploymentAddress = getDeploymentAddress(frame, hub.opCodeData(frame));
     final Account deployedAccount = frame.getWorldUpdater().get(deploymentAddress);
 
     final boolean unaborted = hub.pch().abortingConditions().snapshot().none();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/Blake2fCallDataSizeOobCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/Blake2fCallDataSizeOobCall.java
@@ -19,7 +19,6 @@ import static net.consensys.linea.zktracer.Trace.OOB_INST_BLAKE_CDS;
 import static net.consensys.linea.zktracer.Trace.Oob.CT_MAX_BLAKE2F_CDS;
 import static net.consensys.linea.zktracer.module.oob.OobExoCall.callToEQ;
 import static net.consensys.linea.zktracer.module.oob.OobExoCall.callToIsZero;
-import static net.consensys.linea.zktracer.runtime.callstack.CallFrame.getOpCode;
 import static net.consensys.linea.zktracer.types.Conversions.*;
 
 import lombok.Getter;
@@ -31,7 +30,7 @@ import net.consensys.linea.zktracer.module.hub.fragment.imc.oob.OobCall;
 import net.consensys.linea.zktracer.module.mod.Mod;
 import net.consensys.linea.zktracer.module.oob.OobExoCall;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
-import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.types.EWord;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -50,7 +49,7 @@ public class Blake2fCallDataSizeOobCall extends OobCall {
 
   @Override
   public void setInputData(MessageFrame frame, Hub hub) {
-    final OpCode opCode = getOpCode(frame);
+    final OpCodeData opCode = hub.opCodeData(frame);
     final EWord cds = EWord.of(frame.getStackItem(opCode.callCdsStackIndex()));
     final EWord returnAtCapacity =
         EWord.of(frame.getStackItem(opCode.callReturnAtCapacityStackIndex()));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/Blake2fParamsOobCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/Blake2fParamsOobCall.java
@@ -20,7 +20,6 @@ import static net.consensys.linea.zktracer.Trace.OOB_INST_BLAKE_PARAMS;
 import static net.consensys.linea.zktracer.Trace.Oob.CT_MAX_BLAKE2F_PARAMS;
 import static net.consensys.linea.zktracer.module.oob.OobExoCall.callToEQ;
 import static net.consensys.linea.zktracer.module.oob.OobExoCall.callToLT;
-import static net.consensys.linea.zktracer.runtime.callstack.CallFrame.getOpCode;
 import static net.consensys.linea.zktracer.types.Conversions.*;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 
@@ -35,7 +34,7 @@ import net.consensys.linea.zktracer.module.hub.fragment.imc.oob.OobCall;
 import net.consensys.linea.zktracer.module.mod.Mod;
 import net.consensys.linea.zktracer.module.oob.OobExoCall;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
-import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
@@ -57,7 +56,7 @@ public class Blake2fParamsOobCall extends OobCall {
 
   @Override
   public void setInputData(MessageFrame frame, Hub hub) {
-    final OpCode opCode = getOpCode(frame);
+    final OpCodeData opCode = hub.opCodeData(frame);
     final long argsOffset =
         clampedToLong(
             opCode.callHasValueArgument()

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/common/CommonPrecompileOobCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/common/CommonPrecompileOobCall.java
@@ -16,7 +16,6 @@
 package net.consensys.linea.zktracer.module.hub.fragment.imc.oob.precompiles.common;
 
 import static net.consensys.linea.zktracer.module.oob.OobExoCall.callToIsZero;
-import static net.consensys.linea.zktracer.runtime.callstack.CallFrame.getOpCode;
 import static net.consensys.linea.zktracer.types.Conversions.*;
 
 import java.math.BigInteger;
@@ -30,7 +29,7 @@ import net.consensys.linea.zktracer.module.hub.fragment.imc.oob.OobCall;
 import net.consensys.linea.zktracer.module.mod.Mod;
 import net.consensys.linea.zktracer.module.oob.OobExoCall;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
-import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.types.EWord;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -52,7 +51,7 @@ public abstract class CommonPrecompileOobCall extends OobCall {
 
   @Override
   public void setInputData(MessageFrame frame, Hub hub) {
-    final OpCode opCode = getOpCode(frame);
+    final OpCodeData opCode = hub.opCodeData(frame);
 
     final EWord callDataSize = EWord.of(frame.getStackItem(opCode.callCdsStackIndex()));
     final EWord returnAtCapacity =

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/modexp/ModexpCallDataSizeOobCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/modexp/ModexpCallDataSizeOobCall.java
@@ -19,7 +19,6 @@ import static net.consensys.linea.zktracer.Trace.OOB_INST_MODEXP_CDS;
 import static net.consensys.linea.zktracer.Trace.Oob.CT_MAX_MODEXP_CDS;
 import static net.consensys.linea.zktracer.module.hub.precompiles.ModexpMetadata.*;
 import static net.consensys.linea.zktracer.module.oob.OobExoCall.callToLT;
-import static net.consensys.linea.zktracer.runtime.callstack.CallFrame.getOpCode;
 import static net.consensys.linea.zktracer.types.Conversions.*;
 
 import lombok.Getter;
@@ -31,7 +30,7 @@ import net.consensys.linea.zktracer.module.hub.fragment.imc.oob.OobCall;
 import net.consensys.linea.zktracer.module.hub.precompiles.ModexpMetadata;
 import net.consensys.linea.zktracer.module.mod.Mod;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
-import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.types.EWord;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -50,7 +49,7 @@ public class ModexpCallDataSizeOobCall extends OobCall {
 
   @Override
   public void setInputData(MessageFrame frame, Hub hub) {
-    final OpCode opCode = getOpCode(frame);
+    final OpCodeData opCode = hub.opCodeData(frame);
     cds = EWord.of(frame.getStackItem(opCode.callCdsStackIndex()));
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/modexp/ModexpExtractOobCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/modexp/ModexpExtractOobCall.java
@@ -20,7 +20,6 @@ import static net.consensys.linea.zktracer.Trace.Oob.CT_MAX_MODEXP_EXTRACT;
 import static net.consensys.linea.zktracer.module.hub.precompiles.ModexpMetadata.BASE_MIN_OFFSET;
 import static net.consensys.linea.zktracer.module.oob.OobExoCall.callToIsZero;
 import static net.consensys.linea.zktracer.module.oob.OobExoCall.callToLT;
-import static net.consensys.linea.zktracer.runtime.callstack.CallFrame.getOpCode;
 import static net.consensys.linea.zktracer.types.Conversions.*;
 
 import lombok.Getter;
@@ -33,7 +32,7 @@ import net.consensys.linea.zktracer.module.hub.precompiles.ModexpMetadata;
 import net.consensys.linea.zktracer.module.mod.Mod;
 import net.consensys.linea.zktracer.module.oob.OobExoCall;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
-import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.types.EWord;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -56,7 +55,7 @@ public class ModexpExtractOobCall extends OobCall {
 
   @Override
   public void setInputData(MessageFrame frame, Hub hub) {
-    final OpCode opCode = getOpCode(frame);
+    final OpCodeData opCode = hub.opCodeData(frame);
     setCds(EWord.of(frame.getStackItem(opCode.callCdsStackIndex())));
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/modexp/ModexpLeadOobCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/modexp/ModexpLeadOobCall.java
@@ -21,7 +21,6 @@ import static net.consensys.linea.zktracer.Trace.WORD_SIZE;
 import static net.consensys.linea.zktracer.module.hub.precompiles.ModexpMetadata.BASE_MIN_OFFSET;
 import static net.consensys.linea.zktracer.module.hub.precompiles.ModexpMetadata.EBS_MIN_OFFSET;
 import static net.consensys.linea.zktracer.module.oob.OobExoCall.*;
-import static net.consensys.linea.zktracer.runtime.callstack.CallFrame.getOpCode;
 import static net.consensys.linea.zktracer.types.Conversions.*;
 
 import java.math.BigInteger;
@@ -36,7 +35,7 @@ import net.consensys.linea.zktracer.module.hub.precompiles.ModexpMetadata;
 import net.consensys.linea.zktracer.module.mod.Mod;
 import net.consensys.linea.zktracer.module.oob.OobExoCall;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
-import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.types.EWord;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -60,7 +59,7 @@ public class ModexpLeadOobCall extends OobCall {
 
   @Override
   public void setInputData(MessageFrame frame, Hub hub) {
-    final OpCode opCode = getOpCode(frame);
+    final OpCodeData opCode = hub.opCodeData(frame);
     cds = EWord.of(frame.getStackItem(opCode.callCdsStackIndex()));
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/modexp/ModexpPricingOobCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/precompiles/modexp/ModexpPricingOobCall.java
@@ -21,7 +21,6 @@ import static net.consensys.linea.zktracer.Trace.Oob.CT_MAX_MODEXP_PRICING;
 import static net.consensys.linea.zktracer.Trace.Oob.G_QUADDIVISOR;
 import static net.consensys.linea.zktracer.module.oob.OobExoCall.*;
 import static net.consensys.linea.zktracer.module.oob.OobOperation.computeExponentLog;
-import static net.consensys.linea.zktracer.runtime.callstack.CallFrame.getOpCode;
 import static net.consensys.linea.zktracer.types.Conversions.*;
 import static org.hyperledger.besu.evm.internal.Words.clampedToInt;
 
@@ -37,7 +36,7 @@ import net.consensys.linea.zktracer.module.hub.precompiles.ModexpMetadata;
 import net.consensys.linea.zktracer.module.mod.Mod;
 import net.consensys.linea.zktracer.module.oob.OobExoCall;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
-import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.types.EWord;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -64,7 +63,7 @@ public class ModexpPricingOobCall extends OobCall {
 
   @Override
   public void setInputData(MessageFrame frame, Hub hub) {
-    final OpCode opCode = getOpCode(frame);
+    final OpCodeData opCode = hub.opCodeData(frame);
     setReturnAtCapacity(EWord.of(frame.getStackItem(opCode.callReturnAtCapacityStackIndex())));
 
     final int cds = clampedToInt(frame.getStackItem(opCode.callCdsStackIndex()));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/stack/StackFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/stack/StackFragment.java
@@ -122,7 +122,7 @@ public abstract class StackFragment implements TraceFragment {
       boolean prospectivePcNewIsInBounds =
           codeSize.compareTo(prospectivePcNew) > 0 && noOutOfGasException;
 
-      if (opCode.equals(OpCode.JUMPI)) {
+      if (opCode.mnemonic().equals(OpCode.JUMPI)) {
         boolean nonzeroJumpCondition =
             !hub.currentFrame()
                 .frame()

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/stack/StackFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/stack/StackFragment.java
@@ -57,7 +57,7 @@ public abstract class StackFragment implements TraceFragment {
   @Setter public boolean hashInfoFlag;
   private EWord hashInfoKeccak = EWord.ZERO;
   @Setter public Bytes hash;
-  @Getter private final OpCode opCode;
+  @Getter private final OpCodeData opCode;
   @Getter private final int rawOpCode;
   @Setter private boolean jumpDestinationVettingRequired;
   private final CommonFragmentValues commonFragmentValues;
@@ -75,8 +75,8 @@ public abstract class StackFragment implements TraceFragment {
     this.stack = stack;
     this.stackOps = stackOps;
     this.exceptions = exceptions;
-    this.opCode = stack.getCurrentOpcodeData().mnemonic();
-    if (this.opCode != OpCode.INVALID) {
+    this.opCode = stack.getCurrentOpcodeData();
+    if (this.opCode.mnemonic() != OpCode.INVALID) {
       this.rawOpCode = 0xff & this.opCode.byteValue();
     } else {
       final int codeSize = hub.messageFrame().getCode().getBytes().size();
@@ -84,7 +84,7 @@ public abstract class StackFragment implements TraceFragment {
       this.rawOpCode = (pc < codeSize) ? 0xff & hub.messageFrame().getCode().getBytes().get(pc) : 0;
     }
     this.hashInfoFlag =
-        switch (this.opCode) {
+        switch (this.opCode.mnemonic()) {
               case SHA3 -> true;
               case RETURN -> isDeploying;
               case CREATE2 -> aborts.none();
@@ -94,7 +94,7 @@ public abstract class StackFragment implements TraceFragment {
             && gp.messageSize() > 0;
     if (this.hashInfoFlag) {
       Bytes memorySegmentToHash;
-      switch (this.opCode) {
+      switch (this.opCode.mnemonic()) {
         case SHA3, RETURN -> {
           final long offset = Words.clampedToLong(hub.currentFrame().frame().getStackItem(0));
           final long size = Words.clampedToLong(hub.currentFrame().frame().getStackItem(1));
@@ -142,7 +142,7 @@ public abstract class StackFragment implements TraceFragment {
   }
 
   private Bytes getPushValue(Hub hub) {
-    checkState(hub.opCode().isNonTrivialPush());
+    checkState(hub.opCodeData().isNonTrivialPush());
 
     final int pc = hub.messageFrame().getPC();
     if (pc + 1 >= hub.messageFrame().getCode().getSize()) {
@@ -328,7 +328,7 @@ public abstract class StackFragment implements TraceFragment {
       case MAX_CODE_SIZE_EXCEPTION -> checkArgument(Exceptions.maxCodeSizeException(exceptions));
       case UNDEFINED -> throw new RuntimeException(
           "tracedException remained UNDEFINED but "
-              + Exceptions.prettyStringOf(this.opCode, exceptions));
+              + Exceptions.prettyStringOf(this.opCode.mnemonic(), exceptions));
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/AccountSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/AccountSection.java
@@ -27,6 +27,7 @@ import net.consensys.linea.zktracer.module.hub.fragment.DomSubStampsSubFragment;
 import net.consensys.linea.zktracer.module.hub.fragment.account.AccountFragment;
 import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.runtime.callstack.CallFrame;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -127,9 +128,9 @@ public class AccountSection extends TraceSection implements PostRollbackDefer {
   }
 
   private static short maxNumberOfRows(Hub hub) {
-    final OpCode opCode = hub.opCode();
+    final OpCodeData opCode = hub.opCodeData();
 
-    if (opCode.isAnyOf(BALANCE, EXTCODESIZE, EXTCODEHASH)) {
+    if (opCode.mnemonic().isAnyOf(BALANCE, EXTCODESIZE, EXTCODEHASH)) {
       return (short) (opCode.numberOfStackRows() + 3);
     }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/EarlyExceptionSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/EarlyExceptionSection.java
@@ -21,17 +21,17 @@ import static net.consensys.linea.zktracer.opcode.InstructionFamily.INVALID;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.module.hub.signals.TracedException;
-import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 
 public class EarlyExceptionSection extends TraceSection {
   public EarlyExceptionSection(Hub hub) {
-    super(hub, (short) (hub.opCode().getData().stackSettings().twoLineInstruction() ? 2 : 1));
+    super(hub, (short) (hub.opCodeData().stackSettings().twoLineInstruction() ? 2 : 1));
 
     this.addStack(hub);
 
     final short exceptions = hub.pch().exceptions();
 
-    final OpCode opCode = hub.opCode();
+    final OpCodeData opCode = hub.opCodeData();
     if (Exceptions.stackUnderflow(exceptions)) {
       checkArgument(opCode.mayTriggerStackUnderflow());
       commonValues.setTracedException(TracedException.STACK_UNDERFLOW);
@@ -44,7 +44,7 @@ public class EarlyExceptionSection extends TraceSection {
       return;
     }
 
-    if (hub.opCode().getData().instructionFamily() == INVALID) {
+    if (hub.opCodeData().instructionFamily() == INVALID) {
       checkArgument(Exceptions.invalidOpcode(exceptions));
       commonValues.setTracedException(TracedException.INVALID_OPCODE);
     }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/LogSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/LogSection.java
@@ -82,7 +82,7 @@ public class LogSection extends TraceSection implements EndTransactionDefer {
 
   private static short maxNumberOfRows(Hub hub) {
     return (short)
-        (hub.opCode().numberOfStackRows()
+        (hub.opCodeData().numberOfStackRows()
             + (Exceptions.staticFault(hub.pch().exceptions()) ? 2 : 3));
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/SloadSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/SloadSection.java
@@ -53,7 +53,8 @@ public class SloadSection extends TraceSection implements PostRollbackDefer {
     super(
         hub,
         (short)
-            (hub.opCode().numberOfStackRows() + (Exceptions.any(hub.pch().exceptions()) ? 5 : 4)));
+            (hub.opCodeData().numberOfStackRows()
+                + (Exceptions.any(hub.pch().exceptions()) ? 5 : 4)));
 
     world = worldView;
     hubStamp = hub.stamp();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/SstoreSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/SstoreSection.java
@@ -54,7 +54,8 @@ public class SstoreSection extends TraceSection implements PostRollbackDefer {
     super(
         hub,
         (short)
-            (hub.opCode().numberOfStackRows() + (Exceptions.any(hub.pch().exceptions()) ? 5 : 4)));
+            (hub.opCodeData().numberOfStackRows()
+                + (Exceptions.any(hub.pch().exceptions()) ? 5 : 4)));
 
     world = worldView;
     hubStamp = hub.stamp();
@@ -110,7 +111,7 @@ public class SstoreSection extends TraceSection implements PostRollbackDefer {
     // set the refundDelta
     commonValues.refundDelta(
         hub.gasProjector
-            .of(hub.currentFrame().frame(), hub.opCode())
+            .of(hub.currentFrame().frame(), hub.opCodeData())
             .refund()); // Note: we can't use Besu's refund value, as our is only for non-reverting
     // context
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/StackOnlySection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/StackOnlySection.java
@@ -19,7 +19,7 @@ import net.consensys.linea.zktracer.module.hub.Hub;
 
 public class StackOnlySection extends TraceSection {
   public StackOnlySection(Hub hub) {
-    super(hub, (short) (hub.opCode().getData().numberOfStackRows()));
+    super(hub, (short) (hub.opCodeData().numberOfStackRows()));
 
     this.addStack(hub);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/TraceSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/TraceSection.java
@@ -79,7 +79,7 @@ public class TraceSection {
    * @param hub the execution context
    */
   public final void addStack(Hub hub) {
-    for (var stackFragment : this.makeStackFragments(hub, hub.currentFrame())) {
+    for (var stackFragment : this.makeStackFragments(hub)) {
       this.addFragment(stackFragment);
     }
   }
@@ -168,11 +168,12 @@ public class TraceSection {
         : 0;
   }
 
-  private List<TraceFragment> makeStackFragments(final Hub hub, CallFrame currentFrame) {
+  private List<TraceFragment> makeStackFragments(final Hub hub) {
+    final CallFrame currentFrame = hub.currentFrame();
     final List<TraceFragment> stackFragments = new ArrayList<>(2);
     final Stack snapshot = currentFrame.stack().snapshot();
     if (currentFrame.pending().lines().isEmpty()) {
-      for (int i = 0; i < (currentFrame.opCodeData().numberOfStackRows()); i++) {
+      for (int i = 0; i < (hub.opCodeData().numberOfStackRows()); i++) {
         stackFragments.add(
             StackFragment.prepare(
                 hub,
@@ -180,7 +181,7 @@ public class TraceSection {
                 new StackLine().asStackItems(),
                 hub.pch().exceptions(),
                 hub.pch().abortingConditions().snapshot(),
-                hub.gasProjector.of(currentFrame.frame(), currentFrame.opCode()),
+                hub.gasProjector.of(currentFrame.frame(), hub.opCodeData()),
                 currentFrame.isDeployment(),
                 commonValues));
       }
@@ -193,7 +194,7 @@ public class TraceSection {
                 line.asStackItems(),
                 hub.pch().exceptions(),
                 hub.pch().abortingConditions().snapshot(),
-                hub.gasProjector.of(currentFrame.frame(), currentFrame.opCode()),
+                hub.gasProjector.of(currentFrame.frame(), hub.opCodeData()),
                 currentFrame.isDeployment(),
                 commonValues));
       }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
@@ -51,7 +51,7 @@ import net.consensys.linea.zktracer.module.hub.fragment.scenario.CallScenarioFra
 import net.consensys.linea.zktracer.module.hub.section.TraceSection;
 import net.consensys.linea.zktracer.module.hub.section.call.precompileSubsection.*;
 import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
-import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.runtime.callstack.CallFrame;
 import net.consensys.linea.zktracer.types.EWord;
 import net.consensys.linea.zktracer.types.MemoryRange;
@@ -134,7 +134,7 @@ public class CallSection extends TraceSection
   private AccountSnapshot reEntryCallerSnapshot;
   private AccountSnapshot reEntryCalleeSnapshot;
 
-  private final OpCode opCode;
+  private final OpCodeData opCode;
   private Wei value;
 
   public StpCall stpCall;
@@ -149,7 +149,7 @@ public class CallSection extends TraceSection
     super(hub, maxNumberOfLines(hub));
 
     factory = hub.factories();
-    opCode = hub.opCode();
+    opCode = hub.opCodeData();
 
     final short exceptions = hub.pch().exceptions();
 
@@ -162,7 +162,7 @@ public class CallSection extends TraceSection
 
     if (Exceptions.any(exceptions)) {
       scenarioFragment.setScenario(CALL_EXCEPTION);
-      if (opCode == CALL) {
+      if (opCode.mnemonic() == CALL) {
         final XCallOobCall oobCall = new XCallOobCall();
         firstImcFragment.callOob(oobCall);
       }
@@ -210,7 +210,8 @@ public class CallSection extends TraceSection
 
     // the call data span and ``return at'' spans are only required once the CALL is unexceptional
     callDataRange =
-        new MemoryRange(currentFrame.contextNumber(), Range.callDataRange(frame), frame);
+        new MemoryRange(
+            currentFrame.contextNumber(), Range.callDataRange(frame, hub.opCodeData(frame)), frame);
     returnAtRange = new MemoryRange(currentFrame.contextNumber(), returnAtRange(frame), frame);
 
     value =
@@ -406,7 +407,7 @@ public class CallSection extends TraceSection
     callerFirstNew = callerFirst.deepCopy();
     calleeFirstNew = calleeFirst.deepCopy().turnOnWarmth();
 
-    if (opCode == CALL) {
+    if (opCode.mnemonic() == CALL) {
       callerFirstNew.decrementBalanceBy(value);
       calleeFirstNew.incrementBalanceBy(value);
     }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/CallDataCopySection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/CallDataCopySection.java
@@ -73,6 +73,6 @@ public class CallDataCopySection extends TraceSection {
   }
 
   private static short maxNumberOfRows(Hub hub) {
-    return (short) (hub.opCode().numberOfStackRows() + 2);
+    return (short) (hub.opCodeData().numberOfStackRows() + 2);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/CodeCopySection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/CodeCopySection.java
@@ -92,6 +92,6 @@ public class CodeCopySection extends TraceSection {
 
   // 4 = 1 (stack row) + 3 (up to 3 non-stack rows)
   private static short maxNumberOfRows(Hub hub) {
-    return (short) (hub.opCode().numberOfStackRows() + 3);
+    return (short) (hub.opCodeData().numberOfStackRows() + 3);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/ExtCodeCopySection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/ExtCodeCopySection.java
@@ -161,6 +161,6 @@ public class ExtCodeCopySection extends TraceSection implements PostRollbackDefe
   }
 
   private static short maxNumberOfRows(Hub hub) {
-    return (short) (hub.opCode().numberOfStackRows() + 3);
+    return (short) (hub.opCodeData().numberOfStackRows() + 3);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/ReturnDataCopySection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/ReturnDataCopySection.java
@@ -75,6 +75,6 @@ public class ReturnDataCopySection extends TraceSection {
   }
 
   private static short maxNumberOfRows(Hub hub) {
-    return (short) (hub.opCode().numberOfStackRows() + 3);
+    return (short) (hub.opCodeData().numberOfStackRows() + 3);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/create/CreateSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/create/CreateSection.java
@@ -105,7 +105,7 @@ public abstract class CreateSection extends TraceSection
     hubStamp = hub.stamp();
 
     creatorAddress = frame.getRecipientAddress();
-    createeAddress = getDeploymentAddress(frame);
+    createeAddress = getDeploymentAddress(frame, hub.opCodeData(frame));
     value = Wei.of(UInt256.fromBytes(frame.getStackItem(0)));
 
     scenarioFragment = new CreateScenarioFragment();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/ReturnSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/ReturnSection.java
@@ -337,6 +337,6 @@ public class ReturnSection extends TraceSection
 
   private static short maxNumberOfRows(Hub hub) {
     return (short)
-        (hub.opCode().numberOfStackRows() + (Exceptions.any(hub.pch().exceptions()) ? 4 : 7));
+        (hub.opCodeData().numberOfStackRows() + (Exceptions.any(hub.pch().exceptions()) ? 4 : 7));
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/transients/OperationAncillaries.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/transients/OperationAncillaries.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Preconditions.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.zktracer.module.hub.Hub;
-import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.types.Range;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -54,8 +54,8 @@ public class OperationAncillaries {
    * @param frame the execution context
    * @return the input data segment
    */
-  public static Range callDataSegment(final MessageFrame frame) {
-    switch (OpCode.of(frame.getCurrentOperation().getOpcode())) {
+  public static Range callDataSegment(final MessageFrame frame, OpCodeData opCode) {
+    switch (opCode.mnemonic()) {
       case CALL, CALLCODE -> {
         long offset = Words.clampedToLong(frame.getStackItem(3));
         long length = Words.clampedToLong(frame.getStackItem(4));
@@ -71,8 +71,8 @@ public class OperationAncillaries {
     }
   }
 
-  public static Range initCodeSegment(final MessageFrame frame) {
-    switch (OpCode.of(frame.getCurrentOperation().getOpcode())) {
+  public static Range initCodeSegment(final MessageFrame frame, OpCodeData opCode) {
+    switch (opCode.mnemonic()) {
       case CREATE, CREATE2 -> {
         long offset = Words.clampedToLong(frame.getStackItem(1));
         long length = Words.clampedToLong(frame.getStackItem(2));
@@ -90,11 +90,11 @@ public class OperationAncillaries {
    * @return the input data segment
    */
   public Range callDataSegment() {
-    return callDataSegment(hub.messageFrame());
+    return callDataSegment(hub.messageFrame(), hub.opCodeData());
   }
 
   public Range initCodeSegment() {
-    return initCodeSegment(hub.messageFrame());
+    return initCodeSegment(hub.messageFrame(), hub.opCodeData());
   }
 
   /**
@@ -113,13 +113,13 @@ public class OperationAncillaries {
    * @param frame the execution context
    * @return the calldata content
    */
-  public static Bytes callData(final MessageFrame frame) {
-    final Range callDataSegment = callDataSegment(frame);
+  public static Bytes callData(final MessageFrame frame, OpCodeData opCode) {
+    final Range callDataSegment = callDataSegment(frame, opCode);
     return maybeShadowReadMemory(callDataSegment, frame);
   }
 
-  public static Bytes initCode(final MessageFrame frame) {
-    final Range initCodeSegment = initCodeSegment(frame);
+  public static Bytes initCode(final MessageFrame frame, OpCodeData opCode) {
+    final Range initCodeSegment = initCodeSegment(frame, opCode);
     return maybeShadowReadMemory(initCodeSegment, frame);
   }
 
@@ -130,8 +130,8 @@ public class OperationAncillaries {
    * @param frame the execution context
    * @return the return data target
    */
-  public static Range returnDataRequestedSegment(final MessageFrame frame) {
-    switch (OpCode.of(frame.getCurrentOperation().getOpcode())) {
+  public static Range returnDataRequestedSegment(final MessageFrame frame, OpCodeData opCode) {
+    switch (opCode.mnemonic()) {
       case CALL, CALLCODE -> {
         long offset = Words.clampedToLong(frame.getStackItem(5));
         long length = Words.clampedToLong(frame.getStackItem(6));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/MxpUtils.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/MxpUtils.java
@@ -20,13 +20,17 @@ import static org.hyperledger.besu.evm.internal.Words.clampedAdd;
 import static org.hyperledger.besu.evm.internal.Words.clampedMultiply;
 
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.types.EWord;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 public class MxpUtils {
 
-  public static boolean isWordPricingOpcode(OpCode opCode) {
-    return opCode == OpCode.SHA3 || opCode.isCopy() || opCode.isCreate() || opCode == OpCode.MCOPY;
+  public static boolean isWordPricingOpcode(OpCodeData opCode) {
+    return opCode.mnemonic() == OpCode.SHA3
+        || opCode.isCopy()
+        || opCode.isCreate()
+        || opCode.mnemonic() == OpCode.MCOPY;
   }
 
   /**
@@ -35,13 +39,12 @@ public class MxpUtils {
    * @param frame where stack items are retrieved
    * @return EWord[] array with [size1, offset1, size2, offset2]
    */
-  public static EWord[] getSizesAndOffsets(MessageFrame frame) {
-    OpCode opCode = OpCode.of(frame.getCurrentOperation().getOpcode());
+  public static EWord[] getSizesAndOffsets(MessageFrame frame, OpCodeData opCode) {
     EWord size1 = EWord.ZERO;
     EWord offset1 = EWord.ZERO;
     EWord size2 = EWord.ZERO;
     EWord offset2 = EWord.ZERO;
-    switch (opCode) {
+    switch (opCode.mnemonic()) {
       case MSIZE -> {}
       case MLOAD, MSTORE -> {
         offset1 = EWord.of(frame.getStackItem(0));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/RomLex.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/RomLex.java
@@ -124,7 +124,7 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
           new RomOperation(
               ContractMetadata.canonical(hub, deploymentAddress),
               tx.getInit().get(),
-              hub.getOpcodes());
+              hub.opCodes());
 
       operations.add(operation);
     }
@@ -140,7 +140,7 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
                 final Address calledAddress = tx.getTo().get();
                 final RomOperation operation =
                     new RomOperation(
-                        ContractMetadata.canonical(hub, calledAddress), code, hub.getOpcodes());
+                        ContractMetadata.canonical(hub, calledAddress), code, hub.opCodes());
 
                 operations.add(operation);
               }
@@ -189,7 +189,7 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
         final ContractMetadata contractMetadata =
             ContractMetadata.make(
                 deploymentAddress, hub.deploymentNumberOf(deploymentAddress), false);
-        final RomOperation chunk = new RomOperation(contractMetadata, byteCode, hub.getOpcodes());
+        final RomOperation chunk = new RomOperation(contractMetadata, byteCode, hub.opCodes());
         operations.add(chunk);
       }
 
@@ -205,7 +205,7 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
                         new RomOperation(
                             ContractMetadata.canonical(hub, calleeAddress),
                             byteCode,
-                            hub.getOpcodes());
+                            hub.opCodes());
                     operations.add(operation);
                   }
                 });
@@ -234,7 +234,7 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
                         new RomOperation(
                             ContractMetadata.canonical(hub, foreignCodeAddress),
                             byteCode,
-                            hub.getOpcodes());
+                            hub.opCodes());
 
                     operations.add(operation);
                   }
@@ -254,7 +254,7 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
 
     final ContractMetadata contractMetadata = ContractMetadata.canonical(hub, address);
 
-    final RomOperation operation = new RomOperation(contractMetadata, byteCode, hub.getOpcodes());
+    final RomOperation operation = new RomOperation(contractMetadata, byteCode, hub.opCodes());
     operations.add(operation);
     createDefers.trigger(contractMetadata);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/RomLex.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/RomLex.java
@@ -17,7 +17,6 @@ package net.consensys.linea.zktracer.module.romlex;
 
 import static com.google.common.base.Preconditions.*;
 import static net.consensys.linea.zktracer.Trace.LLARGE;
-import static net.consensys.linea.zktracer.runtime.callstack.CallFrame.getOpCode;
 import static net.consensys.linea.zktracer.types.AddressUtils.getDeploymentAddress;
 import static net.consensys.linea.zktracer.types.AddressUtils.highPart;
 import static net.consensys.linea.zktracer.types.AddressUtils.lowPart;
@@ -33,6 +32,7 @@ import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.defer.ContextEntryDefer;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -121,7 +121,10 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
     if (tx.getInit().isPresent() && !tx.getInit().get().isEmpty()) {
       final Address deploymentAddress = Address.contractAddress(tx.getSender(), tx.getNonce());
       final RomOperation operation =
-          new RomOperation(ContractMetadata.canonical(hub, deploymentAddress), tx.getInit().get());
+          new RomOperation(
+              ContractMetadata.canonical(hub, deploymentAddress),
+              tx.getInit().get(),
+              hub.getOpcodes());
 
       operations.add(operation);
     }
@@ -136,7 +139,8 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
 
                 final Address calledAddress = tx.getTo().get();
                 final RomOperation operation =
-                    new RomOperation(ContractMetadata.canonical(hub, calledAddress), code);
+                    new RomOperation(
+                        ContractMetadata.canonical(hub, calledAddress), code, hub.getOpcodes());
 
                 operations.add(operation);
               }
@@ -144,7 +148,9 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
   }
 
   public void callRomLex(final MessageFrame frame) {
-    switch (getOpCode(frame)) {
+    OpCodeData opCode = hub.opCodeData(frame);
+
+    switch (opCode.mnemonic()) {
       case CREATE, CREATE2 -> {
         final long offset = Words.clampedToLong(frame.getStackItem(1));
         final long length = Words.clampedToLong(frame.getStackItem(2));
@@ -153,7 +159,7 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
 
         hub.defers().scheduleForContextEntry(this);
         byteCode = frame.shadowReadMemory(offset, length);
-        address = getDeploymentAddress(frame);
+        address = getDeploymentAddress(frame, opCode);
       }
 
       case RETURN -> {
@@ -183,7 +189,7 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
         final ContractMetadata contractMetadata =
             ContractMetadata.make(
                 deploymentAddress, hub.deploymentNumberOf(deploymentAddress), false);
-        final RomOperation chunk = new RomOperation(contractMetadata, byteCode);
+        final RomOperation chunk = new RomOperation(contractMetadata, byteCode, hub.getOpcodes());
         operations.add(chunk);
       }
 
@@ -196,7 +202,10 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
                 byteCode -> {
                   if (!byteCode.isEmpty()) {
                     final RomOperation operation =
-                        new RomOperation(ContractMetadata.canonical(hub, calleeAddress), byteCode);
+                        new RomOperation(
+                            ContractMetadata.canonical(hub, calleeAddress),
+                            byteCode,
+                            hub.getOpcodes());
                     operations.add(operation);
                   }
                 });
@@ -223,7 +232,9 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
                   if (!byteCode.isEmpty()) {
                     final RomOperation operation =
                         new RomOperation(
-                            ContractMetadata.canonical(hub, foreignCodeAddress), byteCode);
+                            ContractMetadata.canonical(hub, foreignCodeAddress),
+                            byteCode,
+                            hub.getOpcodes());
 
                     operations.add(operation);
                   }
@@ -231,7 +242,7 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
       }
 
       default -> throw new RuntimeException(
-          String.format("%s does not trigger the creation of ROM_LEX", getOpCode(frame)));
+          String.format("%s does not trigger the creation of ROM_LEX", opCode.mnemonic()));
     }
   }
 
@@ -243,7 +254,7 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
 
     final ContractMetadata contractMetadata = ContractMetadata.canonical(hub, address);
 
-    final RomOperation operation = new RomOperation(contractMetadata, byteCode);
+    final RomOperation operation = new RomOperation(contractMetadata, byteCode, hub.getOpcodes());
     operations.add(operation);
     createDefers.trigger(contractMetadata);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/RomOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/RomOperation.java
@@ -24,7 +24,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.ModuleOperation;
-import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
+import net.consensys.linea.zktracer.opcode.OpCodes;
 import net.consensys.linea.zktracer.types.UnsignedByte;
 import org.apache.tuweni.bytes.Bytes;
 
@@ -39,6 +40,8 @@ public final class RomOperation extends ModuleOperation {
 
   @Getter @EqualsAndHashCode.Include private final ContractMetadata metadata;
   private final Bytes byteCode;
+
+  private final OpCodes opCodes;
 
   public void trace(Trace.Rom trace, int cfi, int cfiInfty) {
     // WARN this is the tracing used by the ROM, not by the ROMLEX
@@ -94,8 +97,8 @@ public final class RomOperation extends ModuleOperation {
       // Deal when not in a PUSH instruction
       if (pushParameter == 0) {
         final UnsignedByte opCodeUB = UnsignedByte.of(dataPadded.get(i));
-        final OpCode opcode = OpCode.of(opCodeUB.toInteger());
-        final boolean isPush = opcode.isNonTrivialPush();
+        final OpCodeData opCode = opCodes.of(opCodeUB.toInteger());
+        final boolean isPush = opCode.isNonTrivialPush();
 
         // The OpCode is a PUSH instruction
         if (isPush) {
@@ -118,7 +121,7 @@ public final class RomOperation extends ModuleOperation {
             .pushValueHi(pushValueHigh)
             .pushValueLo(pushValueLow)
             .pushFunnelBit(false)
-            .isJumpdest(opcode.getData().isJumpDest());
+            .isJumpdest(opCode.isJumpDest());
       }
       // Deal when in a PUSH instruction
       else {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/Stp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/Stp.java
@@ -47,10 +47,10 @@ public class Stp implements OperationSetModule<StpOperation> {
     operations.add(stpOperation);
 
     checkArgument(
-        stpCall.opCode().isCall() || stpCall.opCode().isCreate(),
+        stpCall.opCodeData().isCall() || stpCall.opCodeData().isCreate(),
         "STP handles only Calls and CREATEs");
 
-    if (stpCall.opCode().isCreate()) {
+    if (stpCall.opCodeData().isCreate()) {
       wcp.callLT(longToBytes32(stpCall.gasActual()), Bytes32.ZERO);
       wcp.callLT(longToBytes32(stpCall.gasActual()), longToBytes32(stpCall.upfrontGasCost()));
       if (!stpCall.outOfGasException()) {
@@ -58,9 +58,9 @@ public class Stp implements OperationSetModule<StpOperation> {
       }
     }
 
-    if (stpCall.opCode().isCall()) {
+    if (stpCall.opCodeData().isCall()) {
       wcp.callLT(longToBytes32(stpCall.gasActual()), Bytes32.ZERO);
-      if (stpCall.opCode().callHasValueArgument()) {
+      if (stpCall.opCodeData().callHasValueArgument()) {
         wcp.callISZERO(Bytes32.leftPad(stpCall.value()));
       }
       wcp.callLT(longToBytes32(stpCall.gasActual()), longToBytes32(stpCall.upfrontGasCost()));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/StpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/StpOperation.java
@@ -40,27 +40,27 @@ public final class StpOperation extends ModuleOperation {
   }
 
   private boolean isCall() {
-    return stpCall.opCode() == OpCode.CALL;
+    return stpCall.opCode().mnemonic() == OpCode.CALL;
   }
 
   private boolean isCallCode() {
-    return stpCall.opCode() == OpCode.CALLCODE;
+    return stpCall.opCode().mnemonic() == OpCode.CALLCODE;
   }
 
   private boolean isDelegateCall() {
-    return stpCall.opCode() == OpCode.DELEGATECALL;
+    return stpCall.opCode().mnemonic() == OpCode.DELEGATECALL;
   }
 
   private boolean isStaticCall() {
-    return stpCall.opCode() == OpCode.STATICCALL;
+    return stpCall.opCode().mnemonic() == OpCode.STATICCALL;
   }
 
   private boolean isCreate() {
-    return stpCall.opCode() == OpCode.CREATE;
+    return stpCall.opCode().mnemonic() == OpCode.CREATE;
   }
 
   private boolean isCreate2() {
-    return stpCall.opCode() == OpCode.CREATE2;
+    return stpCall.opCode().mnemonic() == OpCode.CREATE2;
   }
 
   long getGDiff() {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/StpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/StpOperation.java
@@ -40,27 +40,27 @@ public final class StpOperation extends ModuleOperation {
   }
 
   private boolean isCall() {
-    return stpCall.opCode().mnemonic() == OpCode.CALL;
+    return stpCall.opCode() == OpCode.CALL;
   }
 
   private boolean isCallCode() {
-    return stpCall.opCode().mnemonic() == OpCode.CALLCODE;
+    return stpCall.opCode() == OpCode.CALLCODE;
   }
 
   private boolean isDelegateCall() {
-    return stpCall.opCode().mnemonic() == OpCode.DELEGATECALL;
+    return stpCall.opCode() == OpCode.DELEGATECALL;
   }
 
   private boolean isStaticCall() {
-    return stpCall.opCode().mnemonic() == OpCode.STATICCALL;
+    return stpCall.opCode() == OpCode.STATICCALL;
   }
 
   private boolean isCreate() {
-    return stpCall.opCode().mnemonic() == OpCode.CREATE;
+    return stpCall.opCode() == OpCode.CREATE;
   }
 
   private boolean isCreate2() {
-    return stpCall.opCode().mnemonic() == OpCode.CREATE2;
+    return stpCall.opCode() == OpCode.CREATE2;
   }
 
   long getGDiff() {
@@ -77,7 +77,7 @@ public final class StpOperation extends ModuleOperation {
   }
 
   void trace(Trace.Stp trace, int stamp) {
-    if (stpCall.opCode().isCreate()) {
+    if (stpCall.opCodeData().isCreate()) {
       this.traceCreate(trace, stamp);
     } else {
       this.traceCall(trace, stamp);
@@ -181,7 +181,7 @@ public final class StpOperation extends ModuleOperation {
             .arg2Lo(Bytes.EMPTY)
             .exogenousModuleInstruction(UnsignedByte.of(OpCode.ISZERO.byteValue()))
             .resLo(Bytes.of(stpCall.value().isZero() ? 1 : 0))
-            .wcpFlag(stpCall.opCode().callHasValueArgument())
+            .wcpFlag(stpCall.opCodeData().callHasValueArgument())
             .modFlag(false)
             .fillAndValidateRow();
         case 2 -> trace
@@ -227,9 +227,9 @@ public final class StpOperation extends ModuleOperation {
 
   private int maxCt() {
     if (stpCall.outOfGasException()) {
-      return stpCall.opCode().isCreate() ? 1 : 2;
+      return stpCall.opCodeData().isCreate() ? 1 : 2;
     } else {
-      return stpCall.opCode().isCreate() ? 2 : 4;
+      return stpCall.opCodeData().isCreate() ? 2 : 4;
     }
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/CancunInstructionDecoder.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/CancunInstructionDecoder.java
@@ -20,8 +20,14 @@ import static net.consensys.linea.zktracer.opcode.InstructionFamily.TRANSIENT;
 
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
+import net.consensys.linea.zktracer.opcode.OpCodes;
 
 public class CancunInstructionDecoder extends LondonInstructionDecoder {
+
+  public CancunInstructionDecoder(OpCodes opCodes) {
+    super(opCodes);
+  }
+
   @Override
   protected void traceTransientFamily(OpCodeData op, Trace.Instdecoder trace) {
     trace.familyTransient(op.instructionFamily() == TRANSIENT);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/InstructionDecoder.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/InstructionDecoder.java
@@ -20,12 +20,18 @@ import java.util.List;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.Module;
 import net.consensys.linea.zktracer.opcode.InstructionFamily;
-import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
+import net.consensys.linea.zktracer.opcode.OpCodes;
 import net.consensys.linea.zktracer.opcode.gas.BillingRate;
 import net.consensys.linea.zktracer.types.UnsignedByte;
 
 public abstract class InstructionDecoder implements Module {
+  private final OpCodes opCodes;
+
+  public InstructionDecoder(OpCodes opCodes) {
+    this.opCodes = opCodes;
+  }
+
   private void traceFamily(OpCodeData op, Trace.Instdecoder trace) {
     trace
         .familyAdd(op.instructionFamily() == InstructionFamily.ADD)
@@ -128,7 +134,7 @@ public abstract class InstructionDecoder implements Module {
   }
 
   private void traceOpcode(final int i, final Trace trace) {
-    final OpCodeData op = OpCode.of(i).getData();
+    final OpCodeData op = opCodes.of(i);
     traceFamily(op, trace.instdecoder());
     traceStackSettings(op, trace.instdecoder());
     traceBillingSettings(op, trace.instdecoder());

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/LondonInstructionDecoder.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/LondonInstructionDecoder.java
@@ -17,9 +17,15 @@ package net.consensys.linea.zktracer.module.tables.instructionDecoder;
 
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
+import net.consensys.linea.zktracer.opcode.OpCodes;
 import net.consensys.linea.zktracer.opcode.gas.MxpType;
 
 public class LondonInstructionDecoder extends InstructionDecoder {
+
+  public LondonInstructionDecoder(OpCodes opCodes) {
+    super(opCodes);
+  }
+
   @Override
   protected void traceTransientFamily(OpCodeData op, Trace.Instdecoder trace) {
     // London does not have any transient family opcodes, they appear in Cancun

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCode.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCode.java
@@ -193,25 +193,6 @@ public enum OpCode {
     return OpCode.valueOf(mnemonic.toUpperCase());
   }
 
-  //
-  //  /**
-  //   * Retrieves {@link OpCode} metadata of type {@link OpCodeData}.
-  //   *
-  //   * @return the current {@link OpCode}'s {@link OpCodeData}
-  //   */
-  //  public OpCodeData getData() {
-  //    return OpCodes.of(this);
-  //  }
-  //
-  //  /**
-  //   * Retrieves the {@link OpCode} corresponding to a given value.
-  //   *
-  //   * @return the {@link OpCode}
-  //   */
-  //  public static OpCode of(final int value) {
-  //    return OpCodes.of(value).mnemonic();
-  //  }
-  //
   /**
    * Returns the {@link OpCode}'s opcode value as a byte.
    *

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCode.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCode.java
@@ -18,7 +18,6 @@ package net.consensys.linea.zktracer.opcode;
 import static com.google.common.base.Preconditions.*;
 import static net.consensys.linea.zktracer.Trace.*;
 
-import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.types.UnsignedByte;
 
 /** Represents the entire set of opcodes that are required by the arithmetization process. */
@@ -194,31 +193,32 @@ public enum OpCode {
     return OpCode.valueOf(mnemonic.toUpperCase());
   }
 
+  //
+  //  /**
+  //   * Retrieves {@link OpCode} metadata of type {@link OpCodeData}.
+  //   *
+  //   * @return the current {@link OpCode}'s {@link OpCodeData}
+  //   */
+  //  public OpCodeData getData() {
+  //    return OpCodes.of(this);
+  //  }
+  //
+  //  /**
+  //   * Retrieves the {@link OpCode} corresponding to a given value.
+  //   *
+  //   * @return the {@link OpCode}
+  //   */
+  //  public static OpCode of(final int value) {
+  //    return OpCodes.of(value).mnemonic();
+  //  }
+  //
   /**
-   * Retrieves {@link OpCode} metadata of type {@link OpCodeData}.
+   * Returns the {@link OpCode}'s opcode value as a byte.
    *
-   * @return the current {@link OpCode}'s {@link OpCodeData}
-   */
-  public OpCodeData getData() {
-    return OpCodes.of(this);
-  }
-
-  /**
-   * Retrieves the {@link OpCode} corresponding to a given value.
-   *
-   * @return the {@link OpCode}
-   */
-  public static OpCode of(final int value) {
-    return OpCodes.of(value).mnemonic();
-  }
-
-  /**
-   * Returns the {@link OpCode}'s long value as a byte type.
-   *
-   * @return the {@link OpCode}'s value as a byte
+   * @return the {@link OpCode}'s opcode value as a byte
    */
   public byte byteValue() {
-    return (byte) this.getData().value();
+    return (byte) this.opcode;
   }
 
   /**
@@ -228,63 +228,6 @@ public enum OpCode {
    */
   public UnsignedByte unsignedByteValue() {
     return UnsignedByte.of(byteValue());
-  }
-
-  /** Returns true for PUSH-type instructions */
-  public boolean isNonTrivialPush() {
-    return getData().isNonTrivialPush();
-  }
-
-  public boolean isPushZero() {
-    return getData().isPushZero();
-  }
-
-  /** Returns true for JUMP-type instructions */
-  public boolean isJump() {
-    return getData().isJump();
-  }
-
-  public boolean isLog() {
-    return getData().isLog();
-  }
-
-  public boolean isCopy() {
-    return getData().isCopy();
-  }
-
-  /** Returns whether the {@link OpCode} entails a contract creation. */
-  public boolean isCreate() {
-    return getData().isCreate();
-  }
-
-  /** Returns whether the {@link OpCode} is one of the CALL opcodes */
-  public boolean isCall() {
-    return getData().isCall();
-  }
-
-  public boolean isHalt() {
-    return getData().isHalt();
-  }
-
-  public boolean isCallOrCreate() {
-    return isCall() || isCreate();
-  }
-
-  public boolean callHasValueArgument() {
-    checkArgument(isCall(), "Expected any CALL opcode, got %s", this);
-    return this == CALL || this == CALLCODE;
-  }
-
-  public short callCdoStackIndex() {
-    return (short) (callHasValueArgument() ? 3 : 2);
-  }
-
-  public short callCdsStackIndex() {
-    return (short) (callHasValueArgument() ? 4 : 3);
-  }
-
-  public short callReturnAtCapacityStackIndex() {
-    return (short) (callHasValueArgument() ? 6 : 5);
   }
 
   /**
@@ -301,29 +244,5 @@ public enum OpCode {
     }
 
     return false;
-  }
-
-  public short numberOfStackRows() {
-    return (short) (this.getData().numberOfStackRows());
-  }
-
-  public boolean mayTriggerStackUnderflow() {
-    return this.getData().stackSettings().delta() > 0;
-  }
-
-  public boolean mayTriggerStackOverflow() {
-    return this.getData().stackSettings().alpha() > 0;
-  }
-
-  public boolean mayTriggerStaticException() {
-    return this.getData().stackSettings().forbiddenInStatic();
-  }
-
-  public boolean mayTriggerMemoryExpansionException(Fork fork) {
-    return switch (fork) {
-      case LONDON, PARIS, SHANGHAI -> this != MSIZE && this.getData().isMxpLondon();
-      case CANCUN, PRAGUE -> this != MSIZE && this.getData().isMxp();
-      default -> throw new IllegalArgumentException("Unknown fork: " + fork);
-    };
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
@@ -254,14 +254,16 @@ public record OpCodeData(
 
   @Override
   public boolean equals(Object o) {
-    // Instances of this class are not intended to be compared.  Hence, an exception is explicitly raised to quickly
+    // Instances of this class are not intended to be compared.  Hence, an exception is explicitly
+    // raised to quickly
     // identify situations where this method is accidentally being used.
     throw new UnsupportedOperationException();
   }
 
   @Override
   public int hashCode() {
-    // Instances of this class are not intended to be used in hashmaps, etc.  Hence, an exception is explicitly raised
+    // Instances of this class are not intended to be used in hashmaps, etc.  Hence, an exception is
+    // explicitly raised
     // to quickly identify situations where this method is accidentally being used.
     throw new UnsupportedOperationException();
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
@@ -15,17 +15,21 @@
 
 package net.consensys.linea.zktracer.opcode;
 
+import static com.google.common.base.Preconditions.*;
 import static net.consensys.linea.zktracer.Trace.*;
 import static net.consensys.linea.zktracer.opcode.InstructionFamily.*;
+import static net.consensys.linea.zktracer.opcode.OpCode.MSIZE;
 
 import java.util.Objects;
 
+import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.opcode.gas.Billing;
 import net.consensys.linea.zktracer.opcode.gas.BillingRate;
 import net.consensys.linea.zktracer.opcode.gas.GasConstants;
 import net.consensys.linea.zktracer.opcode.gas.MxpType;
 import net.consensys.linea.zktracer.opcode.stack.Pattern;
 import net.consensys.linea.zktracer.opcode.stack.StackSettings;
+import net.consensys.linea.zktracer.types.UnsignedByte;
 
 /**
  * Contains the {@link OpCode} and its related metadata.
@@ -107,6 +111,10 @@ public record OpCodeData(
     return instructionFamily == CREATE;
   }
 
+  public boolean isCallOrCreate() {
+    return isCall() || isCreate();
+  }
+
   public boolean isLog() {
     return instructionFamily == LOG;
   }
@@ -129,7 +137,7 @@ public record OpCodeData(
   }
 
   public boolean isMSize() {
-    return mnemonic == OpCode.MSIZE;
+    return mnemonic == MSIZE;
   }
 
   public boolean isFixedSize32() {
@@ -169,7 +177,7 @@ public record OpCodeData(
   }
 
   public boolean isBytePricing() {
-    return mnemonic == OpCode.MSIZE
+    return mnemonic == MSIZE
         || mnemonic == OpCode.MLOAD
         || mnemonic == OpCode.MSTORE
         || mnemonic == OpCode.MSTORE8
@@ -187,5 +195,60 @@ public record OpCodeData(
   // Used from Cancun and on, before ixMxp is determined by checking if there is a type
   public boolean isMxp() {
     return isMSize() || isSingleOffset() || isDoubleOffset();
+  }
+
+  public boolean callHasValueArgument() {
+    checkArgument(isCall(), "Expected any CALL opcode, got %s", this);
+    return this.mnemonic == OpCode.CALL || this.mnemonic == OpCode.CALLCODE;
+  }
+
+  /**
+   * Returns the {@link OpCode}'s opcode value as a byte.
+   *
+   * @return the {@link OpCode}'s opcode value as a byte
+   */
+  public byte byteValue() {
+    return (byte) this.value;
+  }
+
+  /**
+   * Returns the {@link OpCode}'s long value as an {@link UnsignedByte} type.
+   *
+   * @return the {@link OpCode}'s value as an {@link UnsignedByte}
+   */
+  public UnsignedByte unsignedByteValue() {
+    return UnsignedByte.of(byteValue());
+  }
+
+  public short callCdoStackIndex() {
+    return (short) (callHasValueArgument() ? 3 : 2);
+  }
+
+  public short callCdsStackIndex() {
+    return (short) (callHasValueArgument() ? 4 : 3);
+  }
+
+  public short callReturnAtCapacityStackIndex() {
+    return (short) (callHasValueArgument() ? 6 : 5);
+  }
+
+  public boolean mayTriggerStackUnderflow() {
+    return this.stackSettings().delta() > 0;
+  }
+
+  public boolean mayTriggerStackOverflow() {
+    return this.stackSettings().alpha() > 0;
+  }
+
+  public boolean mayTriggerStaticException() {
+    return this.stackSettings().forbiddenInStatic();
+  }
+
+  public boolean mayTriggerMemoryExpansionException(Fork fork) {
+    return switch (fork) {
+      case LONDON, PARIS, SHANGHAI -> this.mnemonic != MSIZE && this.isMxpLondon();
+      case CANCUN, PRAGUE -> this.mnemonic != MSIZE && this.isMxp();
+      default -> throw new IllegalArgumentException("Unknown fork: " + fork);
+    };
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
@@ -251,4 +251,18 @@ public record OpCodeData(
       default -> throw new IllegalArgumentException("Unknown fork: " + fork);
     };
   }
+
+  @Override
+  public boolean equals(Object o) {
+    // Instances of this class are not intended to be compared.  Hence, an exception is explicitly raised to quickly
+    // identify situations where this method is accidentally being used.
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int hashCode() {
+    // Instances of this class are not intended to be used in hashmaps, etc.  Hence, an exception is explicitly raised
+    // to quickly identify situations where this method is accidentally being used.
+    throw new UnsupportedOperationException();
+  }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodes.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodes.java
@@ -16,10 +16,10 @@
 package net.consensys.linea.zktracer.opcode;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -40,46 +40,102 @@ import net.consensys.linea.zktracer.opcode.gas.BillingDeserializer;
  */
 public class OpCodes {
   private static final short OPCODES_LIST_SIZE = 256;
-  private static volatile Fork forkLoaded;
-  private static final List<OpCodeData> opCodeDataList = new ArrayList<>(OPCODES_LIST_SIZE);
 
-  /** Loads all opcode metadata from src/main/resources/shanghaiOpcodes.yml. */
-  @SneakyThrows(IOException.class)
-  public static void loadOpcodes(Fork fork) {
-    // Handle fast case where fork already loaded
-    if (fork.equals(forkLoaded)) {
-      log.debug("opCodeDataList has already been initialized for {} fork.", fork);
-      return;
-    } else if (forkLoaded != null) {
-      throw new IllegalArgumentException(
-          "request to load opcodes for "
-              + fork
-              + " conflicts with those previously "
-              + "loaded for "
-              + forkLoaded);
+  /**
+   * Map of fork to loaded opcode information. The purpose of this map is to prevent a given YAML
+   * file from being loaded more than once. In actual fact, this could happen if we have concurrent
+   * accesses which are very close together --- but that is not a real concern.
+   */
+  private static final ConcurrentHashMap<Fork, OpCodes> opCodesMap = new ConcurrentHashMap<>();
+
+  /**
+   * Loads all opcode metadata for a given fork. This may result in loading the necessary
+   * information from a corresponding yaml file. Howwever, this method caches OpCodes instances to
+   * prevent this happening more than once.
+   *
+   * @param fork Fork for which opcode metadata is required.
+   * @return
+   */
+  public static OpCodes load(Fork fork) {
+    OpCodes instance = opCodesMap.get(fork);
+    //
+    if (instance == null) {
+      instance = new OpCodes(fork);
+      opCodesMap.put(fork, instance);
     }
-    // Slow case.  Acquire lock and load opcodes.
-    synchronized (opCodeDataList) {
-      if (forkLoaded != null) {
-        // Retry to get either an error or a warning above.
-        loadOpcodes(fork);
-        return;
-      }
-      // If we get here, then we are the only thread where forkLoaded == null.  Therefore, we can
-      // proceed in peace.
-      for (int i = 0; i < OPCODES_LIST_SIZE; i++) {
-        opCodeDataList.add(null);
-      }
-      for (OpCodeData opCodeData : opCodesLocal(fork)) {
-        opCodeDataList.set(opCodeData.value(), opCodeData);
-      }
-      // Finally, assign the fork.  Note, this must be done last.
-      forkLoaded = fork;
+    // Done
+    return instance;
+  }
+
+  /** Opcode data appropriate for a given fork. */
+  private final OpCodeData[] opcodes = new OpCodeData[OPCODES_LIST_SIZE];
+
+  /**
+   * Construct a new instance of OpCodes for a given fork. This necessarily loads the opcode
+   * information from the corresponding YAML file.
+   *
+   * @param fork
+   */
+  private OpCodes(Fork fork) {
+    for (OpCodeData opCodeData : opCodesLocal(fork)) {
+      opcodes[opCodeData.value()] = opCodeData;
     }
   }
 
+  /**
+   * isValid checks whether or not a given opcode index corresponds with a real opcode.
+   *
+   * @param value
+   * @return
+   */
+  public boolean isValid(final int value) {
+    if (value < 0 || value > 255) {
+      throw new IllegalArgumentException("No OpCode with value %s is defined.".formatted(value));
+    }
+    return opcodes[value] != null;
+  }
+
+  /**
+   * Get opcode metadata per opcode long value.
+   *
+   * @param value opcode value.
+   * @return an instance of {@link OpCodeData} corresponding to the numeric value.
+   */
+  public OpCodeData of(final int value) {
+    if (value < 0 || value > 255) {
+      throw new IllegalArgumentException("No OpCode with value %s is defined.".formatted(value));
+    }
+    //
+    return Optional.ofNullable(opcodes[value]).orElse(OpCodeData.forNonOpCodes(value));
+  }
+
+  /**
+   * Get opcode metadata per opcode mnemonic of type {@link OpCode}.
+   *
+   * @param code opcode mnemonic of type {@link OpCode}.
+   * @return an instance of {@link OpCodeData} corresponding to mnemonic of type {@link OpCode}.
+   */
+  public OpCodeData of(final OpCode code) {
+    //
+    return Optional.ofNullable(opcodes[code.getOpcode()])
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "No OpCode of mnemonic %s is defined.".formatted(code)));
+  }
+
+  /**
+   * Get an iterator over the underlying opcode data.
+   *
+   * @return
+   */
+  public Iterable<OpCodeData> iterator() {
+    return Arrays.asList(opcodes);
+  }
+
   // Load opcodedata from yaml file.
-  private static List<OpCodeData> opCodesLocal(Fork fork) throws IOException {
+  @SneakyThrows(IOException.class)
+  private static List<OpCodeData> opCodesLocal(Fork fork) {
     final JsonConverter yamlConverter = JsonConverter.builder().enableYaml().build();
 
     final String yamlFileName = Fork.toString(fork) + "Opcodes.yml";
@@ -108,88 +164,5 @@ public class OpCodes {
     yamlConverter.getObjectMapper().registerModule(module);
 
     return yamlConverter.getObjectMapper().treeToValue(rootNode, typeReference);
-  }
-
-  /**
-   * isValid checks whether or not a given opcode index corresponds with a real opcode.
-   *
-   * @param value
-   * @return
-   */
-  public static boolean isValid(final int value) {
-    if (value < 0 || value > 255) {
-      throw new IllegalArgumentException("No OpCode with value %s is defined.".formatted(value));
-    }
-    synchronized (opCodeDataList) {
-      if (opCodeDataList.isEmpty()) {
-        throw new IllegalArgumentException("opcodes not initialised!");
-      }
-      return opCodeDataList.get(value) != null;
-    }
-  }
-
-  /**
-   * Get opcode metadata per opcode long value.
-   *
-   * @param value opcode value.
-   * @return an instance of {@link OpCodeData} corresponding to the numeric value.
-   */
-  public static OpCodeData of(final int value) {
-    if (value < 0 || value > 255) {
-      throw new IllegalArgumentException("No OpCode with value %s is defined.".formatted(value));
-    }
-    synchronized (opCodeDataList) {
-      if (opCodeDataList.isEmpty()) {
-        throw new IllegalArgumentException("opcodes not initialised!");
-      }
-      //
-      return Optional.ofNullable(opCodeDataList.get(value)).orElse(OpCodeData.forNonOpCodes(value));
-    }
-  }
-
-  /**
-   * Get opcode metadata per opcode mnemonic of type {@link OpCode}.
-   *
-   * @param code opcode mnemonic of type {@link OpCode}.
-   * @return an instance of {@link OpCodeData} corresponding to mnemonic of type {@link OpCode}.
-   */
-  public static OpCodeData of(final OpCode code) {
-    synchronized (opCodeDataList) {
-      if (opCodeDataList.isEmpty()) {
-        throw new IllegalArgumentException("opcodes not initialised!");
-      }
-      //
-      return Optional.ofNullable(opCodeDataList.get(code.getOpcode()))
-          .orElseThrow(
-              () ->
-                  new IllegalArgumentException(
-                      "No OpCode of mnemonic %s is defined.".formatted(code)));
-    }
-  }
-
-  /**
-   * Get opcode metadata for a list of {@link OpCode}s.
-   *
-   * @param codes a list of opcode mnemonics of type {@link OpCode}.
-   * @return a list of {@link OpCodeData} items corresponding their mnemonics of type {@link
-   *     OpCode}.
-   */
-  public static List<OpCodeData> of(final OpCode... codes) {
-    return Arrays.stream(codes).map(OpCodes::of).toList();
-  }
-
-  /**
-   * Get an iterator over the underlying opcode data.
-   *
-   * @return
-   */
-  public static Iterable<OpCodeData> iterator() {
-    synchronized (opCodeDataList) {
-      if (opCodeDataList.isEmpty()) {
-        throw new IllegalArgumentException("opcodes not initialised!");
-      }
-      //
-      return opCodeDataList;
-    }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodes.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodes.java
@@ -96,6 +96,16 @@ public class OpCodes {
   }
 
   /**
+   * isValid checks whether or not a given opcode index corresponds with a real opcode.
+   *
+   * @param opcode
+   * @return
+   */
+  public boolean isValid(final OpCode opcode) {
+    return isValid(opcode.getOpcode());
+  }
+
+  /**
    * Get opcode metadata per opcode long value.
    *
    * @param value opcode value.

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/gas/projector/GasProjector.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/gas/projector/GasProjector.java
@@ -19,7 +19,7 @@ import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 
 import lombok.RequiredArgsConstructor;
 import net.consensys.linea.zktracer.module.hub.transients.OperationAncillaries;
-import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.account.Account;
@@ -32,8 +32,8 @@ public class GasProjector {
 
   final GasCalculator gc;
 
-  public GasProjection of(MessageFrame frame, OpCode opCode) {
-    return switch (opCode) {
+  public GasProjection of(MessageFrame frame, OpCodeData opCode) {
+    return switch (opCode.mnemonic()) {
       case STOP -> new Zero(gc);
       case ADD,
           SUB,
@@ -172,8 +172,8 @@ public class GasProjector {
               gc,
               frame,
               maxGasAllowance,
-              OperationAncillaries.callDataSegment(frame),
-              OperationAncillaries.returnDataRequestedSegment(frame),
+              OperationAncillaries.callDataSegment(frame, opCode),
+              OperationAncillaries.returnDataRequestedSegment(frame, opCode),
               value,
               recipient,
               to);
@@ -191,8 +191,8 @@ public class GasProjector {
               gc,
               frame,
               stipend,
-              OperationAncillaries.callDataSegment(frame),
-              OperationAncillaries.returnDataRequestedSegment(frame),
+              OperationAncillaries.callDataSegment(frame, opCode),
+              OperationAncillaries.returnDataRequestedSegment(frame, opCode),
               value,
               recipient,
               to);
@@ -209,8 +209,8 @@ public class GasProjector {
               gc,
               frame,
               stipend,
-              OperationAncillaries.callDataSegment(frame),
-              OperationAncillaries.returnDataRequestedSegment(frame),
+              OperationAncillaries.callDataSegment(frame, opCode),
+              OperationAncillaries.returnDataRequestedSegment(frame, opCode),
               Wei.ZERO,
               recipient,
               to);
@@ -227,8 +227,8 @@ public class GasProjector {
               gc,
               frame,
               stipend,
-              OperationAncillaries.callDataSegment(frame),
-              OperationAncillaries.returnDataRequestedSegment(frame),
+              OperationAncillaries.callDataSegment(frame, opCode),
+              OperationAncillaries.returnDataRequestedSegment(frame, opCode),
               Wei.ZERO,
               recipient,
               to);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/callstack/CallFrame.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/callstack/CallFrame.java
@@ -15,6 +15,8 @@
 
 package net.consensys.linea.zktracer.runtime.callstack;
 
+import static net.consensys.linea.zktracer.Trace.EVM_INST_STOP;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,9 +27,6 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.section.TraceSection;
 import net.consensys.linea.zktracer.module.romlex.ContractMetadata;
-import net.consensys.linea.zktracer.opcode.OpCode;
-import net.consensys.linea.zktracer.opcode.OpCodeData;
-import net.consensys.linea.zktracer.opcode.OpCodes;
 import net.consensys.linea.zktracer.runtime.stack.Stack;
 import net.consensys.linea.zktracer.runtime.stack.StackContext;
 import net.consensys.linea.zktracer.types.Bytecode;
@@ -79,8 +78,7 @@ public class CallFrame {
   }
 
   @Getter @Setter private int pc;
-  @Getter @Setter private OpCode opCode = OpCode.STOP;
-  @Getter @Setter private OpCodeData opCodeData = OpCodes.of(OpCode.STOP);
+  @Getter @Setter private int opCode = EVM_INST_STOP;
   @Getter private MessageFrame frame; // TODO: can we make this final ?
 
   // various memory ranges
@@ -260,8 +258,7 @@ public class CallFrame {
 
   public void frame(MessageFrame frame) {
     this.frame = frame;
-    opCode = OpCode.of(frame.getCurrentOperation().getOpcode());
-    opCodeData = OpCodes.of(opCode);
+    opCode = frame.getCurrentOperation().getOpcode();
     pc = frame.getPC();
   }
 
@@ -269,13 +266,5 @@ public class CallFrame {
       final MessageFrame frame, final Range range) {
     // TODO: optimize me please. Need a review of the MMU operation handling.
     return range.isEmpty() ? Bytes.EMPTY : frame.shadowReadMemory(0, frame.memoryByteSize());
-  }
-
-  public OpCode getOpCode() {
-    return getOpCode(frame);
-  }
-
-  public static OpCode getOpCode(MessageFrame frame) {
-    return OpCode.of(0xFF & frame.getCurrentOperation().getOpcode());
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/stack/Stack.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/stack/Stack.java
@@ -294,7 +294,7 @@ public class Stack {
     Bytes val5 = getStack(frame, 4);
     Bytes val6 = getStack(frame, 5);
 
-    boolean callCanTransferValue = currentOpcodeData.mnemonic().callHasValueArgument();
+    boolean callCanTransferValue = currentOpcodeData.callHasValueArgument();
 
     if (callCanTransferValue) {
       Bytes val7 = getStack(frame, 6);
@@ -393,7 +393,7 @@ public class Stack {
     final CallFrame callFrame = hub.currentFrame();
     stamp = stackStamp;
     currentOpcodeData = hub.opCodeData();
-    callFrame.pending(new StackContext(currentOpcodeData.mnemonic()));
+    callFrame.pending(new StackContext(currentOpcodeData));
 
     final short delta = (short) currentOpcodeData.stackSettings().delta();
     final short alpha = (short) currentOpcodeData.stackSettings().alpha();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/stack/StackContext.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/stack/StackContext.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.runtime.callstack.CallFrame;
 
 /**
@@ -34,7 +35,7 @@ import net.consensys.linea.zktracer.runtime.callstack.CallFrame;
 public final class StackContext {
 
   /** The opcode that triggered the stack operations. */
-  final OpCode opCode;
+  final OpCodeData opCode;
 
   /** One or two lines to be traced, representing the stack operations performed by the opcode. */
   @Getter final List<StackLine> lines;
@@ -44,7 +45,7 @@ public final class StackContext {
    *
    * @param opCode the {@link OpCode} triggering the lines creation
    */
-  public StackContext(OpCode opCode) {
+  public StackContext(OpCodeData opCode) {
     this.opCode = opCode;
     lines = new ArrayList<>(opCode.numberOfStackRows());
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/types/AddressUtils.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/types/AddressUtils.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import net.consensys.linea.zktracer.module.hub.transients.OperationAncillaries;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.crypto.Hash;
@@ -105,18 +106,19 @@ public class AddressUtils {
     return Hash.keccak256(Bytes.concatenate(CREATE2_PREFIX, sender, salt, hash));
   }
 
-  public static Address getCreate2Address(final MessageFrame frame) {
+  public static Address getCreate2Address(final MessageFrame frame, OpCodeData opCode) {
     final Address sender = frame.getRecipientAddress();
     final Bytes32 salt = Bytes32.leftPad(frame.getStackItem(3));
-    final Bytes initCode = OperationAncillaries.initCode(frame);
+    final Bytes initCode = OperationAncillaries.initCode(frame, opCode);
     final Bytes32 hash = Hash.keccak256(initCode);
     return Address.extract(getCreate2RawAddress(sender, salt, hash));
   }
 
-  public static Address getDeploymentAddress(final MessageFrame frame) {
-    final OpCode opcode = OpCode.of(frame.getCurrentOperation().getOpcode());
-    checkArgument(opcode.isCreate(), "Must be called only for CREATE/CREATE2 opcode");
-    return opcode.equals(OpCode.CREATE) ? getCreateAddress(frame) : getCreate2Address(frame);
+  public static Address getDeploymentAddress(final MessageFrame frame, final OpCodeData opCode) {
+    checkArgument(opCode.isCreate(), "Must be called only for CREATE/CREATE2 opcode");
+    return opCode.mnemonic() == OpCode.CREATE
+        ? getCreateAddress(frame)
+        : getCreate2Address(frame, opCode);
   }
 
   public static Address addressFromBytes(final Bytes input) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/types/Range.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/types/Range.java
@@ -17,7 +17,7 @@ package net.consensys.linea.zktracer.types;
 
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 
-import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
@@ -52,8 +52,7 @@ public record Range(long offset, long size) {
     return size.isZero() ? Range.empty() : new Range(clampedToLong(offset), clampedToLong(size));
   }
 
-  public static Range callDataRange(MessageFrame frame) {
-    final OpCode opCode = OpCode.of(frame.getCurrentOperation().getOpcode());
+  public static Range callDataRange(MessageFrame frame, OpCodeData opCode) {
     final Bytes offset = frame.getStackItem(opCode.callCdoStackIndex());
     final Bytes size = frame.getStackItem(opCode.callCdsStackIndex());
     return fromOffsetAndSize(offset, size);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/OpCodesTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/OpCodesTest.java
@@ -15,8 +15,6 @@
 
 package net.consensys.linea.zktracer;
 
-import static net.consensys.linea.zktracer.opcode.OpCodes.loadOpcodes;
-
 import net.consensys.linea.UnitTestWatcher;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.BytecodeCompiler;
@@ -24,7 +22,6 @@ import net.consensys.linea.testing.BytecodeRunner;
 import net.consensys.linea.zktracer.opcode.InstructionFamily;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
-import net.consensys.linea.zktracer.opcode.OpCodes;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,8 +37,8 @@ public class OpCodesTest extends TracerTestBase {
 
   private Bytes getAllOpCodesProgram() {
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
-    loadOpcodes(fork);
-    for (OpCodeData opCodeData : OpCodes.iterator()) {
+    //
+    for (OpCodeData opCodeData : opcodes.iterator()) {
       if (opCodeData != null) {
         if (opCodeData.instructionFamily() != InstructionFamily.HALT
             && opCodeData.instructionFamily() != InstructionFamily.JUMP) {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/InvalidOpcodeExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/InvalidOpcodeExceptionTest.java
@@ -26,7 +26,6 @@ import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.BytecodeRunner;
 import net.consensys.linea.zktracer.module.hub.signals.TracedException;
 import net.consensys.linea.zktracer.opcode.OpCode;
-import net.consensys.linea.zktracer.opcode.OpCodes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -61,9 +60,10 @@ public class InvalidOpcodeExceptionTest extends TracerTestBase {
 
   static Stream<Arguments> nonOpcodeExceptionSource() {
     List<Arguments> arguments = new ArrayList<>();
+    //
     for (int value = 0; value < 256; value++) {
       // If value is not in the map, then it is not an OpCode
-      if (!OpCodes.isValid(value)) {
+      if (!opcodes.isValid(value)) {
         arguments.add(Arguments.of(value));
       }
     }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/MemoryExpansionExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/MemoryExpansionExceptionTest.java
@@ -49,7 +49,7 @@ public class MemoryExpansionExceptionTest extends TracerTestBase {
   public void memoryExpansionExceptionTest(boolean triggerRoob, OpCode opCode) {
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     boolean triggerMaxCodeSizeException = false;
-    new MxpTestUtils()
+    new MxpTestUtils(opcodes)
         .triggerNonTrivialButMxpxOrRoobOrMaxCodeSizeExceptionForOpCode(
             fork, program, triggerRoob, triggerMaxCodeSizeException, opCode);
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
@@ -74,7 +74,7 @@ public class MemoryExpansionExceptionTest extends TracerTestBase {
     boolean triggerMaxCodeSizeException = false;
     OpCode opCode = OpCode.CODECOPY;
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
-    new MxpTestUtils()
+    new MxpTestUtils(opcodes)
         .triggerNonTrivialButMxpxOrRoobOrMaxCodeSizeExceptionForOpCode(
             fork, program, triggerRoob, triggerMaxCodeSizeException, opCode);
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfGasExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/OutOfGasExceptionTest.java
@@ -18,7 +18,6 @@ package net.consensys.linea.zktracer.exceptions;
 import static net.consensys.linea.testing.ToyExecutionEnvironmentV2.DEFAULT_BLOCK_NUMBER;
 import static net.consensys.linea.zktracer.Trace.*;
 import static net.consensys.linea.zktracer.module.hub.signals.TracedException.OUT_OF_GAS_EXCEPTION;
-import static net.consensys.linea.zktracer.opcode.OpCodes.loadOpcodes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -35,7 +34,6 @@ import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
-import net.consensys.linea.zktracer.opcode.OpCodes;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
@@ -52,16 +50,14 @@ public class OutOfGasExceptionTest extends TracerTestBase {
   @ParameterizedTest
   @MethodSource("outOfGasExceptionWithEmptyAccountsAndNoMemoryExpansionCostTestSource")
   void outOfGasExceptionWithEmptyAccountsAndNoMemoryExpansionCostTest(int opcode, int cornerCase) {
-    // Ensure opcodes relevant to the given fork are loaded.
-    loadOpcodes(fork);
     // TODO: enable SELFDESTRUCT for Cancun again after fixing the issue
     // https://github.com/Consensys/linea-tracer/issues/2159
     // PR https://github.com/Consensys/linea-tracer/pull/2184
     if (fork == Fork.CANCUN && opcode == 255) {
       return;
     }
-    //
-    OpCodeData opCodeData = OpCodes.of(opcode);
+    // Extract relevant opcode data
+    OpCodeData opCodeData = opcodes.of(opcode);
     // Only test opcodes which do not cause memory expansion.
     if (noMemoryExpansion(opCodeData)) {
       OpCode opCode = opCodeData.mnemonic();

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/StackOverflowExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/StackOverflowExceptionTest.java
@@ -27,7 +27,6 @@ import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.BytecodeRunner;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
-import net.consensys.linea.zktracer.opcode.OpCodes;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -56,7 +55,8 @@ public class StackOverflowExceptionTest extends TracerTestBase {
 
   static Stream<Arguments> stackOverflowExceptionSource() {
     List<Arguments> arguments = new ArrayList<>();
-    for (OpCodeData opCodeData : OpCodes.iterator()) {
+
+    for (OpCodeData opCodeData : opcodes.iterator()) {
       if (opCodeData != null) {
         OpCode opCode = opCodeData.mnemonic();
         int alpha = opCodeData.stackSettings().alpha(); // number of items pushed onto the stack

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/StackUnderflowExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/StackUnderflowExceptionTest.java
@@ -66,7 +66,9 @@ public class StackUnderflowExceptionTest extends TracerTestBase {
 
   static Stream<Arguments> stackUnderflowExceptionSource() {
     List<Arguments> arguments = new ArrayList<>();
-    for (OpCodeData opCodeData : OpCodes.iterator()) {
+    OpCodes opcodes = OpCodes.load(fork);
+    //
+    for (OpCodeData opCodeData : opcodes.iterator()) {
       if (opCodeData != null) {
         OpCode opCode = opCodeData.mnemonic();
         int delta = opCodeData.stackSettings().delta(); // number of items popped from the stack

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/StaticExceptionTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/StaticExceptionTest.java
@@ -161,7 +161,9 @@ public class StaticExceptionTest extends TracerTestBase {
     for (int i = 0; i < numberOfTopics; i++) {
       calleeProgram.push(0);
     }
-    calleeProgram.push(0).push(0).op(OpCode.of(OpCode.LOG0.getData().value() + numberOfTopics));
+    // Construct appropriate LOG bytecode for the given number of topics.
+    OpCode opCode = opcodes.of(OpCode.LOG0.getOpcode() + numberOfTopics).mnemonic();
+    calleeProgram.push(0).push(0).op(opCode);
 
     final ToyAccount calleeAccount =
         ToyAccount.builder()

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/CallTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/CallTest.java
@@ -141,7 +141,7 @@ public class CallTest extends TracerTestBase {
     for (boolean roob : triggerRoob) {
       // We prepare a program with an MXPX for the opcode
       BytecodeCompiler pg = BytecodeCompiler.newProgram(testInfo);
-      new MxpTestUtils()
+      new MxpTestUtils(opcodes)
           .triggerNonTrivialButMxpxOrRoobOrMaxCodeSizeExceptionForOpCode(
               fork, pg, roob, triggerMaxCodeSizeException, OpCode.CALL);
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/CreatesTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/CreatesTest.java
@@ -101,7 +101,7 @@ public class CreatesTest extends TracerTestBase {
     for (boolean roob : triggerRoob) {
       // We prepare a program with an MXPX for the opcode
       BytecodeCompiler pg = BytecodeCompiler.newProgram(testInfo);
-      new MxpTestUtils()
+      new MxpTestUtils(opcodes)
           .triggerNonTrivialButMxpxOrRoobOrMaxCodeSizeExceptionForOpCode(
               fork, pg, roob, triggerMaxCodeSizeException, opCode);
 
@@ -197,7 +197,7 @@ public class CreatesTest extends TracerTestBase {
     for (boolean roob : triggerRoob) {
       // We prepare a program with an MXPX and MAX_CODE_SIZE_EXCEPTION for the opcode
       BytecodeCompiler pg = BytecodeCompiler.newProgram(testInfo);
-      new MxpTestUtils()
+      new MxpTestUtils(opcodes)
           .triggerNonTrivialButMxpxOrRoobOrMaxCodeSizeExceptionForOpCode(
               fork, pg, roob, maxCodeSizeException, opCode);
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/LogsTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/exceptions/multiExceptions/LogsTest.java
@@ -90,7 +90,7 @@ public class LogsTest extends TracerTestBase {
     for (boolean roob : triggerRoob) {
       // We prepare a program with an MXPX for the opcode
       BytecodeCompiler pg = BytecodeCompiler.newProgram(testInfo);
-      new MxpTestUtils()
+      new MxpTestUtils(opcodes)
           .triggerNonTrivialButMxpxOrRoobOrMaxCodeSizeExceptionForOpCode(
               fork, pg, roob, triggerMaxCodeSizeException, opCode);
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/Utilities.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/Utilities.java
@@ -26,6 +26,7 @@ import java.util.Random;
 import net.consensys.linea.UnitTestWatcher;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -48,7 +49,7 @@ public class Utilities {
       int rao,
       int rac) {
     program.push(rac).push(rao).push(cds).push(cdo);
-    if (callOpcode.callHasValueArgument()) {
+    if (program.opCodeData(callOpcode).callHasValueArgument()) {
       program.push(value);
     }
     program.push(to).op(GAS).op(callOpcode).op(POP);
@@ -65,7 +66,7 @@ public class Utilities {
       int rao,
       int rac) {
     program.push(rac).push(rao).push(cds).push(cdo);
-    if (callOpcode.callHasValueArgument()) {
+    if (program.opCodeData(callOpcode).callHasValueArgument()) {
       program.push(value);
     }
     program.push(to).push(gas).op(callOpcode);
@@ -81,7 +82,7 @@ public class Utilities {
       int rao,
       int rac) {
     program.push(rac).push(rao).push(cds).push(cdo);
-    if (callOpcode.callHasValueArgument()) {
+    if (program.opCodeData(callOpcode).callHasValueArgument()) {
       program.push(value);
     }
     program.op(CALLER).push(gas).op(callOpcode);
@@ -96,7 +97,7 @@ public class Utilities {
       int cds,
       int rao,
       int rac) {
-    checkArgument(callOpcode.callHasValueArgument());
+    checkArgument(program.opCodeData(callOpcode).callHasValueArgument());
     program
         .push(rac)
         .push(rao)
@@ -245,10 +246,11 @@ public class Utilities {
    * @param callOpCode
    */
   public static void appendCallTo(BytecodeCompiler program, OpCode callOpCode, Address address) {
-    checkArgument(callOpCode.isCall());
+    OpCodeData callInfo = program.opCodeData(callOpCode);
+    checkArgument(callInfo.isCall());
 
     pushSeveral(program, 0, 0, 0, 0);
-    if (callOpCode.callHasValueArgument()) {
+    if (callInfo.callHasValueArgument()) {
       program.push(256); // value
     }
     program.push(address).op(GAS).op(callOpCode);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/abort/MultiCallAbortTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/abort/MultiCallAbortTests.java
@@ -44,6 +44,7 @@ public class MultiCallAbortTests extends TracerTestBase {
   @Test
   void abortedCallNormalCallToEoaThenRevert() {
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
+
     appendInsufficientBalanceCall(
         program, CALL, 1000, Address.fromHexString(eoaAddress), 0, 0, 0, 0);
     appendCall(program, CALL, 0, Address.fromHexString(eoaAddress), 1, 0, 0, 0, 0);
@@ -55,6 +56,7 @@ public class MultiCallAbortTests extends TracerTestBase {
   @Test
   void balanceThenAbortedCallToEoaThenRevert() {
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
+
     program.push(eoaAddress).op(BALANCE).op(POP);
     appendInsufficientBalanceCall(
         program, CALL, 1000, Address.fromHexString(eoaAddress), 0, 0, 0, 0);
@@ -67,6 +69,7 @@ public class MultiCallAbortTests extends TracerTestBase {
   @Test
   void abortedCallThenBalanceToEoaThenRevert() {
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
+
     appendInsufficientBalanceCall(
         program, CALL, 1000, Address.fromHexString(eoaAddress), 0, 0, 0, 0);
     appendCall(program, CALL, 0, Address.fromHexString(eoaAddress), 0, 0, 0, 0, 0);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/eoa/SmcCallsEoaInRoot.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/eoa/SmcCallsEoaInRoot.java
@@ -40,58 +40,46 @@ public class SmcCallsEoaInRoot extends TracerTestBase {
 
   @Test
   void transfersSomeValueWillRevertTest() {
-
     BytecodeCompiler bytecode = BytecodeCompiler.newProgram(testInfo);
     appendCall(bytecode, CALL, 0, Address.fromHexString(eoaAddress), 13, 2, 3, 4, 5);
     bytecode.op(POP).push(6).push(7).op(REVERT).compile();
-
     BytecodeRunner.of(bytecode.compile()).run(testInfo);
   }
 
   @Test
   void transfersSomeValueWontRevertTest() {
-
     BytecodeCompiler bytecode = BytecodeCompiler.newProgram(testInfo);
     appendCall(bytecode, CALL, 0, Address.fromHexString(eoaAddress), 13, 2, 3, 4, 5);
-
     BytecodeRunner.of(bytecode.compile()).run(testInfo);
   }
 
   @Test
   void transfersAllValueWillRevertTest() {
-
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     fullBalanceCall(program, CALL, Address.fromHexString(eoaAddress), 1, 2, 3, 4);
     program.push(6).push(7).op(REVERT);
-
     BytecodeRunner.of(program.compile()).run(testInfo);
   }
 
   @Test
   void transfersAllValueWontRevertTest() {
-
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     fullBalanceCall(program, CALL, Address.fromHexString(eoaAddress), 1, 2, 3, 4);
-
     BytecodeRunner.of(program.compile()).run(testInfo);
   }
 
   @Test
   void transfersNoValueWillRevertTest() {
-
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, CALL, 0, Address.fromHexString(eoaAddress), 0, 1, 2, 3, 4);
     program.op(POP).push(6).push(7).op(REVERT).compile();
-
     BytecodeRunner.of(program.compile()).run(testInfo);
   }
 
   @Test
   void transfersNoValueWontRevertTest() {
-
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, CALL, 0, Address.fromHexString(eoaAddress), 0, 1, 2, 3, 4);
-
     BytecodeRunner.of(program.compile()).run(testInfo);
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/CallParameters.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/CallParameters.java
@@ -26,7 +26,6 @@ import net.consensys.linea.zktracer.opcode.OpCode;
 import org.hyperledger.besu.datatypes.Address;
 
 public class CallParameters implements PrecompileCallParameters {
-
   public final OpCode call;
   public final GasParameter gas;
   public final MemoryContents memoryContents;
@@ -93,7 +92,7 @@ public class CallParameters implements PrecompileCallParameters {
     program.push(0);
 
     // if appropriate, push the value onto the stack
-    if (call.callHasValueArgument()) {
+    if (program.opCodeData(call).callHasValueArgument()) {
       program.push(willRevert ? 0x0200 : 0);
     }
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/CallParameters.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/CallParameters.java
@@ -23,6 +23,7 @@ import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.ReturnAt
 import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framework.PrecompileCallMemoryContents;
 import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framework.PrecompileCallParameters;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import org.hyperledger.besu.datatypes.Address;
 
 public class CallParameters implements PrecompileCallParameters {
@@ -60,6 +61,7 @@ public class CallParameters implements PrecompileCallParameters {
 
   @Override
   public void appendCustomPrecompileCall(BytecodeCompiler program) {
+    OpCodeData callInfo = program.opCodeData(call);
     // push r@c onto the stack
     switch (this.returnAt) {
       case EMPTY -> program.push(0);
@@ -89,14 +91,14 @@ public class CallParameters implements PrecompileCallParameters {
     program.push(0);
 
     // if appropriate, push the value onto the stack
-    if (call.callHasValueArgument()) {
+    if (callInfo.callHasValueArgument()) {
       program.push(0x0400);
     }
 
     program.push(Address.ALTBN128_MUL);
 
     // push gas onto the stack
-    int callStipend = call.callHasValueArgument() ? 2_300 : 0;
+    int callStipend = callInfo.callHasValueArgument() ? 2_300 : 0;
     switch (gas) {
       case ZERO -> program.push(0); // interesting in the nonzero value case
       case COST_MO -> program.push(6_000 - callStipend - 1);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecpairing/CallParameters.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecpairing/CallParameters.java
@@ -26,6 +26,7 @@ import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.ReturnAt
 import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framework.PrecompileCallMemoryContents;
 import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framework.PrecompileCallParameters;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import org.hyperledger.besu.datatypes.Address;
 
 public class CallParameters implements PrecompileCallParameters {
@@ -63,6 +64,7 @@ public class CallParameters implements PrecompileCallParameters {
 
   @Override
   public void appendCustomPrecompileCall(BytecodeCompiler program) {
+    OpCodeData callInfo = program.opCodeData(call);
     // push r@c onto the stack
     switch (this.returnAt) {
       case EMPTY -> program.push(0);
@@ -84,14 +86,14 @@ public class CallParameters implements PrecompileCallParameters {
     program.push(cdo);
 
     // if appropriate, push the value onto the stack
-    if (call.callHasValueArgument()) {
+    if (callInfo.callHasValueArgument()) {
       program.push(0x0a00);
     }
 
     program.push(Address.ALTBN128_MUL);
 
     // push gas onto the stack
-    int callStipend = call.callHasValueArgument() ? 2_300 : 0;
+    int callStipend = callInfo.callHasValueArgument() ? 2_300 : 0;
     int prcCost =
         GAS_CONST_ECPAIRING + callDataRange.numberOfPairsOfPoints() * GAS_CONST_ECPAIRING_PAIR;
     switch (gas) {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/CallParameters.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/CallParameters.java
@@ -23,6 +23,7 @@ import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.ReturnAt
 import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framework.PrecompileCallMemoryContents;
 import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framework.PrecompileCallParameters;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import org.hyperledger.besu.datatypes.Address;
 
 public class CallParameters implements PrecompileCallParameters {
@@ -58,7 +59,7 @@ public class CallParameters implements PrecompileCallParameters {
   }
 
   public void appendCustomPrecompileCall(BytecodeCompiler program) {
-
+    OpCodeData callInfo = program.opCodeData(call);
     // push r@c onto the stack
     switch (returnAt) {
       case EMPTY -> program.push(0);
@@ -82,14 +83,14 @@ public class CallParameters implements PrecompileCallParameters {
     program.push(0);
 
     // if appropriate, push the value onto the stack
-    if (call.callHasValueArgument()) {
+    if (callInfo.callHasValueArgument()) {
       program.push(0x0600);
     }
 
     program.push(Address.ECREC);
 
     // push gas onto the stack
-    int callStipend = call.callHasValueArgument() ? 2_300 : 0;
+    int callStipend = callInfo.callHasValueArgument() ? 2_300 : 0;
     switch (gas) {
       case ZERO -> program.push(0); // interesting in the nonzero value case
       case COST_MO -> program.push(3000 - callStipend - 1);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/hash/CallParameters.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/hash/CallParameters.java
@@ -23,6 +23,7 @@ import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.*;
 import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framework.PrecompileCallMemoryContents;
 import net.consensys.linea.zktracer.instructionprocessing.callTests.prc.framework.PrecompileCallParameters;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 
 public class CallParameters implements PrecompileCallParameters {
   public final OpCode call;
@@ -79,7 +80,7 @@ public class CallParameters implements PrecompileCallParameters {
 
   @Override
   public void appendCustomPrecompileCall(BytecodeCompiler program) {
-
+    OpCodeData callInfo = program.opCodeData(call);
     // if DISJOINT the "return at range"; it lives among words 2 and 3 of RAM
     switch (rac) {
       case ZERO -> program.push(0);
@@ -109,7 +110,7 @@ public class CallParameters implements PrecompileCallParameters {
       case INFINITY -> program.push("ff".repeat(32));
     }
 
-    if (call.callHasValueArgument()) {
+    if (callInfo.callHasValueArgument()) {
       switch (value) {
         case ZERO -> program.push(0);
         case ONE -> program.push(1);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/hash/GasTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/hash/GasTests.java
@@ -44,7 +44,6 @@ public class GasTests extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void sha2ProvidedWithLittleToNoneGasTest(OpCode callOpCode) {
-
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, callOpCode, 0, Address.SHA256, 1_000_000, 0, 32 * 10 + 1, 7, 32);
     program.op(RETURNDATASIZE); // should return 0
@@ -57,7 +56,6 @@ public class GasTests extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void sha2ProvidedWithLittleToNoneGasWillRevertTest(OpCode callOpCode) {
-
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, callOpCode, 0, Address.SHA256, 1_000_000, 0, 32 * 10, 7, 32);
     program.op(RETURNDATASIZE); // should return 0
@@ -71,7 +69,6 @@ public class GasTests extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void sha2ProvidedWithPlentifulGasTest(OpCode callOpCode) {
-
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, callOpCode, 1_000_000, Address.SHA256, 1_000_000, 0, 32 * 10, 7, 32);
     program.op(RETURNDATASIZE); // should return 32
@@ -83,7 +80,6 @@ public class GasTests extends TracerTestBase {
       value = OpCode.class,
       names = {"CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"})
   void sha2ProvidedWithPlentifulGasWillRevertTest(OpCode callOpCode) {
-
     BytecodeCompiler program = BytecodeCompiler.newProgram(testInfo);
     appendCall(program, callOpCode, 1_000_000, Address.SHA256, 1_000_000, 0, 32 * 10, 7, 32);
     program.op(RETURNDATASIZE); // should return 32

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/smc/complexTargets/FailureWillRevertTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/smc/complexTargets/FailureWillRevertTest.java
@@ -152,7 +152,7 @@ public class FailureWillRevertTest extends TracerTestBase {
 
   public void selfCall(BytecodeCompiler program, OpCode callOpCode, int gas, int value) {
     program.push(0x20).push(0x33).push(0x46).push(0x59); // just some random bullshit
-    if (callOpCode.callHasValueArgument()) {
+    if (opcodes.of(callOpCode).callHasValueArgument()) {
       program.push(value);
     }
     program.op(ADDRESS).push(gas).op(callOpCode);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/utilities/Calls.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/utilities/Calls.java
@@ -20,6 +20,7 @@ import static net.consensys.linea.zktracer.opcode.OpCode.*;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Address;
 
@@ -38,7 +39,7 @@ public class Calls {
 
   public static void appendFullGasCall(
       BytecodeCompiler program,
-      OpCode callOpcode,
+      OpCodeData callOpcode,
       Address to,
       int value,
       int cdo,
@@ -49,13 +50,13 @@ public class Calls {
     if (callOpcode.callHasValueArgument()) {
       program.push(value);
     }
-    program.push(to).op(GAS).op(callOpcode);
+    program.push(to).op(GAS).op(callOpcode.mnemonic());
   }
 
   public static void fullBalanceCall(
       BytecodeCompiler program, OpCode callOpcode, Address to, int cdo, int cds, int rao, int rac) {
     program.push(rac).push(rao).push(cds).push(cdo);
-    if (callOpcode.callHasValueArgument()) {
+    if (program.opCodeData(callOpcode).callHasValueArgument()) {
       program.op(BALANCE);
     }
     program.push(to).op(GAS).op(callOpcode);
@@ -76,7 +77,7 @@ public class Calls {
       int rao,
       int rac) {
     program.push(rac).push(rao).push(cds).push(cdo);
-    if (callOpcode.callHasValueArgument()) {
+    if (program.opCodeData(callOpcode).callHasValueArgument()) {
       program.push(value);
     }
     program.push(to).push(gas).op(callOpcode);
@@ -105,7 +106,7 @@ public class Calls {
       program.push(258).push(259);
     }
 
-    if (callOpcode.callHasValueArgument()) {
+    if (program.opCodeData(callOpcode).callHasValueArgument()) {
       program.push(value);
     }
     program.push(toAccount.getAddress()).push(gas).op(callOpcode);
@@ -120,7 +121,8 @@ public class Calls {
       int cds,
       int rao,
       int rac) {
-    checkArgument(callOpcode.callHasValueArgument());
+    OpCodeData callInfo = program.opCodeData(callOpcode);
+    checkArgument(callInfo.callHasValueArgument());
     program
         .push(rac)
         .push(rao)
@@ -135,9 +137,10 @@ public class Calls {
   }
 
   public static void appendRecursiveSelfCall(BytecodeCompiler program, OpCode callOpCode) {
-    checkArgument(callOpCode.isCall());
+    OpCodeData callInfo = program.opCodeData(callOpCode);
+    checkArgument(callInfo.isCall());
     program.push(0).push(0).push(0).push(0);
-    if (callOpCode.callHasValueArgument()) {
+    if (callInfo.callHasValueArgument()) {
       program.push("1000"); // value
     }
     program

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mxp/MxpTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/mxp/MxpTest.java
@@ -37,6 +37,7 @@ import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.ToyTransaction;
 import net.consensys.linea.testing.TransactionProcessingResultValidator;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.opcode.gas.MxpType;
 import net.consensys.linea.zktracer.types.EWord;
 import org.apache.tuweni.bytes.Bytes;
@@ -59,7 +60,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 public class MxpTest extends TracerTestBase {
 
   /** Construct non-static instance to prevent sharing across tests. */
-  private MxpTestUtils util = new MxpTestUtils();
+  private MxpTestUtils util = new MxpTestUtils(opcodes);
 
   @Test
   void testMxpMinimalNonEmptyReturn() {
@@ -333,7 +334,7 @@ public class MxpTest extends TracerTestBase {
     EWord value = EWord.of(util.getRandomBigIntegerByBytesSize(0, 4));
     Address address = util.getRandomBigIntegerByBytesSize(20, 20).toAddress();
     EWord salt = EWord.of(util.getRandomBigIntegerByBytesSize(0, 4));
-
+    OpCodeData opCodeData = opcodes.of(opCode);
     // Keep generating random values until we are in the !roob && !mxpx case
     do {
       size1 = EWord.of(util.getRandomBigIntegerByBytesSize(0, MAX_BYTE_SIZE));
@@ -360,8 +361,8 @@ public class MxpTest extends TracerTestBase {
       }
 
       // size2 is irrelevant for this case
-      mxpx = isMxpx(fork, opCode, size1, offset1, EWord.ZERO, EWord.ZERO);
-      roob = isRoob(fork, opCode, size1, offset1, EWord.ZERO, EWord.ZERO);
+      mxpx = isMxpx(fork, opCodeData, size1, offset1, EWord.ZERO, EWord.ZERO);
+      roob = isRoob(fork, opCodeData, size1, offset1, EWord.ZERO, EWord.ZERO);
       if (roob || mxpx) {
         throw new RuntimeException("Unexpected ROOB or MXPX");
       }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/shakira/ShakiraInputsExtensiveTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/shakira/ShakiraInputsExtensiveTests.java
@@ -32,6 +32,7 @@ import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.BytecodeRunner;
 import net.consensys.linea.zktracer.module.limits.precompiles.Sha256Blocks;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Address;
@@ -73,9 +74,10 @@ public class ShakiraInputsExtensiveTests extends TracerTestBase {
                 .immediate(instructionSpecificBytecode(size, offset, instruction))
                 .compile());
     bytecodeRunner.run(testInfo);
-
+    // extract relevant opcode data
+    OpCodeData opCode = opcodes.of(instruction);
     // check line Counting if SHA245 PRC is called
-    if (instruction.isCall()) {
+    if (opCode.isCall()) {
       final Sha256Blocks sha256Blocks = bytecodeRunner.getHub().sha256Blocks();
       assertEquals(size == 0 ? 0 : numberOfSha256Blocks(size), sha256Blocks.lineCount());
     }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/shf/ShfRtTracerTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/shf/ShfRtTracerTest.java
@@ -121,9 +121,9 @@ class ShfRtTracerTest extends TracerTestBase {
 
   public static Stream<Arguments> provideShiftOperators() {
     return Stream.of(
-        Arguments.of(Named.of("SAR", OpCode.SAR.getData().value())),
-        Arguments.of(Named.of("SHL", OpCode.SHL.getData().value())),
-        Arguments.of(Named.of("SHR", OpCode.SHR.getData().value())));
+        Arguments.of(Named.of("SAR", OpCode.SAR.getOpcode())),
+        Arguments.of(Named.of("SHL", OpCode.SHL.getOpcode())),
+        Arguments.of(Named.of("SHR", OpCode.SHR.getOpcode())));
   }
 
   private static byte[] concatenateArrays(byte[] a, byte[] b) {

--- a/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
+++ b/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
@@ -16,6 +16,7 @@ package net.consensys.linea.reporting;
 
 import net.consensys.linea.zktracer.ChainConfig;
 import net.consensys.linea.zktracer.Fork;
+import net.consensys.linea.zktracer.opcode.OpCodes;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
@@ -25,7 +26,7 @@ import static net.consensys.linea.zktracer.Fork.*;
 public class TracerTestBase {
   public static TestInfoWithChainConfig testInfo = new TestInfoWithChainConfig();
   public static Fork fork;
-  public Address add;
+  public static OpCodes opcodes;
 
   @BeforeEach
   public void init(TestInfo testInfo) {
@@ -41,6 +42,7 @@ public class TracerTestBase {
             };
     TracerTestBase.testInfo.testInfo = testInfo;
     TracerTestBase.fork = TracerTestBase.testInfo.chainConfig.fork;
+    TracerTestBase.opcodes = OpCodes.load(fork);
   }
 
   public static String getForkOrDefault(String defaultFork) {

--- a/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
+++ b/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
@@ -18,6 +18,7 @@ import net.consensys.linea.zktracer.ChainConfig;
 import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.opcode.OpCodes;
 import org.hyperledger.besu.datatypes.Address;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 
@@ -28,8 +29,9 @@ public class TracerTestBase {
   public static Fork fork;
   public static OpCodes opcodes;
 
-  @BeforeEach
-  public void init(TestInfo testInfo) {
+  @BeforeAll
+  public static void init() {
+      // Configure chain information and fork before any tests are run, including any methods used as MethodSource.
       TracerTestBase.testInfo.chainConfig =
               switch (getForkOrDefault("LONDON")) {
               case "LONDON" -> ChainConfig.MAINNET_TESTCONFIG(LONDON);
@@ -40,9 +42,14 @@ public class TracerTestBase {
               default -> throw new IllegalArgumentException(
                   "Unknown fork: " + System.getProperty("unit.replay.tests.fork"));
             };
-    TracerTestBase.testInfo.testInfo = testInfo;
     TracerTestBase.fork = TracerTestBase.testInfo.chainConfig.fork;
     TracerTestBase.opcodes = OpCodes.load(fork);
+  }
+
+  @BeforeEach
+  public void init(TestInfo testInfo) {
+    // Record information about the specific test being run.
+    TracerTestBase.testInfo.testInfo = testInfo;
   }
 
   public static String getForkOrDefault(String defaultFork) {

--- a/testing/src/main/java/net/consensys/linea/testing/BytecodeCompiler.java
+++ b/testing/src/main/java/net/consensys/linea/testing/BytecodeCompiler.java
@@ -109,8 +109,10 @@ public class BytecodeCompiler {
    * @return current instance
    */
   public BytecodeCompiler op(final OpCode opCode) {
+    if (!opCodes.isValid(opCode)) {
+      throw new IllegalArgumentException("invalid opcode for fork: " + opCode);
+    }
     byteCode.add(Bytes.of(opCode.byteValue()));
-
     return this;
   }
 

--- a/testing/src/main/java/net/consensys/linea/testing/BytecodeCompiler.java
+++ b/testing/src/main/java/net/consensys/linea/testing/BytecodeCompiler.java
@@ -16,7 +16,6 @@
 package net.consensys.linea.testing;
 
 import static net.consensys.linea.zktracer.Trace.*;
-import static net.consensys.linea.zktracer.opcode.OpCodes.loadOpcodes;
 import static net.consensys.linea.zktracer.types.Conversions.bigIntegerToBytes;
 
 import java.io.BufferedReader;
@@ -29,6 +28,8 @@ import java.util.List;
 import net.consensys.linea.reporting.TestInfoWithChainConfig;
 import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.opcode.OpCode;
+import net.consensys.linea.zktracer.opcode.OpCodeData;
+import net.consensys.linea.zktracer.opcode.OpCodes;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -36,9 +37,12 @@ import org.junit.platform.commons.util.Preconditions;
 
 /** Fluent API for constructing custom sequences of EVM bytecode. */
 public class BytecodeCompiler {
+  private final OpCodes opCodes;
   private final List<Bytes> byteCode = new ArrayList<>();
 
-  private BytecodeCompiler() {}
+  private BytecodeCompiler(Fork fork) {
+    this.opCodes = OpCodes.load(fork);
+  }
 
   /**
    * Create a new program instance that will contain a new bytecode sequence.
@@ -46,29 +50,17 @@ public class BytecodeCompiler {
    * @return an instance of {@link BytecodeCompiler}
    */
   public static BytecodeCompiler newProgram(TestInfoWithChainConfig testInfo) {
-    return switch (testInfo.chainConfig.fork) {
-      case Fork.LONDON -> {
-        loadOpcodes(Fork.LONDON);
-        yield new BytecodeCompiler();
-      }
-      case PARIS -> {
-        loadOpcodes(Fork.PARIS);
-        yield new BytecodeCompiler();
-      }
-      case SHANGHAI -> {
-        loadOpcodes(Fork.SHANGHAI);
-        yield new BytecodeCompiler();
-      }
-      case CANCUN -> {
-        loadOpcodes(Fork.CANCUN);
-        yield new BytecodeCompiler();
-      }
-      case PRAGUE -> {
-        loadOpcodes(Fork.PRAGUE);
-        yield new BytecodeCompiler();
-      }
-      default -> throw new IllegalArgumentException("Unknown fork: " + testInfo.chainConfig.fork);
-    };
+    return new BytecodeCompiler(testInfo.chainConfig.fork);
+  }
+
+  /**
+   * Return information about a given opcode for the given fork used in this compiler.
+   *
+   * @param opcode
+   * @return
+   */
+  public OpCodeData opCodeData(OpCode opcode) {
+    return opCodes.of(opcode);
   }
 
   private static Bytes toBytes(final int x) {
@@ -243,7 +235,7 @@ public class BytecodeCompiler {
 
     final int padding = w - bs.length;
 
-    this.op(OpCode.of(0x5f + w));
+    this.op(opCodes.of(0x5f + w).mnemonic());
     this.byteCode.add(Bytes.repeat((byte) 0, padding));
     this.byteCode.add(Bytes.of(bs));
 
@@ -304,7 +296,7 @@ public class BytecodeCompiler {
     Preconditions.condition(w > 0 && w <= WORD_SIZE, "Invalid PUSH width");
     Preconditions.condition(bs.length <= w, "PUSH argument must be smaller than the width");
 
-    this.op(OpCode.of(EVM_INST_PUSH1 + w - 1));
+    this.op(opCodes.of(EVM_INST_PUSH1 + w - 1).mnemonic());
     this.byteCode.add(Bytes.of(bs));
 
     return this;


### PR DESCRIPTION
Previously, the OpCodes API was implemented via a number of static methods and, once a given fork was loaded, it was not possible to load another fork (doing so would cause a runtime exception).

Therefore, this refactors the OpCodes API to remove entirely the static API and, instead, replace it with an API based around OpCodes *instances*.  That is, we have an instance of OpCodes for each fork under consideration.  This means that, in situations where previously we could look up OpCodeData information statically, we must now be able to access a relevant instance of OpCodes.  As such, quite a lot of refactoring was required to make this possible.

The interface now promoters OpCodeData over OpCode as the primary source of useful information.  The OpCode class is now largely relegated to being simply a "mnemonic" with essentially no actual functionality.  In most cases, this works out well because OpCodeData already had a mnemonic accessor, meaning whereever we have an instance of OpCodeData we also have an instance of OpCode.