### PR TITLE
feat: include fork in lt tracefile metadata

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -115,6 +115,7 @@ public class ZkTracer implements LineCountingTracer {
     // Configure metadata
     trace.addMetadata("releaseVersion", ZkTracer.class.getPackage().getSpecificationVersion());
     trace.addMetadata("chainId", this.chain.id.toString());
+    trace.addMetadata("fork", this.chain.fork.toString());
     trace.addMetadata("l2L1LogSmcAddress", this.chain.bridgeConfiguration.contract().toString());
     trace.addMetadata("l2L1LogTopic", this.chain.bridgeConfiguration.topic().toString());
     // include block range


### PR DESCRIPTION
This simply includes the fork in the tracefile metadata, as determined from the ChainConfig.  This is, amongst other things, to help debugging in a multi-fork environment (e.g. during a fork upgrade).