### PR TITLE
feat: support file system caching of trace files

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/RpcConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/RpcConfiguration.java
@@ -20,4 +20,5 @@ import net.consensys.linea.plugins.LineaOptionsConfiguration;
 
 /** The Linea tracer configuration private to this repo. */
 @Builder(toBuilder = true)
-public record RpcConfiguration(int concurrentRequestsLimit, boolean caching) implements LineaOptionsConfiguration {}
+public record RpcConfiguration(int concurrentRequestsLimit, boolean caching)
+    implements LineaOptionsConfiguration {}

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/RpcConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/RpcConfiguration.java
@@ -20,4 +20,4 @@ import net.consensys.linea.plugins.LineaOptionsConfiguration;
 
 /** The Linea tracer configuration private to this repo. */
 @Builder(toBuilder = true)
-public record RpcConfiguration(int concurrentRequestsLimit) implements LineaOptionsConfiguration {}
+public record RpcConfiguration(int concurrentRequestsLimit, boolean caching) implements LineaOptionsConfiguration {}

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
@@ -15,23 +15,12 @@
 
 package net.consensys.linea.plugins.rpc.tracegeneration;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.util.JSONPObject;
 import com.google.common.base.Stopwatch;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +30,7 @@ import net.consensys.linea.plugins.rpc.RequestLimiter;
 import net.consensys.linea.plugins.rpc.Validator;
 import net.consensys.linea.tracewriter.TraceWriter;
 import net.consensys.linea.zktracer.Fork;
+import net.consensys.linea.zktracer.LtTraceFile;
 import net.consensys.linea.zktracer.ZkTracer;
 import net.consensys.linea.zktracer.json.JsonConverter;
 import org.hyperledger.besu.plugin.ServiceManager;
@@ -115,43 +105,45 @@ public class GenerateConflatedTracesV2 {
     final long fromBlock = params.startBlockNumber();
     final long toBlock = params.endBlockNumber();
     // Determine expected path of the trace file.
-    Path path = this.traceWriter.traceFilePath(fromBlock, toBlock, params.expectedTracesEngineVersion());
+    Path path =
+        this.traceWriter.traceFilePath(fromBlock, toBlock, params.expectedTracesEngineVersion());
     // Check whether the trace file already exists (or not).
-    if(cachedTraceFileAvailable(path)) {
-      log.info("[TRACING] reusing existing trace for {}-{} serialized to {} in {}", toBlock, fromBlock, path, sw);
+    if (cachedTraceFileAvailable(path)) {
+      log.info("[TRACING] cached trace for {}-{} detected as {}", fromBlock, toBlock, path);
     } else {
       final ZkTracer tracer =
-        new ZkTracer(
-          fork,
-          l1L2BridgeSharedConfiguration,
-          BesuServiceProvider.getBesuService(besuContext, BlockchainService.class)
-            .getChainId()
-            .orElseThrow());
+          new ZkTracer(
+              fork,
+              l1L2BridgeSharedConfiguration,
+              BesuServiceProvider.getBesuService(besuContext, BlockchainService.class)
+                  .getChainId()
+                  .orElseThrow());
 
       traceService.trace(
-        fromBlock,
-        toBlock,
-        worldStateBeforeTracing -> tracer.traceStartConflation(toBlock - fromBlock + 1),
-        tracer::traceEndConflation,
-        tracer);
+          fromBlock,
+          toBlock,
+          worldStateBeforeTracing -> tracer.traceStartConflation(toBlock - fromBlock + 1),
+          tracer::traceEndConflation,
+          tracer);
 
       log.info("[TRACING] trace for {}-{} computed in {}", fromBlock, toBlock, sw);
       sw.reset().start();
       // Generate trace file
-      path = traceWriter.writeTraceToFile(
-          tracer,
-          params.startBlockNumber(),
-          params.endBlockNumber(),
-          params.expectedTracesEngineVersion());
-      log.info("[TRACING] trace for {}-{} serialized to {} in {}", path, toBlock, fromBlock, sw);
+      path =
+          traceWriter.writeTraceToFile(
+              tracer,
+              params.startBlockNumber(),
+              params.endBlockNumber(),
+              params.expectedTracesEngineVersion());
+      log.info("[TRACING] trace for {}-{} serialized to {} in {}", fromBlock, toBlock, path, sw);
     }
 
     return new TraceFile(params.expectedTracesEngineVersion(), path.toString());
   }
 
   /**
-   * Determine whether a suitable trace file already exists in the desired location, and that it has the correction
-   * versioning, etc.
+   * Determine whether a suitable trace file already exists in the desired location, and that it has
+   * the correction versioning, etc.
    *
    * @param path Expected path for tracefile
    * @return
@@ -159,79 +151,38 @@ public class GenerateConflatedTracesV2 {
   @SneakyThrows(IOException.class)
   private boolean cachedTraceFileAvailable(final Path path) {
     // Initial sanity checks
-    if(!traceFileCaching || !Files.exists(path)) {
-     // Caching disabled or trace file doesn't exist.
+    if (!Files.exists(path)) {
+      // trace file doesn't exist.
+      return false;
+    } else if (!traceFileCaching) {
+      // Caching disabled.
+      log.info("[TRACING] cached trace {} ignored (caching disabled)", path);
       return false;
     }
-    // Trace file exists.  Check that it has matching tracer versioning.
-    String expectedVersion = ZkTracer.class.getPackage().getSpecificationVersion();
-    String actualVersion = extractTraceFileReleaseVersion(path);
-    //
-    return expectedVersion.equals(actualVersion);
-  }
-
-  /**
-   * Extract the embedded release version from the trace file.  This requires loading the file, and
-   * parsing its metadata to look for the release version.
-   *
-   * @param path
-   * @return
-   */
-  private String extractTraceFileReleaseVersion(final Path path) throws IOException {
-    HashMap<String,Object> metadata = new HashMap<>();
-    byte[] bytes = extractTraceFileMetaDataBytes(path);
-    // Sanity check we correctly read something
-    if(bytes != null) {
-      // Attempt to parse metadata bytes
-      JsonNode node = objectMapper.readTree(bytes).get("releaseVersion");
-      // Look for the appropriate field
-      if(node != null && node.isValueNode()) {
-        return node.asText();
-      }
-    }
-    // Return empty string
-    return "";
-  }
-
-  private byte[] extractTraceFileMetaDataBytes(final Path path) throws IOException {
-    byte[] zktracer = {'z','k','t','r','a','c','e','r'};
-
-    try (FileChannel ch = FileChannel.open(path)) {
-      ByteBuffer header = ByteBuffer.allocate(16);
-      // Reader header bytes
-      int nBytes = ch.read(header);
-      //
-      if(nBytes != 16) {
-        return null;
-      }
-      // Sanity check watermark
-      for(int i=0;i<zktracer.length;i++) {
-        if(zktracer[i] != header.get(i)) {
-          // corrupted trace file
-          return null;
+    // Read trace file header
+    try (LtTraceFile tf = new LtTraceFile(path)) {
+      LtTraceFile.Header header = tf.getHeader();
+      // Sanity check we got something
+      if (header != null) {
+        // Trace file exists.  Check that it has matching release version.
+        String expectedVersion = TraceRequestParams.getTracerRuntime();
+        Object actualVersion = header.getMetaData().get("releaseVersion");
+        boolean matchedTracer = expectedVersion != null && expectedVersion.equals(actualVersion);
+        // Log decision to ignore
+        if (!matchedTracer) {
+          log.info(
+              "[TRACING] cached trace {} ignored (incompatible release version {})",
+              path,
+              actualVersion);
         }
+        //
+        return matchedTracer;
+      } else {
+        // Provide useful information on what happened.
+        log.info("[TRACING] cached trace {} ignored (corrupted header)", path);
       }
-      // Read metadata bytes
-      int metadataLength = header.getInt(8 + 2 + 2);
-      //
-      ByteBuffer metadata = ByteBuffer.allocate(metadataLength);
-      byte []metadataBytes = new byte[metadataLength];
-      nBytes = ch.read(metadata);
-      // Sanity check
-      if(nBytes != metadataLength) {
-        return null;
-      }
-      // Looks ok.
-      metadata.get(metadataBytes);
-      //
-      return metadataBytes;
     }
+    // Default
+    return false;
   }
-
-
-  /**
-   * Object writer is used for generating JSON byte strings.
-   */
-   private static final ObjectMapper objectMapper = new ObjectMapper();
-
 }

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
@@ -15,14 +15,12 @@
 
 package net.consensys.linea.plugins.rpc.tracegeneration;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 
 import com.google.common.base.Stopwatch;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.plugins.BesuServiceProvider;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
@@ -30,7 +28,6 @@ import net.consensys.linea.plugins.rpc.RequestLimiter;
 import net.consensys.linea.plugins.rpc.Validator;
 import net.consensys.linea.tracewriter.TraceWriter;
 import net.consensys.linea.zktracer.Fork;
-import net.consensys.linea.zktracer.LtTraceFile;
 import net.consensys.linea.zktracer.ZkTracer;
 import net.consensys.linea.zktracer.json.JsonConverter;
 import org.hyperledger.besu.plugin.ServiceManager;
@@ -107,8 +104,11 @@ public class GenerateConflatedTracesV2 {
     final long toBlock = params.endBlockNumber();
     // Determine expected path of the trace file.
     Path path =
-        this.traceWriter.traceFilePath(fromBlock, toBlock, params.expectedTracesEngineVersion(),
-                                       TraceRequestParams.getBesuRuntime());
+        this.traceWriter.traceFilePath(
+            fromBlock,
+            toBlock,
+            params.expectedTracesEngineVersion(),
+            TraceRequestParams.getBesuRuntime());
     // Check whether the trace file already exists (or not).
     if (cachedTraceFileAvailable(path)) {
       log.info("[TRACING] cached trace for {}-{} detected as {}", fromBlock, toBlock, path);
@@ -151,7 +151,6 @@ public class GenerateConflatedTracesV2 {
    * @param path Expected path for tracefile
    * @return
    */
-  @SneakyThrows(IOException.class)
   private boolean cachedTraceFileAvailable(final Path path) {
     // Initial sanity checks
     if (!Files.exists(path)) {
@@ -162,30 +161,7 @@ public class GenerateConflatedTracesV2 {
       log.info("[TRACING] cached trace {} ignored (caching disabled)", path);
       return false;
     }
-    // Read trace file header
-    try (LtTraceFile tf = new LtTraceFile(path)) {
-      LtTraceFile.Header header = tf.getHeader();
-      // Sanity check we got something
-      if (header != null) {
-        // Trace file exists.  Check that it has matching release version.
-        String expectedVersion = TraceRequestParams.getTracerRuntime();
-        Object actualVersion = header.getMetaData().get("releaseVersion");
-        boolean matchedTracer = expectedVersion != null && expectedVersion.equals(actualVersion);
-        // Log decision to ignore
-        if (!matchedTracer) {
-          log.info(
-              "[TRACING] cached trace {} ignored (incompatible release version {})",
-              path,
-              actualVersion);
-        }
-        //
-        return matchedTracer;
-      } else {
-        // Provide useful information on what happened.
-        log.info("[TRACING] cached trace {} ignored (corrupted header)", path);
-      }
-    }
-    // Default
-    return false;
+    //
+    return true;
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
@@ -48,7 +48,7 @@ import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
 public class GenerateConflatedTracesV2 {
   private static final JsonConverter CONVERTER = JsonConverter.builder().build();
 
-  private final boolean traceFileCaching = true;
+  private final boolean traceFileCaching;
   private final RequestLimiter requestLimiter;
   private final TraceWriter traceWriter;
   private final ServiceManager besuContext;
@@ -67,6 +67,7 @@ public class GenerateConflatedTracesV2 {
     this.traceWriter = new TraceWriter(Paths.get(endpointConfiguration.tracesOutputPath()));
     this.l1L2BridgeSharedConfiguration = lineaL1L2BridgeSharedConfiguration;
     this.fork = fork;
+    this.traceFileCaching = endpointConfiguration.caching();
   }
 
   public String getNamespace() {
@@ -106,7 +107,8 @@ public class GenerateConflatedTracesV2 {
     final long toBlock = params.endBlockNumber();
     // Determine expected path of the trace file.
     Path path =
-        this.traceWriter.traceFilePath(fromBlock, toBlock, params.expectedTracesEngineVersion());
+        this.traceWriter.traceFilePath(fromBlock, toBlock, params.expectedTracesEngineVersion(),
+                                       TraceRequestParams.getBesuRuntime());
     // Check whether the trace file already exists (or not).
     if (cachedTraceFileAvailable(path)) {
       log.info("[TRACING] cached trace for {}-{} detected as {}", fromBlock, toBlock, path);
@@ -134,7 +136,8 @@ public class GenerateConflatedTracesV2 {
               tracer,
               params.startBlockNumber(),
               params.endBlockNumber(),
-              params.expectedTracesEngineVersion());
+              params.expectedTracesEngineVersion(),
+              TraceRequestParams.getBesuRuntime());
       log.info("[TRACING] trace for {}-{} serialized to {} in {}", fromBlock, toBlock, path, sw);
     }
 

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
@@ -15,11 +15,25 @@
 
 package net.consensys.linea.plugins.rpc.tracegeneration;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.util.JSONPObject;
 import com.google.common.base.Stopwatch;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.plugins.BesuServiceProvider;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
@@ -44,9 +58,9 @@ import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
 public class GenerateConflatedTracesV2 {
   private static final JsonConverter CONVERTER = JsonConverter.builder().build();
 
+  private final boolean traceFileCaching = true;
   private final RequestLimiter requestLimiter;
-
-  private final Path tracesOutputPath;
+  private final TraceWriter traceWriter;
   private final ServiceManager besuContext;
   private TraceService traceService;
   private final LineaL1L2BridgeSharedConfiguration l1L2BridgeSharedConfiguration;
@@ -60,7 +74,7 @@ public class GenerateConflatedTracesV2 {
       final Fork fork) {
     this.besuContext = besuContext;
     this.requestLimiter = requestLimiter;
-    this.tracesOutputPath = Paths.get(endpointConfiguration.tracesOutputPath());
+    this.traceWriter = new TraceWriter(Paths.get(endpointConfiguration.tracesOutputPath()));
     this.l1L2BridgeSharedConfiguration = lineaL1L2BridgeSharedConfiguration;
     this.fork = fork;
   }
@@ -100,33 +114,124 @@ public class GenerateConflatedTracesV2 {
 
     final long fromBlock = params.startBlockNumber();
     final long toBlock = params.endBlockNumber();
-    final ZkTracer tracer =
+    // Determine expected path of the trace file.
+    Path path = this.traceWriter.traceFilePath(fromBlock, toBlock, params.expectedTracesEngineVersion());
+    // Check whether the trace file already exists (or not).
+    if(cachedTraceFileAvailable(path)) {
+      log.info("[TRACING] reusing existing trace for {}-{} serialized to {} in {}", toBlock, fromBlock, path, sw);
+    } else {
+      final ZkTracer tracer =
         new ZkTracer(
-            fork,
-            l1L2BridgeSharedConfiguration,
-            BesuServiceProvider.getBesuService(besuContext, BlockchainService.class)
-                .getChainId()
-                .orElseThrow());
-    final TraceWriter traceWriter = new TraceWriter(tracer);
+          fork,
+          l1L2BridgeSharedConfiguration,
+          BesuServiceProvider.getBesuService(besuContext, BlockchainService.class)
+            .getChainId()
+            .orElseThrow());
 
-    traceService.trace(
+      traceService.trace(
         fromBlock,
         toBlock,
         worldStateBeforeTracing -> tracer.traceStartConflation(toBlock - fromBlock + 1),
         tracer::traceEndConflation,
         tracer);
 
-    log.info("[TRACING] trace for {}-{} computed in {}", fromBlock, toBlock, sw);
-    sw.reset().start();
-
-    final Path path =
-        traceWriter.writeTraceToFile(
-            tracesOutputPath,
-            params.startBlockNumber(),
-            params.endBlockNumber(),
-            params.expectedTracesEngineVersion());
-    log.info("[TRACING] trace for {}-{} serialized to {} in {}", path, toBlock, fromBlock, sw);
+      log.info("[TRACING] trace for {}-{} computed in {}", fromBlock, toBlock, sw);
+      sw.reset().start();
+      // Generate trace file
+      path = traceWriter.writeTraceToFile(
+          tracer,
+          params.startBlockNumber(),
+          params.endBlockNumber(),
+          params.expectedTracesEngineVersion());
+      log.info("[TRACING] trace for {}-{} serialized to {} in {}", path, toBlock, fromBlock, sw);
+    }
 
     return new TraceFile(params.expectedTracesEngineVersion(), path.toString());
   }
+
+  /**
+   * Determine whether a suitable trace file already exists in the desired location, and that it has the correction
+   * versioning, etc.
+   *
+   * @param path Expected path for tracefile
+   * @return
+   */
+  @SneakyThrows(IOException.class)
+  private boolean cachedTraceFileAvailable(final Path path) {
+    // Initial sanity checks
+    if(!traceFileCaching || !Files.exists(path)) {
+     // Caching disabled or trace file doesn't exist.
+      return false;
+    }
+    // Trace file exists.  Check that it has matching tracer versioning.
+    String expectedVersion = ZkTracer.class.getPackage().getSpecificationVersion();
+    String actualVersion = extractTraceFileReleaseVersion(path);
+    //
+    return expectedVersion.equals(actualVersion);
+  }
+
+  /**
+   * Extract the embedded release version from the trace file.  This requires loading the file, and
+   * parsing its metadata to look for the release version.
+   *
+   * @param path
+   * @return
+   */
+  private String extractTraceFileReleaseVersion(final Path path) throws IOException {
+    HashMap<String,Object> metadata = new HashMap<>();
+    byte[] bytes = extractTraceFileMetaDataBytes(path);
+    // Sanity check we correctly read something
+    if(bytes != null) {
+      // Attempt to parse metadata bytes
+      JsonNode node = objectMapper.readTree(bytes).get("releaseVersion");
+      // Look for the appropriate field
+      if(node != null && node.isValueNode()) {
+        return node.asText();
+      }
+    }
+    // Return empty string
+    return "";
+  }
+
+  private byte[] extractTraceFileMetaDataBytes(final Path path) throws IOException {
+    byte[] zktracer = {'z','k','t','r','a','c','e','r'};
+
+    try (FileChannel ch = FileChannel.open(path)) {
+      ByteBuffer header = ByteBuffer.allocate(16);
+      // Reader header bytes
+      int nBytes = ch.read(header);
+      //
+      if(nBytes != 16) {
+        return null;
+      }
+      // Sanity check watermark
+      for(int i=0;i<zktracer.length;i++) {
+        if(zktracer[i] != header.get(i)) {
+          // corrupted trace file
+          return null;
+        }
+      }
+      // Read metadata bytes
+      int metadataLength = header.getInt(8 + 2 + 2);
+      //
+      ByteBuffer metadata = ByteBuffer.allocate(metadataLength);
+      byte []metadataBytes = new byte[metadataLength];
+      nBytes = ch.read(metadata);
+      // Sanity check
+      if(nBytes != metadataLength) {
+        return null;
+      }
+      // Looks ok.
+      metadata.get(metadataBytes);
+      //
+      return metadataBytes;
+    }
+  }
+
+
+  /**
+   * Object writer is used for generating JSON byte strings.
+   */
+   private static final ObjectMapper objectMapper = new ObjectMapper();
+
 }

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TraceRequestParams.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TraceRequestParams.java
@@ -50,7 +50,7 @@ public record TraceRequestParams(
     }
   }
 
-  private static String getTracerRuntime() {
+  static String getTracerRuntime() {
     return ZkTracer.class.getPackage().getSpecificationVersion();
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TraceRequestParams.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TraceRequestParams.java
@@ -18,6 +18,7 @@ package net.consensys.linea.plugins.rpc.tracegeneration;
 import java.security.InvalidParameterException;
 
 import net.consensys.linea.zktracer.ZkTracer;
+import org.hyperledger.besu.evm.EVM;
 
 /** Holds needed parameters for sending an execution trace generation request. */
 public record TraceRequestParams(
@@ -52,5 +53,9 @@ public record TraceRequestParams(
 
   static String getTracerRuntime() {
     return ZkTracer.class.getPackage().getSpecificationVersion();
+  }
+
+  static String getBesuRuntime() {
+    return EVM.class.getPackage().getSpecificationVersion();
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointCliOptions.java
@@ -26,8 +26,7 @@ public class TracesEndpointCliOptions implements LineaCliOptions {
   static final String CONFLATED_TRACE_GENERATION_TRACES_OUTPUT_PATH =
       "--plugin-linea-conflated-trace-generation-traces-output-path";
 
-  static final String CONFLATED_TRACE_GENERATION_CONCURRENT_REQUESTS_LIMIT =
-      "--plugin-linea-conflated-trace-generation-concurrent-requests-limit";
+  static final String CACHING = "--plugin-linea-rpc-caching";
 
   @CommandLine.Option(
       required = true,
@@ -36,6 +35,15 @@ public class TracesEndpointCliOptions implements LineaCliOptions {
       paramLabel = "<PATH>",
       description = "Path to where traces will be written")
   private String tracesOutputPath = null;
+
+
+  @CommandLine.Option(
+          required = true,
+          names = {CACHING},
+          hidden = true,
+          paramLabel = "<CACHING>",
+          description = "Reuse existing trace files when available")
+  private boolean caching = true;
 
   private TracesEndpointCliOptions() {}
 
@@ -57,6 +65,7 @@ public class TracesEndpointCliOptions implements LineaCliOptions {
   static TracesEndpointCliOptions fromConfig(final TracesEndpointConfiguration config) {
     final TracesEndpointCliOptions options = create();
     options.tracesOutputPath = config.tracesOutputPath();
+    options.caching = config.caching();
     return options;
   }
 
@@ -67,13 +76,14 @@ public class TracesEndpointCliOptions implements LineaCliOptions {
    */
   @Override
   public TracesEndpointConfiguration toDomainObject() {
-    return TracesEndpointConfiguration.builder().tracesOutputPath(tracesOutputPath).build();
+    return TracesEndpointConfiguration.builder().tracesOutputPath(tracesOutputPath).caching(caching).build();
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add(CONFLATED_TRACE_GENERATION_TRACES_OUTPUT_PATH, tracesOutputPath)
-        .toString();
+            .add(CACHING, caching)
+            .toString();
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointCliOptions.java
@@ -38,7 +38,6 @@ public class TracesEndpointCliOptions implements LineaCliOptions {
 
 
   @CommandLine.Option(
-          required = true,
           names = {CACHING},
           hidden = true,
           paramLabel = "<CACHING>",

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointConfiguration.java
@@ -20,5 +20,5 @@ import net.consensys.linea.plugins.LineaOptionsConfiguration;
 
 /** The Linea tracer configuration private to this repo. */
 @Builder(toBuilder = true)
-public record TracesEndpointConfiguration(String tracesOutputPath)
+public record TracesEndpointConfiguration(String tracesOutputPath, boolean caching)
     implements LineaOptionsConfiguration {}

--- a/arithmetization/src/main/java/net/consensys/linea/tracewriter/TraceWriter.java
+++ b/arithmetization/src/main/java/net/consensys/linea/tracewriter/TraceWriter.java
@@ -36,11 +36,29 @@ public class TraceWriter {
   private static final String TRACE_FILE_EXTENSION = ".lt";
   private static final String TRACE_TEMP_FILE_EXTENSION = ".lt.tmp";
 
-  private final ZkTracer tracer;
+  final Path tracesOutputDirPath;
+
+  /**
+   * Check whether the corresponding trace file already exists, or not.
+   * @param startBlockNumber start block number for conflation.
+   * @param endBlockNumber end block number for conflation.
+   * @param expectedTracesEngineVersion expected version of tracer
+   *
+   * @return True if the trace file exists.
+   */
+  public Path traceFilePath(final long startBlockNumber,
+                                 final long endBlockNumber,
+                                 final String expectedTracesEngineVersion) {
+    // Generate the original and final trace file name.
+    final String origTraceFileName =
+      generateOutputFileName(startBlockNumber, endBlockNumber, expectedTracesEngineVersion);
+    // Generate and resolve the original and final trace file path.
+    return generateOutputFilePath(tracesOutputDirPath, origTraceFileName + TRACE_FILE_EXTENSION);
+  }
 
   @SneakyThrows(IOException.class)
   public Path writeTraceToFile(
-      final Path tracesOutputDirPath,
+      final ZkTracer tracer,
       final long startBlockNumber,
       final long endBlockNumber,
       final String expectedTracesEngineVersion) {
@@ -50,12 +68,11 @@ public class TraceWriter {
     // Generate and resolve the original and final trace file path.
     final Path origTraceFilePath =
         generateOutputFilePath(tracesOutputDirPath, origTraceFileName + TRACE_FILE_EXTENSION);
-
     // Write the trace at the original and final trace file path, but with the suffix .tmp at the
     // end of the file.
     final Path tmpTraceFilePath =
         writeToTmpFile(
-            tracesOutputDirPath,
+            tracer,
             origTraceFileName + ".",
             TRACE_TEMP_FILE_EXTENSION,
             startBlockNumber,
@@ -69,7 +86,7 @@ public class TraceWriter {
   }
 
   public Path writeToTmpFile(
-      final Path rootDir,
+      final ZkTracer tracer,
       final String prefix,
       final String suffix,
       final long startBlockNumber,
@@ -78,17 +95,17 @@ public class TraceWriter {
     try {
       FileAttribute<Set<PosixFilePermission>> perms =
           PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--"));
-      traceFile = Files.createTempFile(rootDir, prefix, suffix, perms);
+      traceFile = Files.createTempFile(tracesOutputDirPath, prefix, suffix, perms);
     } catch (IOException e) {
       log.error(
           "Error while creating tmp file {} {} {}. Trying without setting the permissions",
-          rootDir,
+          tracesOutputDirPath,
           prefix,
           suffix);
       try {
-        traceFile = Files.createTempFile(rootDir, prefix, suffix);
+        traceFile = Files.createTempFile(tracesOutputDirPath, prefix, suffix);
       } catch (IOException f) {
-        log.error("Still Failing while creating tmp file {} {} {}", rootDir, prefix, suffix);
+        log.error("Still Failing while creating tmp file {} {} {}", tracesOutputDirPath, prefix, suffix);
         throw new RuntimeException(e);
       }
     }

--- a/arithmetization/src/main/java/net/consensys/linea/tracewriter/TraceWriter.java
+++ b/arithmetization/src/main/java/net/consensys/linea/tracewriter/TraceWriter.java
@@ -40,18 +40,20 @@ public class TraceWriter {
 
   /**
    * Check whether the corresponding trace file already exists, or not.
-   * @param startBlockNumber start block number for conflation.
-   * @param endBlockNumber end block number for conflation.
-   * @param expectedTracesEngineVersion expected version of tracer
    *
+   * @param startBlockNumber            start block number for conflation.
+   * @param endBlockNumber              end block number for conflation.
+   * @param expectedTracesEngineVersion expected version of tracer
+   * @param besuVersion
    * @return True if the trace file exists.
    */
   public Path traceFilePath(final long startBlockNumber,
-                                 final long endBlockNumber,
-                                 final String expectedTracesEngineVersion) {
+                            final long endBlockNumber,
+                            final String expectedTracesEngineVersion,
+                            final String besuVersion) {
     // Generate the original and final trace file name.
     final String origTraceFileName =
-      generateOutputFileName(startBlockNumber, endBlockNumber, expectedTracesEngineVersion);
+      generateOutputFileName(startBlockNumber, endBlockNumber, expectedTracesEngineVersion, besuVersion);
     // Generate and resolve the original and final trace file path.
     return generateOutputFilePath(tracesOutputDirPath, origTraceFileName + TRACE_FILE_EXTENSION);
   }
@@ -61,10 +63,11 @@ public class TraceWriter {
       final ZkTracer tracer,
       final long startBlockNumber,
       final long endBlockNumber,
-      final String expectedTracesEngineVersion) {
+      final String expectedTracesEngineVersion,
+      final String besuVersion) {
     // Generate the original and final trace file name.
     final String origTraceFileName =
-        generateOutputFileName(startBlockNumber, endBlockNumber, expectedTracesEngineVersion);
+        generateOutputFileName(startBlockNumber, endBlockNumber, expectedTracesEngineVersion, besuVersion);
     // Generate and resolve the original and final trace file path.
     final Path origTraceFilePath =
         generateOutputFilePath(tracesOutputDirPath, origTraceFileName + TRACE_FILE_EXTENSION);
@@ -129,8 +132,9 @@ public class TraceWriter {
   private String generateOutputFileName(
       final long startBlockNumber,
       final long endBlockNumber,
-      final String expectedTracesEngineVersion) {
-    return "%s-%s.conflated.%s"
-        .formatted(startBlockNumber, endBlockNumber, expectedTracesEngineVersion);
+      final String expectedTracesEngineVersion,
+      final String besuVersion) {
+    return "%s-%s.conflated.%s.%s"
+        .formatted(startBlockNumber, endBlockNumber, expectedTracesEngineVersion, besuVersion);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/LtTraceFile.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/LtTraceFile.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright ConsenSys Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.zktracer;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Provides a basic API for reading the metadata from an LT trace file. */
+public class LtTraceFile implements AutoCloseable {
+
+  /** Represents the header component of an LtTraceFile. */
+  public static class Header {
+    /** Identifier should be "zktracer". */
+    byte[] identifier;
+
+    /** Major version for LT tracefile format. */
+    short majorVersion;
+
+    /** Minor version for LT tracefile format. */
+    short minorVersion;
+
+    /** Metadata bytes for LT tracefile (encoded as JSON by default). */
+    byte[] metadata;
+
+    public Header(byte[] identifier, short majorVersion, short minorVersion, byte[] metadata) {
+      this.identifier = identifier;
+      this.majorVersion = majorVersion;
+      this.minorVersion = minorVersion;
+      this.metadata = metadata;
+    }
+
+    /**
+     * Parse the metadata bytes into a map.
+     *
+     * @return Map representing the metadata
+     */
+    public Map<String, Object> getMetaData() throws IOException {
+      JsonNode node = objectMapper.readTree(this.metadata);
+      return parseJsonNode(node);
+    }
+
+    private static Map<String, Object> parseJsonNode(JsonNode node) {
+      HashMap<String, Object> metadata = new HashMap<>();
+
+      for (java.util.Map.Entry<String, JsonNode> entry : node.properties()) {
+        JsonNode val = entry.getValue();
+        Object obj;
+        //
+        if (val.isObject()) {
+          obj = parseJsonNode(val);
+        } else if (val.isTextual()) {
+          obj = val.asText();
+        } else if (val.isBoolean()) {
+          obj = val.asBoolean();
+        } else if (val.isInt()) {
+          obj = val.asInt();
+        } else if (val.isLong()) {
+          obj = val.asLong();
+        } else {
+          // Fall back, including for null.
+          obj = val.textValue();
+        }
+        //
+        metadata.put(entry.getKey(), obj);
+      }
+      //
+      return metadata;
+    }
+  }
+
+  private final FileChannel ch;
+
+  public LtTraceFile(Path path) throws IOException {
+    this.ch = FileChannel.open(path);
+  }
+
+  public Header getHeader() throws IOException {
+    return parseHeader(ch);
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.ch.close();
+  }
+
+  private static Header parseHeader(FileChannel ch) throws IOException {
+    ByteBuffer header = ByteBuffer.allocate(16);
+    byte[] identifier = new byte[8];
+    // Reset channel position to beginning of file.
+    ch.position(0);
+    // Reader header bytes
+    int nBytes = ch.read(header);
+    //
+    if (nBytes != 16) {
+      return null;
+    }
+    // Reset buffer position
+    header.position(0);
+    // Read identifier bytes
+    header.get(identifier);
+    // Read major version
+    short majorVersion = header.getShort();
+    // Read minor version
+    short minorVersion = header.getShort();
+    // Read metadata length
+    int metadataLength = header.getInt();
+    // read metadata bytes
+    byte[] metadata = parseMetaDataBytes(ch, metadataLength);
+    // Sanity check
+    if (metadata == null) {
+      return null;
+    }
+    //
+    return new Header(identifier, majorVersion, minorVersion, metadata);
+  }
+
+  private static byte[] parseMetaDataBytes(FileChannel ch, int metadataLength) throws IOException {
+    // read metadata bytes
+    ByteBuffer metadata = ByteBuffer.allocate(metadataLength);
+    byte[] metadataBytes = new byte[metadataLength];
+    int nBytes = ch.read(metadata);
+    metadata.position(0);
+    // Sanity check
+    if (nBytes != metadataLength) {
+      return null;
+    }
+    // Looks ok.
+    metadata.get(metadataBytes);
+    // Done
+    return metadataBytes;
+  }
+
+  /** Object mapper is used for parsing JSON byte strings. */
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+}


### PR DESCRIPTION
## Import Notes

* (**Testing**) As yet, the plugin `GenerateConflatedTracesV2` has not been tested.  However, the `LtTraceFile` class has.

* (**Acivation**) There is no command-line argument (or similar) for activating or deactiving caching.  This could be done using a CLI argument for the `TracesEndpointServicePlugin`.