### PR TITLE
fix: missing equals and hashcode for `ExpCall` and `GasParameters`

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/gas/GasParameters.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/gas/GasParameters.java
@@ -17,6 +17,7 @@ package net.consensys.linea.zktracer.module.gas;
 
 import java.math.BigInteger;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -24,11 +25,12 @@ import lombok.experimental.Accessors;
 @Getter
 @Setter
 @Accessors(fluent = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 public class GasParameters {
-  BigInteger gasActual;
-  BigInteger gasCost;
-  boolean xahoy;
-  boolean oogx;
+  @EqualsAndHashCode.Include BigInteger gasActual;
+  @EqualsAndHashCode.Include BigInteger gasCost;
+  @EqualsAndHashCode.Include boolean xahoy;
+  @EqualsAndHashCode.Include boolean oogx;
 
   public int compareTo(GasParameters other) {
     if (oogx() != other.oogx()) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/exp/ExplogExpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/exp/ExplogExpCall.java
@@ -17,6 +17,7 @@ package net.consensys.linea.zktracer.module.hub.fragment.imc.exp;
 
 import static net.consensys.linea.zktracer.Trace.EXP_INST_EXPLOG;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -27,9 +28,10 @@ import org.apache.tuweni.bytes.Bytes;
 @Accessors(fluent = true)
 @Getter
 @Setter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 public class ExplogExpCall implements ExpCall {
-  EWord exponent;
-  long dynCost;
+  @EqualsAndHashCode.Include EWord exponent;
+  @EqualsAndHashCode.Include long dynCost;
 
   @Override
   public int expInstruction() {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/exp/ExplogExpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/exp/ExplogExpCall.java
@@ -56,4 +56,8 @@ public class ExplogExpCall implements ExpCall {
         .pMiscExpData2(exponent.lo())
         .pMiscExpData5(Bytes.ofUnsignedLong(dynCost));
   }
+
+  public String toString() {
+    return "EXPLOG(" + exponent.toString() + ")=" + dynCost;
+  }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/exp/ModexpLogExpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/exp/ModexpLogExpCall.java
@@ -20,6 +20,7 @@ import static net.consensys.linea.zktracer.types.Conversions.bigIntegerToBytes;
 
 import java.math.BigInteger;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -31,12 +32,13 @@ import org.apache.tuweni.bytes.Bytes;
 @Setter
 @Getter
 @RequiredArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 public class ModexpLogExpCall implements ExpCall {
   final ModexpMetadata modexpMetadata;
-  EWord rawLeadingWord;
-  int cdsCutoff;
-  int ebsCutoff;
-  BigInteger leadLog;
+  @EqualsAndHashCode.Include EWord rawLeadingWord;
+  @EqualsAndHashCode.Include int cdsCutoff;
+  @EqualsAndHashCode.Include int ebsCutoff;
+  @EqualsAndHashCode.Include BigInteger leadLog;
 
   @Override
   public int expInstruction() {
@@ -78,5 +80,4 @@ public class ModexpLogExpCall implements ExpCall {
   public String toString() {
     return "MODEXPLOG(" + rawLeadingWord.toString() + ", " + cdsCutoff + ", " + ebsCutoff + ")=" + leadLog.toString();
   }
-
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/exp/ModexpLogExpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/exp/ModexpLogExpCall.java
@@ -78,6 +78,13 @@ public class ModexpLogExpCall implements ExpCall {
   }
 
   public String toString() {
-    return "MODEXPLOG(" + rawLeadingWord.toString() + ", " + cdsCutoff + ", " + ebsCutoff + ")=" + leadLog.toString();
+    return "MODEXPLOG("
+        + rawLeadingWord.toString()
+        + ", "
+        + cdsCutoff
+        + ", "
+        + ebsCutoff
+        + ")="
+        + leadLog.toString();
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/exp/ModexpLogExpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/exp/ModexpLogExpCall.java
@@ -74,4 +74,9 @@ public class ModexpLogExpCall implements ExpCall {
         .pMiscExpData4(Bytes.ofUnsignedShort(ebsCutoff))
         .pMiscExpData5(bigIntegerToBytes(leadLog));
   }
+
+  public String toString() {
+    return "MODEXPLOG(" + rawLeadingWord.toString() + ", " + cdsCutoff + ", " + ebsCutoff + ")=" + leadLog.toString();
+  }
+
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/OobCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/oob/OobCall.java
@@ -43,4 +43,8 @@ public abstract class OobCall implements TraceSubFragment {
   public abstract void callExoModulesAndSetOutputs(final Add add, final Mod mod, final Wcp wcp);
 
   public abstract int ctMax();
+
+  public abstract boolean equals(Object o);
+
+  public abstract int hashCode();
 }


### PR DESCRIPTION
Both of these classes / interfaces are used within instances of `ModuleOperation` and require proper `equals()` and `hashCode()` methods.  Some notes on this:

* For the two implementations of `ExpCall`, the outputs are included in the `equals()` and `hashCode()` methods.  However, this is safe because these methods are filled when `ExpOperation` is created.
* For `GasParameters` there are no output values per se. 