### PR TITLE
Reduce memory allocations on non opcode data

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/OpCodeData.java
@@ -24,10 +24,7 @@ import java.util.Objects;
 
 import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.opcode.gas.Billing;
-import net.consensys.linea.zktracer.opcode.gas.BillingRate;
-import net.consensys.linea.zktracer.opcode.gas.GasConstants;
 import net.consensys.linea.zktracer.opcode.gas.MxpType;
-import net.consensys.linea.zktracer.opcode.stack.Pattern;
 import net.consensys.linea.zktracer.opcode.stack.StackSettings;
 import net.consensys.linea.zktracer.types.UnsignedByte;
 
@@ -53,24 +50,7 @@ public record OpCodeData(
   }
 
   public static OpCodeData forNonOpCodes(int value) {
-    return new OpCodeData(
-        OpCode.INVALID,
-        value,
-        INVALID,
-        new StackSettings(
-            Pattern.ZERO_ZERO,
-            0,
-            0,
-            GasConstants.G_ZERO,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false),
-        new Billing(GasConstants.G_ZERO, BillingRate.NONE, MxpType.NONE));
+    return new OpCodeData(OpCode.INVALID, value, INVALID, StackSettings.DEFAULT, Billing.DEFAULT);
   }
 
   /**

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/stack/StackSettings.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/stack/StackSettings.java
@@ -45,4 +45,19 @@ public record StackSettings(
     boolean flag1,
     boolean flag2,
     boolean flag3,
-    boolean flag4) {}
+    boolean flag4) {
+  public static final StackSettings DEFAULT =
+      new StackSettings(
+          Pattern.ZERO_ZERO,
+          0,
+          0,
+          GasConstants.G_ZERO,
+          false,
+          false,
+          false,
+          false,
+          false,
+          false,
+          false,
+          false);
+}


### PR DESCRIPTION
Make OpCodeData data instances use static instances of Billing and StackSettings when created using `forNonOpCodes(int value)` method.
More details in the issue below.

Fixes https://github.com/Consensys/linea-tracer/issues/2300