### PR TITLE
feat: integrate assembly trm implementation

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -12,4 +12,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@5b76fc01d8ea4e8f78e5e1991665cb2036c8ea6e #v1.1.22
+      run: go install github.com/consensys/go-corset/cmd/go-corset@93c23f239542f79c1db60eb5b8250ab20e30f046 # v1.1.23

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/trm/TrmOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/trm/TrmOperation.java
@@ -15,32 +15,15 @@
 
 package net.consensys.linea.zktracer.module.trm;
 
-import static net.consensys.linea.zktracer.Fork.CANCUN;
-import static net.consensys.linea.zktracer.Fork.LONDON;
-import static net.consensys.linea.zktracer.Fork.PARIS;
-import static net.consensys.linea.zktracer.Fork.PRAGUE;
-import static net.consensys.linea.zktracer.Fork.SHANGHAI;
-import static net.consensys.linea.zktracer.Trace.*;
-import static net.consensys.linea.zktracer.Trace.Trm.TRM_CT_MAX;
-import static net.consensys.linea.zktracer.Trace.Trm.TRM_NB_ROWS;
-import static net.consensys.linea.zktracer.module.wcp.WcpCall.*;
 import static net.consensys.linea.zktracer.types.AddressUtils.isPrecompile;
-import static net.consensys.linea.zktracer.types.Conversions.bigIntegerToBytes;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.Trace;
-import net.consensys.linea.zktracer.TraceCancun;
-import net.consensys.linea.zktracer.TraceLondon;
-import net.consensys.linea.zktracer.TracePrague;
 import net.consensys.linea.zktracer.container.ModuleOperation;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
-import net.consensys.linea.zktracer.module.wcp.WcpCall;
 import net.consensys.linea.zktracer.types.EWord;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -50,29 +33,11 @@ import org.hyperledger.besu.datatypes.Address;
 public class TrmOperation extends ModuleOperation {
   private final Fork fork;
   @EqualsAndHashCode.Include @Getter private final EWord rawAddress;
-  private final List<WcpCall> wcpCalls = new ArrayList<>(TRM_NB_ROWS);
-  private static final Bytes TWOFIFTYSIX_TO_THE_TWENTY_BYTES =
-      bigIntegerToBytes(TWOFIFTYSIX_TO_THE_TWENTY);
-  private static final Bytes TWOFIFTYSIX_TO_THE_TWELVE_MO_BYTES =
-      bigIntegerToBytes(TWOFIFTYSIX_TO_THE_TWELVE_MO);
 
   public TrmOperation(Fork fork, EWord rawAddress, Wcp wcp) {
     this.fork = fork;
     this.rawAddress = rawAddress;
     final Bytes trmAddress = rawAddress.toAddress();
-
-    final int maxPrcAddressPerFork =
-        switch (fork) {
-          case LONDON, PARIS, SHANGHAI -> TraceLondon.MAX_PRC_ADDRESS;
-          case CANCUN -> TraceCancun.MAX_PRC_ADDRESS;
-          case PRAGUE -> TracePrague.MAX_PRC_ADDRESS;
-          default -> throw new IllegalArgumentException("Unknown fork: " + fork);
-        };
-
-    wcpCalls.add(0, ltCall(wcp, trmAddress, TWOFIFTYSIX_TO_THE_TWENTY_BYTES));
-    wcpCalls.add(1, leqCall(wcp, rawAddress.slice(0, 12), TWOFIFTYSIX_TO_THE_TWELVE_MO_BYTES));
-    wcpCalls.add(2, isZeroCall(wcp, trmAddress));
-    wcpCalls.add(3, leqCall(wcp, trmAddress, Bytes.ofUnsignedShort(maxPrcAddressPerFork)));
   }
 
   void trace(Trace.Trm trace) {
@@ -80,27 +45,11 @@ public class TrmOperation extends ModuleOperation {
     final boolean isPrec = isPrecompile(fork, trmAddress);
     final long trmAddrHi = trmAddress.slice(0, 4).toLong();
 
-    for (int ct = 0; ct <= TRM_CT_MAX; ct++) {
-      trace
-          .iomf(true)
-          .first(ct == 0)
-          .ct(ct)
-          .isPrecompile(isPrec)
-          .rawAddressHi(rawAddress.hi())
-          .rawAddressLo(rawAddress.lo())
-          .trmAddressHi(trmAddrHi)
-          .inst(wcpCalls.get(ct).instruction())
-          .arg1Hi(wcpCalls.get(ct).arg1Hi())
-          .arg1Lo(wcpCalls.get(ct).arg1Lo())
-          .arg2Hi(wcpCalls.get(ct).arg2Hi())
-          .arg2Lo(wcpCalls.get(ct).arg2Lo())
-          .res(wcpCalls.get(ct).result())
-          .validateRow();
-    }
+    trace.rawAddress(rawAddress).addressHi(trmAddrHi).isPrecompile(isPrec).validateRow();
   }
 
   @Override
   protected int computeLineCount() {
-    return TRM_NB_ROWS;
+    return 1;
   }
 }


### PR DESCRIPTION

This integrates an assembly implementation of the trm module.  As usual, this amounts to removing computation which is now performed by the assembly system.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves TRM tracing to a minimal single-row assembly-backed implementation, updates go-corset to v1.1.23, and refreshes the linea-constraints submodule.
> 
> - **TRM / Tracer**:
>   - Simplifies `TrmOperation` by removing WCP-based checks/loops and related constants/imports; now traces a single row via `trace.rawAddress(...).addressHi(...).isPrecompile(...).validateRow()`.
>   - Updates `computeLineCount()` to return `1`.
> - **CI**:
>   - Bumps `go-corset` to `v1.1.23` in `.github/actions/setup-go-corset/action.yml`.
> - **Submodule**:
>   - Updates `linea-constraints` to commit `34c1293`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3af0fac5c040c0b51c2d4782710ea1244f3acc91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->