### PR TITLE
feat: run weeklys on all forks

### DIFF
--- a/.github/workflows/gradle-weekly-tests.yml
+++ b/.github/workflows/gradle-weekly-tests.yml
@@ -30,14 +30,44 @@ jobs:
     with:
       zkevm_fork: SHANGHAI
 
+  weekly-unit-tests-cancun:
+    uses: ./.github/workflows/reusable-weekly-tests.yml
+    secrets: inherit
+    with:
+      zkevm_fork: CANCUN
+
+  weekly-unit-tests-prague:
+    uses: ./.github/workflows/reusable-weekly-tests.yml
+    secrets: inherit
+    with:
+      zkevm_fork: PRAGUE
+
   weekly-prc-call-tests-london:
     uses: ./.github/workflows/reusable-weekly-prc-tests.yml
     secrets: inherit
     with:
       zkevm_fork: LONDON
 
+  weekly-prc-call-tests-paris:
+    uses: ./.github/workflows/reusable-weekly-prc-tests.yml
+    secrets: inherit
+    with:
+      zkevm_fork: PARIS
+
   weekly-prc-call-tests-shanghai:
     uses: ./.github/workflows/reusable-weekly-prc-tests.yml
     secrets: inherit
     with:
       zkevm_fork: SHANGHAI
+
+  weekly-prc-call-tests-cancun:
+    uses: ./.github/workflows/reusable-weekly-prc-tests.yml
+    secrets: inherit
+    with:
+      zkevm_fork: CANCUN
+
+  weekly-prc-call-tests-prague:
+    uses: ./.github/workflows/reusable-weekly-prc-tests.yml
+    secrets: inherit
+    with:
+      zkevm_fork: PRAGUE


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extend weekly GitHub Actions to run unit tests on CANCUN and PRAGUE and PRC-call tests on PARIS, CANCUN, and PRAGUE.
> 
> - **CI • GitHub Actions (`.github/workflows/gradle-weekly-tests.yml`)**:
>   - **Unit tests**: add `weekly-unit-tests-cancun` (CANCUN) and `weekly-unit-tests-prague` (PRAGUE).
>   - **PRC-call tests**: add `weekly-prc-call-tests-paris` (PARIS), `weekly-prc-call-tests-cancun` (CANCUN), and `weekly-prc-call-tests-prague` (PRAGUE).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a07de07e1eea42cf49c04d6edddd04848d548518. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->