### PR TITLE
fix: reference tests fork spec

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/Fork.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/Fork.java
@@ -186,4 +186,16 @@ public enum Fork {
       default -> throw new IllegalArgumentException("Unknown fork: " + fork);
     };
   }
+
+  public static String toPascalCase(Fork fork) {
+    return switch (fork) {
+      case LONDON -> "London";
+      case PARIS -> "Merge";
+      case SHANGHAI -> "Shanghai";
+      case CANCUN -> "Cancun";
+      case PRAGUE -> "Prague";
+      case OSAKA -> "Osaka";
+      default -> throw new IllegalArgumentException("Unknown fork: " + fork);
+    };
+  }
 }

--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -21,6 +21,7 @@ import static net.consensys.linea.ReferenceTestOutcomeRecorderTool.JSON_INPUT_FI
 import static net.consensys.linea.reporting.TracerTestBase.getForkOrDefault;
 import static net.consensys.linea.testing.ToyExecutionTools.addSystemAccountsIfRequired;
 import static net.consensys.linea.zktracer.Fork.LONDON;
+import static net.consensys.linea.zktracer.Fork.toPascalCase;
 import static net.consensys.linea.zktracer.container.module.IncrementAndDetectModule.ERROR_MESSAGE_TRIED_TO_COMMIT_UNPROVABLE_TX;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,7 +73,7 @@ public class BlockchainReferenceTestTools {
   private static final ReferenceTestProtocolSchedules REFERENCE_TEST_PROTOCOL_SCHEDULES =
       ReferenceTestProtocolSchedules.create();
 
-  private static final List<String> NETWORKS_TO_RUN = List.of(fork.toString());
+  private static final List<String> NETWORKS_TO_RUN = List.of(toPascalCase(fork));
 
   public static final JsonTestParameters<?, ?> PARAMS =
       JsonTestParameters.create(BlockchainReferenceTestCaseSpec.class)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Fork.toPascalCase and update reference tests to filter by PascalCase network names; bump linea-constraints submodule.
> 
> - **Reference Tests**:
>   - Use PascalCase network filter `NETWORKS_TO_RUN = List.of(toPascalCase(fork))` in `reference-tests/.../BlockchainReferenceTestTools.java`.
> - **zktracer**:
>   - Add `Fork.toPascalCase(Fork)` helper mapping forks to `London`, `Merge`, `Shanghai`, `Cancun`, `Prague`, `Osaka` in `arithmetization/.../Fork.java`.
> - **Submodule**:
>   - Update `linea-constraints` to `ab22bad4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75f6d3bfba105f99b6e9bec7375b90bfb3c0f346. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->