### PR TITLE
fix: HubShomeiTests.opcodeProvider()

### DIFF
--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/HubShomeiTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/HubShomeiTests.java
@@ -18,7 +18,6 @@ package net.consensys.linea.zktracer.statemanager;
 import static net.consensys.linea.testing.BytecodeCompiler.newProgram;
 import static net.consensys.linea.testing.ToyExecutionEnvironmentV2.DEFAULT_COINBASE_ADDRESS;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,7 +39,6 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /** Those tests are intended to produce LT trace to test the HUB <-> Shomei lookups. */
@@ -143,7 +141,6 @@ public class HubShomeiTests extends TracerTestBase {
   @ParameterizedTest
   @MethodSource("opcodeProvider")
   void uselessPrewarming(OpCode opcode, TestInfo testInfo) {
-
     final KeyPair keyPair = new SECP256K1().generateKeyPair();
     final Address senderAddress =
         Address.extract(Hash.hash(keyPair.getPublicKey().getEncodedBytes()));
@@ -195,9 +192,7 @@ public class HubShomeiTests extends TracerTestBase {
     assert (storageSeen.get(DEFAULT).contains(key2));
   }
 
-  private static Stream<Arguments> opcodeProvider() {
-    List<Arguments> arguments = new ArrayList<>();
-    arguments.add(Arguments.of(OpCode.SSTORE, OpCode.SLOAD));
-    return arguments.stream();
+  private static Stream<OpCode> opcodeProvider() {
+    return Stream.of(OpCode.SSTORE, OpCode.SLOAD);
   }
 }


### PR DESCRIPTION
This method had a bug whereby it was intending to test both the SSTORE and SLOAD cases but, in fact, was only testing the SSTORE case.  When the TestInfo parameter was added as part of a previous PR, this bug was exposed because it meant JUnit was trying to fill the TestInfo class with an SLOAD opcode --- which does not work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the parameterized provider to return a Stream<OpCode> with SSTORE and SLOAD so both test cases run.
> 
> - **Tests**:
>   - **HubShomeiTests**: Fix `opcodeProvider` to return `Stream<OpCode>` with `SSTORE` and `SLOAD`, ensuring both parameterized tests (`sandwichPrewarming`, `uselessPrewarming`) run for each opcode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d2e0a0cb374830fd895b5438df562b728aa0117. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->