### PR TITLE
fix: RlptxnTests.rlpInputs()

### DIFF
--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlptxn/RlptxnTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlptxn/RlptxnTests.java
@@ -176,26 +176,19 @@ public class RlptxnTests extends TracerTestBase {
             // ...
             );
 
-    final List<BigInteger> signatures = List.of(BigInteger.ZERO);
-
     for (TransactionType txType : possibleTxType) {
       for (int isDeployment = 0; isDeployment <= 1; isDeployment++) {
         for (BigInteger value : values) {
           for (Bytes payload : payloads) {
-            for (BigInteger signature : signatures) {
-              if (txType == FRONTIER) {
+            if (txType == FRONTIER) {
+              arguments.add(
+                  Arguments.of(txType, isDeployment == 1, value, payload, List.of(), false));
+              arguments.add(
+                  Arguments.of(txType, isDeployment == 1, value, payload, List.of(), true));
+            } else {
+              for (List<AccessListEntry> accessList : accessLists) {
                 arguments.add(
-                    Arguments.of(
-                        txType, isDeployment == 1, value, payload, List.of(), false, signature));
-                arguments.add(
-                    Arguments.of(
-                        txType, isDeployment == 1, value, payload, List.of(), true, signature));
-              } else {
-                for (List<AccessListEntry> accessList : accessLists) {
-                  arguments.add(
-                      Arguments.of(
-                          txType, isDeployment == 1, value, payload, accessList, false, signature));
-                }
+                    Arguments.of(txType, isDeployment == 1, value, payload, accessList, false));
               }
             }
           }


### PR DESCRIPTION
This function was incorrectly including a "signature" parameter which did not correspond to any parameter for the actual test (testRlpTxn). As such, the extra parameter was clashing with the TestInfo parameter. It remains unclear to me why this did not cause a failure earlier on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove unused `signature` param from `rlpInputs` and update `Arguments.of` generation to match `testRlpTxn` (including two FRONTIER variants for `chainLess`).
> 
> - **Tests**:
>   - `arithmetization/src/test/java/net/consensys/linea/zktracer/module/rlptxn/RlptxnTests.java`:
>     - Remove extraneous `signature` parameter, list, and loop from `rlpInputs`.
>     - Update `Arguments.of(...)` to match `testRlpTxn` signature:
>       - `FRONTIER`: add two cases for `chainLess` (`false` and `true`) with empty `accessList`.
>       - Non-`FRONTIER`: iterate `accessLists` with `chainLess=false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e6e012bcd4b023085e8fdd4956cdd02138fdbae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->