### PR TITLE
doc: add error messages

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/bytestheta/BytesArray.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/bytestheta/BytesArray.java
@@ -92,7 +92,7 @@ public class BytesArray {
    * @param bytes the new Bytes value
    */
   public void set(int index, Bytes bytes) {
-    checkArgument(bytes.size() == 8);
+    checkArgument(bytes.size() == 8, "bytes size must be 8");
     bytesArray[index] = MutableBytes.wrap(bytes.toArray());
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/CountingOnlyModule.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/CountingOnlyModule.java
@@ -65,7 +65,7 @@ public class CountingOnlyModule implements Module {
   }
 
   public void updateTally(final int count) {
-    Preconditions.checkArgument(count >= 0, "Must be non-negative");
+    Preconditions.checkArgument(count >= 0, "CountingOnlyModule: count %s in updateTally must be nonnegative", count);
     counts.add(count);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/CountingOnlyModule.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/CountingOnlyModule.java
@@ -65,7 +65,8 @@ public class CountingOnlyModule implements Module {
   }
 
   public void updateTally(final int count) {
-    Preconditions.checkArgument(count >= 0, "CountingOnlyModule: count %s in updateTally must be nonnegative", count);
+    Preconditions.checkArgument(
+        count >= 0, "CountingOnlyModule: count %s in updateTally must be nonnegative", count);
     counts.add(count);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/IncrementingModule.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/IncrementingModule.java
@@ -29,7 +29,8 @@ public class IncrementingModule extends CountingOnlyModule {
   public void updateTally(final int numberEffectiveCall) {
     checkArgument(
         numberEffectiveCall == 0 || numberEffectiveCall == 1,
-        "IncrementingModule: updateTally can only update the tally by 0 or 1, here it's by %s", numberEffectiveCall);
+        "IncrementingModule: updateTally can only update the tally by 0 or 1, here it's by %s",
+        numberEffectiveCall);
     counts.add(numberEffectiveCall);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/IncrementingModule.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/IncrementingModule.java
@@ -29,7 +29,7 @@ public class IncrementingModule extends CountingOnlyModule {
   public void updateTally(final int numberEffectiveCall) {
     checkArgument(
         numberEffectiveCall == 0 || numberEffectiveCall == 1,
-        "Can only update the tally by one at the time.");
+        "IncrementingModule: updateTally can only update the tally by 0 or 1, here it's by %s", numberEffectiveCall);
     counts.add(numberEffectiveCall);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/stacked/CountOnlyOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/stacked/CountOnlyOperation.java
@@ -37,7 +37,7 @@ public class CountOnlyOperation {
   }
 
   public void add(final int operationCount) {
-    Preconditions.checkArgument(operationCount >= 0, "operationCount must be non negative");
+    Preconditions.checkArgument(operationCount >= 0, "operationCount %s should be nonnegative", operationCount);
     countInTransactionBundle += operationCount;
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/stacked/CountOnlyOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/stacked/CountOnlyOperation.java
@@ -37,7 +37,8 @@ public class CountOnlyOperation {
   }
 
   public void add(final int operationCount) {
-    Preconditions.checkArgument(operationCount >= 0, "operationCount %s should be nonnegative", operationCount);
+    Preconditions.checkArgument(
+        operationCount >= 0, "operationCount %s should be nonnegative", operationCount);
     countInTransactionBundle += operationCount;
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/Util.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/Util.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static net.consensys.linea.zktracer.types.Utils.rightPadTo;
 
 import java.math.BigInteger;
@@ -117,7 +116,7 @@ public class Util {
    * @return The UInt256 sum of the products of the elements in the two input ranges.
    */
   public static UInt256 multiplyRange(Bytes[] range1, Bytes[] range2) {
-    checkArgument(range1.length == range2.length);
+    assert range1.length == range2.length : "Ranges must be of the same length";
     UInt256 sum = UInt256.ZERO;
     for (int i = 0; i < range1.length; i++) {
       UInt256 prod =
@@ -178,8 +177,8 @@ public class Util {
    */
   public static Bytes rightPaddedSlice(Bytes data, int offset, int size) {
 
-    checkArgument(offset >= 0, "Offset must be non-negative");
-    checkArgument(size >= 0, "Size must be non-negative");
+    assert offset >= 0 : "Offset must be non-negative";
+    assert size >= 0 : "Size must be non-negative";
 
     final int dataSize = data.size();
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/Util.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/Util.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static net.consensys.linea.zktracer.types.Utils.rightPadTo;
 
 import java.math.BigInteger;
@@ -116,7 +117,7 @@ public class Util {
    * @return The UInt256 sum of the products of the elements in the two input ranges.
    */
   public static UInt256 multiplyRange(Bytes[] range1, Bytes[] range2) {
-    assert range1.length == range2.length : "Ranges must be of the same length";
+    checkArgument(range1.length == range2.length, "Ranges must be of the same length");
     UInt256 sum = UInt256.ZERO;
     for (int i = 0; i < range1.length; i++) {
       UInt256 prod =
@@ -177,8 +178,8 @@ public class Util {
    */
   public static Bytes rightPaddedSlice(Bytes data, int offset, int size) {
 
-    assert offset >= 0 : "Offset must be non-negative";
-    assert size >= 0 : "Size must be non-negative";
+    checkArgument(offset >= 0, "Offset must be non-negative");
+    checkArgument(size >= 0, "Size must be non-negative");
 
     final int dataSize = data.size();
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/moduleOperation/BlockdataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/moduleOperation/BlockdataOperation.java
@@ -262,8 +262,8 @@ public abstract class BlockdataOperation extends ModuleOperation {
 
   // Module call macros
   private boolean wcpCallTo(int w, EWord arg1, EWord arg2, int inst) {
-    checkArgument(arg1.bitLength() / 8 <= 32);
-    checkArgument(arg2.bitLength() / 8 <= 32);
+    checkArgument(arg1.bitLength() / 8 <= 32, "WCP: arg1 bit width too large");
+    checkArgument(arg2.bitLength() / 8 <= 32, "WCP: arg2 bit width too large");
 
     this.arg1[w] = arg1;
     this.arg2[w] = arg2;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blsdata/BlsDataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blsdata/BlsDataOperation.java
@@ -129,7 +129,7 @@ public class BlsDataOperation extends ModuleOperation {
       Bytes callData,
       Bytes returnData,
       boolean successBit) {
-    checkArgument(precompileFlag.isBlsPrecompile(), "invalid BLS type");
+    checkArgument(precompileFlag.isBlsPrecompile(), "BlsDataOperation: precompile %s isn't of BLS type", precompileFlag);
 
     this.precompileFlag = precompileFlag;
     this.callData = callData;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blsdata/BlsDataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blsdata/BlsDataOperation.java
@@ -162,8 +162,12 @@ public class BlsDataOperation extends ModuleOperation {
     // Set successBit
     this.successBit = successBit;
     final int returnDataSize = returnData.toArray().length;
+    final int expectedReturnDataSize = (successBit ? expectedReturnDataSize(precompileFlag) : 0);
     Preconditions.checkArgument(
-        returnDataSize == (successBit ? expectedReturnDataSize(precompileFlag) : 0));
+        returnDataSize == expectedReturnDataSize,
+        "BLS precompile return data size %s does not agree with the expected value %s",
+        returnDataSize,
+        expectedReturnDataSize);
   }
 
   public static int expectedReturnDataSize(
@@ -250,7 +254,8 @@ public class BlsDataOperation extends ModuleOperation {
       final boolean isSmallPointOnCurve =
           isSmallPointOnCurve(indexOffset, callData.slice(sizeOffset, SIZE_SMALL_POINT));
       final boolean mextBit = wellFormedCoordinate && !isSmallPointOnCurve;
-      Preconditions.checkArgument(mextBit == (wellFormedCoordinate && !successBit));
+      Preconditions.checkArgument(
+          mextBit == (wellFormedCoordinate && !successBit), "BLS_G1ADD: mext bit inconsistency");
 
       if (mextBit && !mextBitIsSet) {
         for (int j = 0; j <= CT_MAX_SMALL_POINT; j++) {
@@ -277,7 +282,8 @@ public class BlsDataOperation extends ModuleOperation {
       final boolean isSmallPointInSubgroup =
           isSmallPointInSubGroup(indexOffset, callData.slice(sizeOffset, SIZE_SMALL_POINT));
       final boolean mextBit = wellFormedCoordinate && !isSmallPointInSubgroup;
-      Preconditions.checkArgument(mextBit == (wellFormedCoordinate && !successBit));
+      Preconditions.checkArgument(
+          mextBit == (wellFormedCoordinate && !successBit), "BLS_G1MSM: mext bit inconsistency");
 
       if (mextBit && !mextBitIsSet) {
         for (int j = 0; j <= CT_MAX_SMALL_POINT; j++) {
@@ -307,7 +313,8 @@ public class BlsDataOperation extends ModuleOperation {
       final boolean isLargePointOnCurve =
           isLargePointOnCurve(indexOffset, callData.slice(sizeOffset, SIZE_LARGE_POINT));
       final boolean mextBit = wellFormedCoordinate && !isLargePointOnCurve;
-      Preconditions.checkArgument(mextBit == (wellFormedCoordinate && !successBit));
+      Preconditions.checkArgument(
+          mextBit == (wellFormedCoordinate && !successBit), "BLS_G2ADD: mext bit inconsistency");
 
       if (mextBit && !mextBitIsSet) {
         for (int j = 0; j <= CT_MAX_LARGE_POINT; j++) {
@@ -338,7 +345,8 @@ public class BlsDataOperation extends ModuleOperation {
       final boolean isLargePointInSubgroup =
           isLargePointInSubGroup(indexOffset, callData.slice(sizeOffset, SIZE_LARGE_POINT));
       final boolean mextBit = wellFormedCoordinate && !isLargePointInSubgroup;
-      Preconditions.checkArgument(mextBit == (wellFormedCoordinate && !successBit));
+      Preconditions.checkArgument(
+          mextBit == (wellFormedCoordinate && !successBit), "BLS_G2MSM: mext bit inconsistency");
 
       if (mextBit && !mextBitIsSet) {
         for (int j = 0; j <= CT_MAX_LARGE_POINT; j++) {
@@ -371,7 +379,9 @@ public class BlsDataOperation extends ModuleOperation {
       final boolean isSmallPointInSubgroup =
           isSmallPointInSubGroup(indexOffset, callData.slice(sizeOffset, SIZE_SMALL_POINT));
       final boolean mextBitSmall = wellFormedFpCoordinate && !isSmallPointInSubgroup;
-      Preconditions.checkArgument(mextBitSmall == (wellFormedFpCoordinate && !successBit));
+      Preconditions.checkArgument(
+          mextBitSmall == (wellFormedFpCoordinate && !successBit),
+          "BLS_PAIRING_CHECK: mext bit inconsistency for small point");
 
       if (mextBitSmall && !mextBitIsSet) {
         for (int j = 0; j <= CT_MAX_SMALL_POINT; j++) {
@@ -388,7 +398,9 @@ public class BlsDataOperation extends ModuleOperation {
           isLargePointInSubGroup(
               8 + indexOffset, callData.slice(8 * LLARGE + sizeOffset, SIZE_LARGE_POINT));
       final boolean mextBitLarge = wellFormedFp2Coordinate && !isLargePointInSubgroup;
-      Preconditions.checkArgument(mextBitLarge == (wellFormedFp2Coordinate && !successBit));
+      Preconditions.checkArgument(
+          mextBitLarge == (wellFormedFp2Coordinate && !successBit),
+          "BLS_PAIRING_CHECK: mext bit inconsistency for large point");
 
       if (mextBitLarge && !mextBitIsSet) {
         for (int j = 0; j <= CT_MAX_LARGE_POINT; j++) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blsdata/BlsDataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blsdata/BlsDataOperation.java
@@ -129,7 +129,10 @@ public class BlsDataOperation extends ModuleOperation {
       Bytes callData,
       Bytes returnData,
       boolean successBit) {
-    checkArgument(precompileFlag.isBlsPrecompile(), "BlsDataOperation: precompile %s isn't of BLS type", precompileFlag);
+    checkArgument(
+        precompileFlag.isBlsPrecompile(),
+        "BlsDataOperation: precompile %s isn't of BLS type",
+        precompileFlag);
 
     this.precompileFlag = precompileFlag;
     this.callData = callData;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/EcDataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/EcDataOperation.java
@@ -135,13 +135,15 @@ public class EcDataOperation extends ModuleOperation {
       final PrecompileScenarioFragment.PrecompileFlag precompileFlag,
       Bytes callData,
       Bytes returnData) {
-    checkArgument(precompileFlag.isEcdataPrecompile(), "EcDataOperation: precompile %s isn't of EC_DATA type", precompileFlag);
+    checkArgument(
+        precompileFlag.isEcdataPrecompile(),
+        "EcDataOperation: precompile %s isn't of EC_DATA type",
+        precompileFlag);
 
     this.precompileFlag = precompileFlag;
     final int callDataSize = callData.size();
     checkArgument(
-        callDataSize > 0,
-        "EcDataOperation should only be called with nonempty call data");
+        callDataSize > 0, "EcDataOperation should only be called with nonempty call data");
     final int paddedCallDataLength =
         switch (precompileFlag) {
           case PRC_ECRECOVER -> TOTAL_SIZE_ECRECOVER_DATA;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/EcDataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/EcDataOperation.java
@@ -135,13 +135,13 @@ public class EcDataOperation extends ModuleOperation {
       final PrecompileScenarioFragment.PrecompileFlag precompileFlag,
       Bytes callData,
       Bytes returnData) {
-    checkArgument(precompileFlag.isEcdataPrecompile(), "invalid EC type");
+    checkArgument(precompileFlag.isEcdataPrecompile(), "EcDataOperation: precompile %s isn't of EC_DATA type", precompileFlag);
 
     this.precompileFlag = precompileFlag;
     final int callDataSize = callData.size();
     checkArgument(
         callDataSize > 0,
-        "EcDataOperation should only be called with nonempty call rightPaddedCallData");
+        "EcDataOperation should only be called with nonempty call data");
     final int paddedCallDataLength =
         switch (precompileFlag) {
           case PRC_ECRECOVER -> TOTAL_SIZE_ECRECOVER_DATA;
@@ -150,7 +150,7 @@ public class EcDataOperation extends ModuleOperation {
           case PRC_ECPAIRING -> {
             checkArgument(
                 callDataSize % TOTAL_SIZE_ECPAIRING_DATA_MIN == 0,
-                "ECPAIRING call data size expected to be multiple of %s, but remainder is %s",
+                "ECPAIRING: call data size expected to be multiple of %s, but remainder is %s ≠ 0",
                 TOTAL_SIZE_ECPAIRING_DATA_MIN,
                 callDataSize % TOTAL_SIZE_ECPAIRING_DATA_MIN);
             yield callDataSize;
@@ -431,7 +431,7 @@ public class EcDataOperation extends ModuleOperation {
     if (internalChecksPassed && returnData.toArray().length != 0) {
       checkArgument(
           returnData.toArray().length == 64,
-          "ECADD return data size %s should be 64",
+          "ECADD: return data size %s should be 64",
           returnData.toArray().length);
       resX = EWord.of(returnData.slice(0, 32));
       resY = EWord.of(returnData.slice(32, 32));
@@ -702,14 +702,14 @@ public class EcDataOperation extends ModuleOperation {
       if (precompileFlag != PRC_ECPAIRING || !isData) {
         checkArgument(
             ct == 0,
-            "ct should be 0 except for ECPAIRING data row, yet prc = %s, isData = %s, ct = %s",
+            "EcDataOperation's trace method: ct should be 0 except for ECPAIRING data rows, yet prc = %s, isData = %s, ct = %s",
             precompileFlag,
             isData,
             ct);
       }
       checkArgument(
           !(isSmallPoint && isLargePoint),
-          "ECPAIRING: data simultaneously categorized as small and large point");
+          "EcDataOperation's trace: ECPAIRING data simultaneously categorized as small and large point");
 
       trace
           .stamp(stamp)

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/EcDataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/EcDataOperation.java
@@ -148,7 +148,11 @@ public class EcDataOperation extends ModuleOperation {
           case PRC_ECADD -> TOTAL_SIZE_ECADD_DATA;
           case PRC_ECMUL -> TOTAL_SIZE_ECMUL_DATA;
           case PRC_ECPAIRING -> {
-            checkArgument(callDataSize % TOTAL_SIZE_ECPAIRING_DATA_MIN == 0);
+            checkArgument(
+                callDataSize % TOTAL_SIZE_ECPAIRING_DATA_MIN == 0,
+                "ECPAIRING call data size expected to be multiple of %s, but remainder is %s",
+                TOTAL_SIZE_ECPAIRING_DATA_MIN,
+                callDataSize % TOTAL_SIZE_ECPAIRING_DATA_MIN);
             yield callDataSize;
           }
           default -> throw new IllegalArgumentException(
@@ -425,7 +429,10 @@ public class EcDataOperation extends ModuleOperation {
 
     // Extract output
     if (internalChecksPassed && returnData.toArray().length != 0) {
-      checkArgument(returnData.toArray().length == 64);
+      checkArgument(
+          returnData.toArray().length == 64,
+          "ECADD return data size %s should be 64",
+          returnData.toArray().length);
       resX = EWord.of(returnData.slice(0, 32));
       resY = EWord.of(returnData.slice(32, 32));
     }
@@ -473,7 +480,10 @@ public class EcDataOperation extends ModuleOperation {
 
     // Extract output
     if (internalChecksPassed && returnData.toArray().length != 0) {
-      checkArgument(returnData.toArray().length == 64);
+      checkArgument(
+          returnData.toArray().length == 64,
+          "ECMUL: return data size %s should be 64",
+          returnData.toArray().length);
       resX = EWord.of(returnData.slice(0, 32));
       resY = EWord.of(returnData.slice(32, 32));
     }
@@ -690,9 +700,16 @@ public class EcDataOperation extends ModuleOperation {
       }
 
       if (precompileFlag != PRC_ECPAIRING || !isData) {
-        checkArgument(ct == 0);
+        checkArgument(
+            ct == 0,
+            "ct should be 0 except for ECPAIRING data row, yet prc = %s, isData = %s, ct = %s",
+            precompileFlag,
+            isData,
+            ct);
       }
-      checkArgument(!(isSmallPoint && isLargePoint));
+      checkArgument(
+          !(isSmallPoint && isLargePoint),
+          "ECPAIRING: data simultaneously categorized as small and large point");
 
       trace
           .stamp(stamp)

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpOperation.java
@@ -59,7 +59,7 @@ public class ExpOperation extends ModuleOperation {
         final int ebsInt = modexpMetadata.ebsInt();
         checkArgument(
             modexpMetadata.callData().size() - BASE_MIN_OFFSET - bbsInt >= 0,
-            "Modexp CDS too small");
+            "Modexp CDS unexpectedly small");
         final EWord rawLead = modexpMetadata.rawLeadingWord();
         final int cdsCutoff =
             Math.min(modexpMetadata.callData().size() - BASE_MIN_OFFSET - bbsInt, 32);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpOperation.java
@@ -57,8 +57,9 @@ public class ExpOperation extends ModuleOperation {
         final ModexpMetadata modexpMetadata = modexplogExpCall.getModexpMetadata();
         final int bbsInt = modexpMetadata.bbsInt();
         final int ebsInt = modexpMetadata.ebsInt();
-        assert modexpMetadata.callData().size() - BASE_MIN_OFFSET - bbsInt >= 0
-            : "Modexp CDS too small";
+        checkArgument(
+            modexpMetadata.callData().size() - BASE_MIN_OFFSET - bbsInt >= 0,
+            "Modexp CDS too small");
         final EWord rawLead = modexpMetadata.rawLeadingWord();
         final int cdsCutoff =
             Math.min(modexpMetadata.callData().size() - BASE_MIN_OFFSET - bbsInt, 32);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpOperation.java
@@ -59,7 +59,7 @@ public class ExpOperation extends ModuleOperation {
         final int ebsInt = modexpMetadata.ebsInt();
         checkArgument(
             modexpMetadata.callData().size() - BASE_MIN_OFFSET - bbsInt >= 0,
-            "Modexp CDS unexpectedly small");
+            "MODEXP call data unexpectedly short");
         final EWord rawLead = modexpMetadata.rawLeadingWord();
         final int cdsCutoff =
             Math.min(modexpMetadata.callData().size() - BASE_MIN_OFFSET - bbsInt, 32);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpOperation.java
@@ -57,7 +57,8 @@ public class ExpOperation extends ModuleOperation {
         final ModexpMetadata modexpMetadata = modexplogExpCall.getModexpMetadata();
         final int bbsInt = modexpMetadata.bbsInt();
         final int ebsInt = modexpMetadata.ebsInt();
-        checkArgument(modexpMetadata.callData().size() - BASE_MIN_OFFSET - bbsInt >= 0);
+        assert modexpMetadata.callData().size() - BASE_MIN_OFFSET - bbsInt >= 0
+            : "Modexp CDS too small";
         final EWord rawLead = modexpMetadata.rawLeadingWord();
         final int cdsCutoff =
             Math.min(modexpMetadata.callData().size() - BASE_MIN_OFFSET - bbsInt, 32);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.hub;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static net.consensys.linea.zktracer.types.AddressUtils.isAddressWarm;
 
@@ -158,7 +157,7 @@ public class AccountSnapshot {
 
   public void wipe(DeploymentInfo deploymentInfo) {
     final boolean deploymentStatus = deploymentInfo.getDeploymentStatus(address);
-    checkArgument(!deploymentStatus);
+    assert !deploymentStatus : "Cannot wipe an account that is under deployment";
     this.nonce(0).balance(Wei.ZERO).code(Bytecode.EMPTY).setDeploymentInfo(deploymentInfo);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java
@@ -232,7 +232,10 @@ public class AccountSnapshot {
   }
 
   public AccountSnapshot decrementNonceByOne() {
-    checkState(nonce > 0, "AccountSnapshot: attempting to decrement nonce by one when nonce is %s ≤ 0", nonce);
+    checkState(
+        nonce > 0,
+        "AccountSnapshot: attempting to decrement nonce by one when nonce is %s ≤ 0",
+        nonce);
     return this.nonce(nonce - 1);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java
@@ -232,7 +232,7 @@ public class AccountSnapshot {
   }
 
   public AccountSnapshot decrementNonceByOne() {
-    checkState(nonce > 0);
+    checkState(nonce > 0, "Attempting to decrement nonce by one when nonce is %s ≤ 0", nonce);
     return this.nonce(nonce - 1);
   }
 
@@ -245,7 +245,10 @@ public class AccountSnapshot {
   }
 
   public void decrementDeploymentNumberByOne() {
-    checkState(deploymentNumber > 0);
+    checkState(
+        deploymentNumber > 0,
+        "Attempting to decrement deployment number by one when deployment number is %s ≤ 0",
+        deploymentNumber);
     this.deploymentNumber(deploymentNumber - 1);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java
@@ -232,7 +232,7 @@ public class AccountSnapshot {
   }
 
   public AccountSnapshot decrementNonceByOne() {
-    checkState(nonce > 0, "Attempting to decrement nonce by one when nonce is %s ≤ 0", nonce);
+    checkState(nonce > 0, "AccountSnapshot: attempting to decrement nonce by one when nonce is %s ≤ 0", nonce);
     return this.nonce(nonce - 1);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.hub;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static net.consensys.linea.zktracer.types.AddressUtils.isAddressWarm;
 
@@ -157,7 +158,7 @@ public class AccountSnapshot {
 
   public void wipe(DeploymentInfo deploymentInfo) {
     final boolean deploymentStatus = deploymentInfo.getDeploymentStatus(address);
-    assert !deploymentStatus : "Cannot wipe an account that is under deployment";
+    checkArgument(!deploymentStatus, "Cannot wipe an account that is under deployment");
     this.nonce(0).balance(Wei.ZERO).code(Bytecode.EMPTY).setDeploymentInfo(deploymentInfo);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -846,7 +846,7 @@ public abstract class Hub implements Module {
     final Address bytecodeAddress = currentFrame().byteCodeAddress();
     checkArgument(
         bytecodeAddress.equals(bytecodeAddress()),
-        "bytecode and contract address mismatch when exit from deployment");
+        "bytecode address mismatch between frame / callFrame at exit from deployment");
 
     /**
      * Explanation: if the current address isn't under deployment there is nothing to do.
@@ -857,7 +857,7 @@ public abstract class Hub implements Module {
     if (state.processingPhase() == TX_SKIP) {
       checkArgument(
           !deploymentStatusOfBytecodeAddress(),
-          "In TX_SKIP phase all deployments must be empty code");
+          "TX_SKIP: deployments must have empty code");
       return;
     }
     /**

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -636,7 +636,9 @@ public abstract class Hub implements Module {
     // root and transaction call data context's
     if (frame.getDepth() == 0) {
       if (state.processingPhase() == TX_SKIP) {
-        checkState(currentTraceSection() instanceof TxSkipSection, "traceContextEnter of Hub: expected a skip section");
+        checkState(
+            currentTraceSection() instanceof TxSkipSection,
+            "traceContextEnter of Hub: expected a skip section");
         ((TxSkipSection) currentTraceSection()).coinbaseSnapshots(this, frame);
       }
       final TransactionProcessingMetadata currentTransaction = transients().tx();
@@ -856,8 +858,7 @@ public abstract class Hub implements Module {
      */
     if (state.processingPhase() == TX_SKIP) {
       checkArgument(
-          !deploymentStatusOfBytecodeAddress(),
-          "TX_SKIP: deployments must have empty code");
+          !deploymentStatusOfBytecodeAddress(), "TX_SKIP: deployments must have empty code");
       return;
     }
     /**

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -645,13 +645,17 @@ public abstract class Hub implements Module {
       final long initiallyAvailableGas = frame.getRemainingGas();
       final Transaction tx = currentTransaction.getBesuTransaction();
 
-      assert recipientAddress.equals(effectiveToAddress(tx))
-          : "Mismatch between frame and transaction recipient";
-      assert senderAddress.equals(tx.getSender()) : "Mismatch between frame and transaction sender";
-      assert isDeployment == tx.getTo().isEmpty()
-          : "Mismatch between frame and transaction deployment info";
-      assert value.equals(Wei.of(tx.getValue().getAsBigInteger()))
-          : "Mismatch between frame and transaction value";
+      checkArgument(
+          recipientAddress.equals(effectiveToAddress(tx)),
+          "Mismatch between frame and transaction recipient");
+      checkArgument(
+          senderAddress.equals(tx.getSender()), "Mismatch between frame and transaction sender");
+      checkArgument(
+          isDeployment == tx.getTo().isEmpty(),
+          "Mismatch between frame and transaction deployment info");
+      checkArgument(
+          value.equals(Wei.of(tx.getValue().getAsBigInteger())),
+          "Mismatch between frame and transaction value");
       checkArgument(
           frame.getRemainingGas() == currentTransaction.getInitiallyAvailableGas(),
           "Frame gas available at the beginning of the tx %s != transaction initially available gas %s",
@@ -778,8 +782,9 @@ public abstract class Hub implements Module {
   }
 
   public void tracePreExecution(final MessageFrame frame) {
-    assert state().processingPhase() == TX_EXEC
-        : "There can't be any execution if the HUB is not in execution phase";
+    checkArgument(
+        state().processingPhase() == TX_EXEC,
+        "There can't be any execution if the HUB is not in execution phase");
     this.processStateExec(frame);
   }
 
@@ -794,8 +799,9 @@ public abstract class Hub implements Module {
    * (i.e. empty initialization code) ?
    */
   public void tracePostExecution(MessageFrame frame, Operation.OperationResult operationResult) {
-    assert state().processingPhase() == TX_EXEC
-        : "There can't be any execution if the HUB is not in execution phase";
+    checkArgument(
+        state().processingPhase() == TX_EXEC,
+        "There can't be any execution if the HUB is not in execution phase");
 
     final TraceSection currentSection = state.currentTransactionHubSections().currentSection();
 
@@ -831,8 +837,9 @@ public abstract class Hub implements Module {
    */
   private void exitDeploymentFromDeploymentInfoPov(MessageFrame frame) {
     final Address bytecodeAddress = currentFrame().byteCodeAddress();
-    assert bytecodeAddress.equals(bytecodeAddress())
-        : "bytecode and contract address mismatch when exit from deployment";
+    checkArgument(
+        bytecodeAddress.equals(bytecodeAddress()),
+        "bytecode and contract address mismatch when exit from deployment");
 
     /**
      * Explanation: if the current address isn't under deployment there is nothing to do.
@@ -841,8 +848,9 @@ public abstract class Hub implements Module {
      * immediately set to the deployed state
      */
     if (state.processingPhase() == TX_SKIP) {
-      assert !deploymentStatusOfBytecodeAddress()
-          : "In TX_SKIP phase all deployments must be empty code";
+      checkArgument(
+          !deploymentStatusOfBytecodeAddress(),
+          "In TX_SKIP phase all deployments must be empty code");
       return;
     }
     /**
@@ -875,8 +883,9 @@ public abstract class Hub implements Module {
 
     final boolean emptyDeployment = messageFrame().getCode().getBytes().isEmpty();
 
-    assert deploymentStatusOfBytecodeAddress() == !emptyDeployment
-        : "empty deployments are immediately considered as 'deployed'";
+    checkArgument(
+        deploymentStatusOfBytecodeAddress() == !emptyDeployment,
+        "empty deployments are immediately considered as 'deployed'");
 
     if (emptyDeployment) return;
     // from here on out nonempty deployments

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -439,7 +439,7 @@ public abstract class Hub implements Module {
     gasCalculator = getGasCalculatorFromFork(fork);
     opCodes = OpCodes.load(fork);
     gasProjector = new GasProjector(fork, gasCalculator);
-    checkState(chain.id.signum() >= 0, "chain id must be non negative");
+    checkState(chain.id.signum() >= 0, "Hub constructor: chain id must be nonnegative");
     Address l2l1ContractAddress = chain.bridgeConfiguration.contract();
     final Bytes l2l1Topic = chain.bridgeConfiguration.topic();
     //
@@ -636,7 +636,7 @@ public abstract class Hub implements Module {
     // root and transaction call data context's
     if (frame.getDepth() == 0) {
       if (state.processingPhase() == TX_SKIP) {
-        checkState(currentTraceSection() instanceof TxSkipSection, "expected a skip section");
+        checkState(currentTraceSection() instanceof TxSkipSection, "traceContextEnter of Hub: expected a skip section");
         ((TxSkipSection) currentTraceSection()).coinbaseSnapshots(this, frame);
       }
       final TransactionProcessingMetadata currentTransaction = transients().tx();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -438,7 +438,7 @@ public abstract class Hub implements Module {
     gasCalculator = getGasCalculatorFromFork(fork);
     opCodes = OpCodes.load(fork);
     gasProjector = new GasProjector(fork, gasCalculator);
-    checkState(chain.id.signum() >= 0);
+    checkState(chain.id.signum() >= 0, "chain id must be non negative");
     Address l2l1ContractAddress = chain.bridgeConfiguration.contract();
     final Bytes l2l1Topic = chain.bridgeConfiguration.topic();
     //
@@ -635,6 +635,7 @@ public abstract class Hub implements Module {
     // root and transaction call data context's
     if (frame.getDepth() == 0) {
       if (state.processingPhase() == TX_SKIP) {
+        checkState(currentTraceSection() instanceof TxSkipSection, "expected a skip section");
         ((TxSkipSection) currentTraceSection()).coinbaseSnapshots(this, frame);
       }
       final TransactionProcessingMetadata currentTransaction = transients().tx();
@@ -694,11 +695,16 @@ public abstract class Hub implements Module {
       final OpCodeData currentOpCode = opCodes.of(callStack.currentCallFrame().opCode());
       final boolean isDeployment = frame.getType() == CONTRACT_CREATION;
 
-      checkState(currentOpCode.isCall() || currentOpCode.isCreate());
+      checkState(
+          currentOpCode.isCall() || currentOpCode.isCreate(),
+          "trace context enter at positive depth must be call or create");
       checkState(
           currentTraceSection() instanceof CallSection
-              || currentTraceSection() instanceof CreateSection);
-      checkState(currentTraceSection() instanceof CreateSection == isDeployment);
+              || currentTraceSection() instanceof CreateSection,
+          "trace context enter at positive depth must have in call or create section as most recent trace section");
+      checkState(
+          currentTraceSection() instanceof CreateSection == isDeployment,
+          "trace context enter at positive depth must have a create section as most recent trace section iff it is a deployment");
 
       final CallFrameType frameType =
           frame.isStatic() ? CallFrameType.STATIC : CallFrameType.STANDARD;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -635,7 +635,6 @@ public abstract class Hub implements Module {
     // root and transaction call data context's
     if (frame.getDepth() == 0) {
       if (state.processingPhase() == TX_SKIP) {
-        checkState(currentTraceSection() instanceof TxSkipSection);
         ((TxSkipSection) currentTraceSection()).coinbaseSnapshots(this, frame);
       }
       final TransactionProcessingMetadata currentTransaction = transients().tx();
@@ -644,15 +643,20 @@ public abstract class Hub implements Module {
       final boolean isDeployment = frame.getType() == CONTRACT_CREATION;
       final Wei value = frame.getValue();
       final long initiallyAvailableGas = frame.getRemainingGas();
+      final Transaction tx = currentTransaction.getBesuTransaction();
 
+      assert recipientAddress.equals(effectiveToAddress(tx))
+          : "Mismatch between frame and transaction recipient";
+      assert senderAddress.equals(tx.getSender()) : "Mismatch between frame and transaction sender";
+      assert isDeployment == tx.getTo().isEmpty()
+          : "Mismatch between frame and transaction deployment info";
+      assert value.equals(Wei.of(tx.getValue().getAsBigInteger()))
+          : "Mismatch between frame and transaction value";
       checkArgument(
-          recipientAddress.equals(effectiveToAddress(currentTransaction.getBesuTransaction())));
-      checkArgument(senderAddress.equals(currentTransaction.getBesuTransaction().getSender()));
-      checkArgument(isDeployment == currentTransaction.getBesuTransaction().getTo().isEmpty());
-      checkArgument(
-          value.equals(
-              Wei.of(currentTransaction.getBesuTransaction().getValue().getAsBigInteger())));
-      checkArgument(frame.getRemainingGas() == currentTransaction.getInitiallyAvailableGas());
+          frame.getRemainingGas() == currentTransaction.getInitiallyAvailableGas(),
+          "Frame gas available at the beginning of the tx %s != transaction initially available gas %s",
+          frame.getRemainingGas(),
+          currentTransaction.getInitiallyAvailableGas());
 
       final boolean copyTransactionCallData = currentTransaction.copyTransactionCallData();
       if (copyTransactionCallData) {
@@ -774,10 +778,8 @@ public abstract class Hub implements Module {
   }
 
   public void tracePreExecution(final MessageFrame frame) {
-    checkArgument(
-        this.state().processingPhase() == TX_EXEC,
-        "There can't be any execution if the HUB is not in execution phase");
-
+    assert state().processingPhase() == TX_EXEC
+        : "There can't be any execution if the HUB is not in execution phase";
     this.processStateExec(frame);
   }
 
@@ -792,9 +794,8 @@ public abstract class Hub implements Module {
    * (i.e. empty initialization code) ?
    */
   public void tracePostExecution(MessageFrame frame, Operation.OperationResult operationResult) {
-    checkArgument(
-        state().processingPhase() == TX_EXEC,
-        "There can't be any execution if the HUB is not in execution phase");
+    assert state().processingPhase() == TX_EXEC
+        : "There can't be any execution if the HUB is not in execution phase";
 
     final TraceSection currentSection = state.currentTransactionHubSections().currentSection();
 
@@ -829,11 +830,9 @@ public abstract class Hub implements Module {
    * deployment in the sense that it updates the relevant deployment information.
    */
   private void exitDeploymentFromDeploymentInfoPov(MessageFrame frame) {
-
-    // sanity check
-    final Address bytecodeAddress = this.currentFrame().byteCodeAddress();
-    checkArgument(bytecodeAddress.equals(frame.getContractAddress()));
-    checkArgument(bytecodeAddress.equals(this.bytecodeAddress()));
+    final Address bytecodeAddress = currentFrame().byteCodeAddress();
+    assert bytecodeAddress.equals(bytecodeAddress())
+        : "bytecode and contract address mismatch when exit from deployment";
 
     /**
      * Explanation: if the current address isn't under deployment there is nothing to do.
@@ -842,7 +841,8 @@ public abstract class Hub implements Module {
      * immediately set to the deployed state
      */
     if (state.processingPhase() == TX_SKIP) {
-      checkArgument(!deploymentStatusOfBytecodeAddress());
+      assert !deploymentStatusOfBytecodeAddress()
+          : "In TX_SKIP phase all deployments must be empty code";
       return;
     }
     /**
@@ -875,9 +875,8 @@ public abstract class Hub implements Module {
 
     final boolean emptyDeployment = messageFrame().getCode().getBytes().isEmpty();
 
-    // empty deployments are immediately considered as 'deployed' i.e.
-    // deploymentStatus = false
-    checkArgument(deploymentStatusOfBytecodeAddress() == !emptyDeployment);
+    assert deploymentStatusOfBytecodeAddress() == !emptyDeployment
+        : "empty deployments are immediately considered as 'deployed'";
 
     if (emptyDeployment) return;
     // from here on out nonempty deployments

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/account/AccountFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/account/AccountFragment.java
@@ -121,7 +121,7 @@ public abstract class AccountFragment
       TransactionProcessingType txProcessingType) {
     checkArgument(
         oldState.address().equals(newState.address()),
-        "Address mismatch in AccountFragment constructor");
+        "AccountFragment: address mismatch in constructor");
 
     transactionProcessingMetadata = txProcessingType == USER ? hub.txStack().current() : null;
     hubStamp = hub.stamp();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/account/AccountFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/account/AccountFragment.java
@@ -234,7 +234,7 @@ public abstract class AccountFragment
               newState.address(), newState.deploymentNumber(), newState.deploymentStatus());
     } catch (RuntimeException e) {
       // getCfi should NEVER throw en exception when requiresRomLex ≡ true
-      checkState(!requiresRomlex, "Can't get an exception to get CFI when RomLex is required");
+      checkState(!requiresRomlex, "AccountFragment: can't get an exception to get CFI when RomLex is required");
       codeFragmentIndex = 0;
     }
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/account/AccountFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/account/AccountFragment.java
@@ -119,7 +119,9 @@ public abstract class AccountFragment
       Optional<Bytes> addressToTrim,
       DomSubStampsSubFragment domSubStampsSubFragment,
       TransactionProcessingType txProcessingType) {
-    checkArgument(oldState.address().equals(newState.address()));
+    checkArgument(
+        oldState.address().equals(newState.address()),
+        "Address mismatch in AccountFragment constructor");
 
     transactionProcessingMetadata = txProcessingType == USER ? hub.txStack().current() : null;
     hubStamp = hub.stamp();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/account/AccountFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/account/AccountFragment.java
@@ -234,7 +234,9 @@ public abstract class AccountFragment
               newState.address(), newState.deploymentNumber(), newState.deploymentStatus());
     } catch (RuntimeException e) {
       // getCfi should NEVER throw en exception when requiresRomLex ≡ true
-      checkState(!requiresRomlex, "AccountFragment: can't get an exception to get CFI when RomLex is required");
+      checkState(
+          !requiresRomlex,
+          "AccountFragment: can't get an exception to get CFI when RomLex is required");
       codeFragmentIndex = 0;
     }
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/account/AccountFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/account/AccountFragment.java
@@ -15,7 +15,7 @@
 
 package net.consensys.linea.zktracer.module.hub.fragment.account;
 
-import static com.google.common.base.Preconditions.*;
+import static com.google.common.base.Preconditions.checkState;
 import static net.consensys.linea.zktracer.Trace.Hub.MULTIPLIER___DOM_SUB_STAMPS;
 import static net.consensys.linea.zktracer.module.hub.TransactionProcessingType.USER;
 import static net.consensys.linea.zktracer.types.AddressUtils.*;
@@ -118,7 +118,7 @@ public abstract class AccountFragment
       Optional<Bytes> addressToTrim,
       DomSubStampsSubFragment domSubStampsSubFragment,
       TransactionProcessingType txProcessingType) {
-    checkArgument(oldState.address().equals(newState.address()));
+    assert oldState.address().equals(newState.address()) : "Address mismatch in ACC fragment";
 
     transactionProcessingMetadata = txProcessingType == USER ? hub.txStack().current() : null;
     hubStamp = hub.stamp();
@@ -231,7 +231,7 @@ public abstract class AccountFragment
               newState.address(), newState.deploymentNumber(), newState.deploymentStatus());
     } catch (RuntimeException e) {
       // getCfi should NEVER throw en exception when requiresRomLex ≡ true
-      checkState(!requiresRomlex);
+      checkState(!requiresRomlex, "Can't get an exception to get CFI when RomLex is required");
       codeFragmentIndex = 0;
     }
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/account/AccountFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/account/AccountFragment.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.hub.fragment.account;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static net.consensys.linea.zktracer.Trace.Hub.MULTIPLIER___DOM_SUB_STAMPS;
 import static net.consensys.linea.zktracer.module.hub.TransactionProcessingType.USER;
@@ -118,7 +119,8 @@ public abstract class AccountFragment
       Optional<Bytes> addressToTrim,
       DomSubStampsSubFragment domSubStampsSubFragment,
       TransactionProcessingType txProcessingType) {
-    assert oldState.address().equals(newState.address()) : "Address mismatch in ACC fragment";
+    checkArgument(
+        oldState.address().equals(newState.address()), "Address mismatch in ACC fragment");
 
     transactionProcessingMetadata = txProcessingType == USER ? hub.txStack().current() : null;
     hubStamp = hub.stamp();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/account/AccountFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/account/AccountFragment.java
@@ -119,8 +119,7 @@ public abstract class AccountFragment
       Optional<Bytes> addressToTrim,
       DomSubStampsSubFragment domSubStampsSubFragment,
       TransactionProcessingType txProcessingType) {
-    checkArgument(
-        oldState.address().equals(newState.address()), "Address mismatch in ACC fragment");
+    checkArgument(oldState.address().equals(newState.address()));
 
     transactionProcessingMetadata = txProcessingType == USER ? hub.txStack().current() : null;
     hubStamp = hub.stamp();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.hub.fragment.common;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static net.consensys.linea.zktracer.Trace.EVM_INST_PUSH0;
 import static net.consensys.linea.zktracer.module.hub.HubProcessingPhase.TX_EXEC;
 import static net.consensys.linea.zktracer.module.hub.TransactionProcessingType.USER;
@@ -132,7 +133,8 @@ public class CommonFragmentValues {
     }
 
     if (Exceptions.staticFault(exceptions)) {
-      assert opCode.mayTriggerStaticException() : "Static exception on non static opcode" + opCode;
+      checkArgument(
+          opCode.mayTriggerStaticException(), "Static exception on non static opcode" + opCode);
       setTracedException(TracedException.STATIC_FAULT);
       return;
     }
@@ -159,14 +161,14 @@ public class CommonFragmentValues {
     if (maxCodeSizeException(exceptions))
     // the MaxCodeSize exceptions for return is already dealt before
     {
-      assert opCode.isCreate() : "MaxCodeSize exception on non CREATE opcode" + opCode;
+      checkArgument(opCode.isCreate(), "MaxCodeSize exception on non CREATE opcode" + opCode);
       setTracedException(MAX_CODE_SIZE_EXCEPTION);
       return;
     }
 
     if (Exceptions.memoryExpansionException(exceptions)) {
-      assert opCode.mayTriggerMemoryExpansionException(hub.fork)
-          : "MXP on non memory opcode" + opCode;
+      checkArgument(
+          opCode.mayTriggerMemoryExpansionException(hub.fork), "MXP on non memory opcode" + opCode);
       setTracedException(TracedException.MEMORY_EXPANSION_EXCEPTION);
       return;
     }
@@ -183,7 +185,8 @@ public class CommonFragmentValues {
   }
 
   public void setTracedException(TracedException tracedException) {
-    assert tracedException == UNDEFINED : "Traced exception already set to " + this.tracedException;
+    checkArgument(
+        tracedException == UNDEFINED, "Traced exception already set to " + this.tracedException);
     this.tracedException = tracedException;
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
@@ -134,7 +134,9 @@ public class CommonFragmentValues {
 
     if (Exceptions.staticFault(exceptions)) {
       checkArgument(
-          opCode.mayTriggerStaticException(), "CommonFragmentValues: opCode %s throws impossible static exception", opCode);
+          opCode.mayTriggerStaticException(),
+          "CommonFragmentValues: opCode %s throws impossible static exception",
+          opCode);
       setTracedException(TracedException.STATIC_FAULT);
       return;
     }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.hub.fragment.common;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static net.consensys.linea.zktracer.Trace.EVM_INST_PUSH0;
 import static net.consensys.linea.zktracer.module.hub.HubProcessingPhase.TX_EXEC;
 import static net.consensys.linea.zktracer.module.hub.TransactionProcessingType.USER;
@@ -133,7 +132,7 @@ public class CommonFragmentValues {
     }
 
     if (Exceptions.staticFault(exceptions)) {
-      checkArgument(opCode.mayTriggerStaticException());
+      assert opCode.mayTriggerStaticException() : "Static exception on non static opcode" + opCode;
       setTracedException(TracedException.STATIC_FAULT);
       return;
     }
@@ -160,13 +159,14 @@ public class CommonFragmentValues {
     if (maxCodeSizeException(exceptions))
     // the MaxCodeSize exceptions for return is already dealt before
     {
-      checkArgument(opCode.isCreate());
+      assert opCode.isCreate() : "MaxCodeSize exception on non CREATE opcode" + opCode;
       setTracedException(MAX_CODE_SIZE_EXCEPTION);
       return;
     }
 
     if (Exceptions.memoryExpansionException(exceptions)) {
-      checkArgument(opCode.mayTriggerMemoryExpansionException(hub.fork));
+      assert opCode.mayTriggerMemoryExpansionException(hub.fork)
+          : "MXP on non memory opcode" + opCode;
       setTracedException(TracedException.MEMORY_EXPANSION_EXCEPTION);
       return;
     }
@@ -183,7 +183,7 @@ public class CommonFragmentValues {
   }
 
   public void setTracedException(TracedException tracedException) {
-    checkArgument(this.tracedException == UNDEFINED);
+    assert tracedException == UNDEFINED : "Traced exception already set to " + this.tracedException;
     this.tracedException = tracedException;
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
@@ -102,7 +102,7 @@ public class CommonFragmentValues {
     this.callFrame = hub.currentFrame();
     this.exceptions = exceptions;
     this.pc = isExec ? callFrame.pc() : 0;
-    this.pcNew = computePcNew(hub, callFrame, opCode, pc, stackException, isExec);
+    this.pcNew = computePcNew(callFrame, opCode, pc, stackException, isExec);
     this.height = callFrame.stack().getHeight();
     this.heightNew = callFrame.stack().getHeightNew();
 
@@ -186,12 +186,12 @@ public class CommonFragmentValues {
 
   public void setTracedException(TracedException tracedException) {
     checkArgument(
-        tracedException == UNDEFINED, "Traced exception already set to " + this.tracedException);
+        this.tracedException == UNDEFINED,
+        "Traced exception already set to " + this.tracedException);
     this.tracedException = tracedException;
   }
 
   static int computePcNew(
-      final Hub hub,
       final CallFrame callFrame,
       OpCodeData opCode,
       final int pc,

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
@@ -134,7 +134,7 @@ public class CommonFragmentValues {
 
     if (Exceptions.staticFault(exceptions)) {
       checkArgument(
-          opCode.mayTriggerStaticException(), "Static exception on non static opcode" + opCode);
+          opCode.mayTriggerStaticException(), "CommonFragmentValues: opCode %s throws impossible static exception", opCode);
       setTracedException(TracedException.STATIC_FAULT);
       return;
     }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
@@ -168,7 +168,8 @@ public class CommonFragmentValues {
 
     if (Exceptions.memoryExpansionException(exceptions)) {
       checkArgument(
-          opCode.mayTriggerMemoryExpansionException(hub.fork), "MXP on non memory opcode" + opCode);
+          opCode.mayTriggerMemoryExpansionException(hub.fork),
+          "MXP triggered by non MXP opcode" + opCode);
       setTracedException(TracedException.MEMORY_EXPANSION_EXCEPTION);
       return;
     }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/StpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/StpCall.java
@@ -66,7 +66,7 @@ public class StpCall implements TraceSubFragment {
     this.opCodeData = hub.opCodeData();
 
     checkArgument(
-        opCodeData.isCall() || opCodeData.isCreate(), opCode + " is not a CALL or CREATE opcode");
+        opCodeData.isCall() || opCodeData.isCreate(), "STP: opCode %s is not a CALL or CREATE opcode", opCode);
 
     this.memoryExpansionGas = memoryExpansionGas;
     this.gasActual = frame.getRemainingGas();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/StpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/StpCall.java
@@ -64,7 +64,8 @@ public class StpCall implements TraceSubFragment {
   public StpCall(Hub hub, MessageFrame frame, long memoryExpansionGas) {
     this.opCode = hub.opCode();
     this.opCodeData = hub.opCodeData();
-    checkArgument(this.opCodeData.isCall() || this.opCodeData.isCreate());
+    assert opCodeData.isCall() || opCodeData.isCreate()
+        : opCode + " is not a CALL or CREATE opcode";
 
     this.memoryExpansionGas = memoryExpansionGas;
     this.gasActual = frame.getRemainingGas();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/StpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/StpCall.java
@@ -66,7 +66,9 @@ public class StpCall implements TraceSubFragment {
     this.opCodeData = hub.opCodeData();
 
     checkArgument(
-        opCodeData.isCall() || opCodeData.isCreate(), "STP: opCode %s is not a CALL or CREATE opcode", opCode);
+        opCodeData.isCall() || opCodeData.isCreate(),
+        "STP: opCode %s is not a CALL or CREATE opcode",
+        opCode);
 
     this.memoryExpansionGas = memoryExpansionGas;
     this.gasActual = frame.getRemainingGas();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/StpCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/StpCall.java
@@ -64,8 +64,9 @@ public class StpCall implements TraceSubFragment {
   public StpCall(Hub hub, MessageFrame frame, long memoryExpansionGas) {
     this.opCode = hub.opCode();
     this.opCodeData = hub.opCodeData();
-    assert opCodeData.isCall() || opCodeData.isCreate()
-        : opCode + " is not a CALL or CREATE opcode";
+
+    checkArgument(
+        opCodeData.isCall() || opCodeData.isCreate(), opCode + " is not a CALL or CREATE opcode");
 
     this.memoryExpansionGas = memoryExpansionGas;
     this.gasActual = frame.getRemainingGas();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/MmuCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/MmuCall.java
@@ -362,7 +362,12 @@ public class MmuCall implements TraceSubFragment, EndTransactionDefer {
 
     final PrecompileScenarioFragment.PrecompileFlag flag =
         subsection.precompileScenarioFragment().flag;
-    checkArgument(flag.isAnyOf(PRC_SHA2_256, PRC_RIPEMD_160));
+    checkArgument(
+        flag.isAnyOf(PRC_SHA2_256, PRC_RIPEMD_160),
+        "Unexpected precompile %s, only accept %s and %s",
+        flag,
+        PRC_SHA2_256,
+        PRC_RIPEMD_160);
 
     return new MmuCall(hub, MMU_INST_RAM_TO_EXO_WITH_PADDING)
         .sourceId(hub.currentFrame().contextNumber())
@@ -381,7 +386,12 @@ public class MmuCall implements TraceSubFragment, EndTransactionDefer {
 
     final PrecompileScenarioFragment.PrecompileFlag flag =
         subsection.precompileScenarioFragment().flag;
-    checkArgument(flag.isAnyOf(PRC_SHA2_256, PRC_RIPEMD_160));
+    checkArgument(
+        flag.isAnyOf(PRC_SHA2_256, PRC_RIPEMD_160),
+        "Unexpected precompile %s, only accept %s and %s",
+        flag,
+        PRC_SHA2_256,
+        PRC_RIPEMD_160);
 
     final boolean isShaTwo = flag == PRC_SHA2_256;
 
@@ -409,8 +419,15 @@ public class MmuCall implements TraceSubFragment, EndTransactionDefer {
     final PrecompileScenarioFragment.PrecompileFlag flag =
         subsection.precompileScenarioFragment().flag;
 
-    checkArgument(flag.isAnyOf(PRC_SHA2_256, PRC_RIPEMD_160));
-    checkArgument(!subsection.getReturnAtRange().isEmpty());
+    checkArgument(
+        flag.isAnyOf(PRC_SHA2_256, PRC_RIPEMD_160),
+        "Unexpected precompile %s, only accept %s and %s",
+        flag,
+        PRC_SHA2_256,
+        PRC_RIPEMD_160);
+    checkArgument(
+        !subsection.getReturnAtRange().isEmpty(),
+        "Partial copy of return data cannot be done if the `returnAtRange` is empty");
 
     return new MmuCall(hub, MMU_INST_RAM_TO_RAM_SANS_PADDING)
         .sourceId(subsection.returnDataContextNumber())

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/MmuCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/MmuCall.java
@@ -324,7 +324,11 @@ public class MmuCall implements TraceSubFragment, EndTransactionDefer {
 
     final int precompileContextNumber = subsection.exoModuleOperationId();
 
-    checkState(subsection.returnDataRange.getRange().size() == TOTAL_SIZE_ECRECOVER_RESULT);
+    checkState(
+        subsection.returnDataRange.getRange().size() == TOTAL_SIZE_ECRECOVER_RESULT,
+        String.format(
+            "Ecrecover return data size is %d but is expected to be %d",
+            subsection.returnDataRange.getRange().size(), TOTAL_SIZE_ECRECOVER_RESULT));
 
     return new MmuCall(hub, MMU_INST_EXO_TO_RAM_TRANSPLANTS)
         .sourceId(precompileContextNumber)
@@ -435,8 +439,12 @@ public class MmuCall implements TraceSubFragment, EndTransactionDefer {
   public static MmuCall partialCopyOfReturnDataForIdentity(
       final Hub hub, final PrecompileSubsection subsection) {
 
-    checkState(subsection.callDataSize() == subsection.returnDataSize());
-    checkState(subsection.returnDataOffset() == 0);
+    checkState(
+        subsection.callDataSize() == subsection.returnDataSize(),
+        "The IDENTITY precompile should have <call data size> == <return data size>");
+    checkState(
+        subsection.returnDataOffset() == 0,
+        "The IDENTITY precompile store its <return data> starting at offset 0");
 
     return new MmuCall(hub, MMU_INST_RAM_TO_RAM_SANS_PADDING)
         .sourceId(subsection.exoModuleOperationId())
@@ -572,7 +580,9 @@ public class MmuCall implements TraceSubFragment, EndTransactionDefer {
     final int precompileContextNumber = subsection.exoModuleOperationId();
 
     final long expectedReturnDataSize = BlsDataOperation.expectedReturnDataSize(subsection.flag());
-    checkState(subsection.returnDataRange.getRange().size() == expectedReturnDataSize);
+    checkState(
+        subsection.returnDataRange.getRange().size() == expectedReturnDataSize,
+        "The return data size for BLS precompile does not match our expectation of it");
 
     return new MmuCall(hub, MMU_INST_EXO_TO_RAM_TRANSPLANTS)
         .sourceId(precompileContextNumber)

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/MmuCall.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/MmuCall.java
@@ -327,7 +327,7 @@ public class MmuCall implements TraceSubFragment, EndTransactionDefer {
     checkState(
         subsection.returnDataRange.getRange().size() == TOTAL_SIZE_ECRECOVER_RESULT,
         String.format(
-            "Ecrecover return data size is %d but is expected to be %d",
+            "MmuCall: Ecrecover return data size is %d but is expected to be %d",
             subsection.returnDataRange.getRange().size(), TOTAL_SIZE_ECRECOVER_RESULT));
 
     return new MmuCall(hub, MMU_INST_EXO_TO_RAM_TRANSPLANTS)
@@ -458,10 +458,10 @@ public class MmuCall implements TraceSubFragment, EndTransactionDefer {
 
     checkState(
         subsection.callDataSize() == subsection.returnDataSize(),
-        "The IDENTITY precompile should have <call data size> == <return data size>");
+        "MmuCall: the IDENTITY precompile should have <call data size> == <return data size>");
     checkState(
         subsection.returnDataOffset() == 0,
-        "The IDENTITY precompile store its <return data> starting at offset 0");
+        "MmuCall: the IDENTITY precompile store its <return data> starting at offset 0");
 
     return new MmuCall(hub, MMU_INST_RAM_TO_RAM_SANS_PADDING)
         .sourceId(subsection.exoModuleOperationId())

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/opcode/CodeCopy.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/opcode/CodeCopy.java
@@ -48,7 +48,7 @@ public class CodeCopy extends MmuCall {
     final Bytes size = currentFrame.frame().getStackItem(2);
 
     // the MMU module only deals with nontrivial CODECOPY instructions
-    checkArgument(!size.isZero(), "CODECOPY with size 0 should not call the MMU module");
+    checkArgument(!size.isZero(), "CODECOPY: size 0 operations should not trigger the MMU module");
 
     this.exoBytes(Optional.of(currentFrame.code().bytecode()))
         .targetId(currentFrame.contextNumber())

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/opcode/CodeCopy.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/opcode/CodeCopy.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.hub.fragment.imc.mmu.opcode;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static net.consensys.linea.zktracer.Trace.MMU_INST_ANY_TO_RAM_WITH_PADDING;
 import static net.consensys.linea.zktracer.runtime.callstack.CallFrame.extractContiguousLimbsFromMemory;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
@@ -48,7 +47,7 @@ public class CodeCopy extends MmuCall {
     final Bytes size = currentFrame.frame().getStackItem(2);
 
     // the MMU module only deals with nontrivial CODECOPY instructions
-    checkArgument(!size.isZero());
+    assert !size.isZero() : "CODECOPY with size 0 should not call the MMU module";
 
     this.exoBytes(Optional.of(currentFrame.code().bytecode()))
         .targetId(currentFrame.contextNumber())

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/opcode/CodeCopy.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/imc/mmu/opcode/CodeCopy.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.hub.fragment.imc.mmu.opcode;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static net.consensys.linea.zktracer.Trace.MMU_INST_ANY_TO_RAM_WITH_PADDING;
 import static net.consensys.linea.zktracer.runtime.callstack.CallFrame.extractContiguousLimbsFromMemory;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
@@ -47,7 +48,7 @@ public class CodeCopy extends MmuCall {
     final Bytes size = currentFrame.frame().getStackItem(2);
 
     // the MMU module only deals with nontrivial CODECOPY instructions
-    assert !size.isZero() : "CODECOPY with size 0 should not call the MMU module";
+    checkArgument(!size.isZero(), "CODECOPY with size 0 should not call the MMU module");
 
     this.exoBytes(Optional.of(currentFrame.code().bytecode()))
         .targetId(currentFrame.contextNumber())

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/scenario/ReturnScenarioFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/scenario/ReturnScenarioFragment.java
@@ -43,7 +43,7 @@ public class ReturnScenarioFragment implements TraceFragment {
 
   @Override
   public Trace.Hub trace(Trace.Hub trace) {
-    assert !scenario.equals(UNDEFINED) : "Return scenario not defined";
+    checkArgument(!scenario.equals(UNDEFINED), "Return scenario not defined");
     return trace
         .peekAtScenario(true)
         // RETURN scenarios

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/scenario/ReturnScenarioFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/scenario/ReturnScenarioFragment.java
@@ -43,7 +43,7 @@ public class ReturnScenarioFragment implements TraceFragment {
 
   @Override
   public Trace.Hub trace(Trace.Hub trace) {
-    checkArgument(!scenario.equals(UNDEFINED));
+    assert !scenario.equals(UNDEFINED) : "Return scenario not defined";
     return trace
         .peekAtScenario(true)
         // RETURN scenarios

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/scenario/SelfdestructScenarioFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/scenario/SelfdestructScenarioFragment.java
@@ -42,7 +42,7 @@ public class SelfdestructScenarioFragment implements TraceFragment {
   public Trace.Hub trace(Trace.Hub trace) {
     checkArgument(
         !scenario.equals(UNDEFINED),
-        "SELFDESTRUCT scenario %s is UNDEFINED at trace time",
+        "SELFDESTRUCT: scenario %s is UNDEFINED at trace time",
         scenario);
     return trace
         .peekAtScenario(true)

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/scenario/SelfdestructScenarioFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/scenario/SelfdestructScenarioFragment.java
@@ -27,7 +27,7 @@ public class SelfdestructScenarioFragment implements TraceFragment {
   SelfdestructScenario scenario;
 
   public SelfdestructScenarioFragment() {
-    this.scenario = UNDEFINED;
+    scenario = UNDEFINED;
   }
 
   public enum SelfdestructScenario {
@@ -40,18 +40,21 @@ public class SelfdestructScenarioFragment implements TraceFragment {
 
   @Override
   public Trace.Hub trace(Trace.Hub trace) {
-    checkArgument(!this.scenario.equals(UNDEFINED));
+    checkArgument(
+        !scenario.equals(UNDEFINED),
+        "SELFDESTRUCT scenario %s is UNDEFINED at trace time",
+        scenario);
     return trace
         .peekAtScenario(true)
         // // SELFDESTRUCT scenarios
         ////////////////////////////
         .pScenarioSelfdestructException(
-            this.scenario.equals(SelfdestructScenario.SELFDESTRUCT_EXCEPTION))
+            scenario.equals(SelfdestructScenario.SELFDESTRUCT_EXCEPTION))
         .pScenarioSelfdestructWillRevert(
-            this.scenario.equals(SelfdestructScenario.SELFDESTRUCT_WILL_REVERT))
+            scenario.equals(SelfdestructScenario.SELFDESTRUCT_WILL_REVERT))
         .pScenarioSelfdestructWontRevertAlreadyMarked(
-            this.scenario.equals(SelfdestructScenario.SELFDESTRUCT_WONT_REVERT_ALREADY_MARKED))
+            scenario.equals(SelfdestructScenario.SELFDESTRUCT_WONT_REVERT_ALREADY_MARKED))
         .pScenarioSelfdestructWontRevertNotYetMarked(
-            this.scenario.equals(SelfdestructScenario.SELFDESTRUCT_WONT_REVERT_NOT_YET_MARKED));
+            scenario.equals(SelfdestructScenario.SELFDESTRUCT_WONT_REVERT_NOT_YET_MARKED));
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/stack/StackFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/stack/StackFragment.java
@@ -142,7 +142,7 @@ public abstract class StackFragment implements TraceFragment {
   }
 
   private Bytes getPushValue(Hub hub) {
-    checkState(hub.opCodeData().isNonTrivialPush());
+    checkState(hub.opCodeData().isNonTrivialPush(), "getPushValue called for non-PUSH opcode");
 
     final int pc = hub.messageFrame().getPC();
     if (pc + 1 >= hub.messageFrame().getCode().getSize()) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/stack/StackFragment.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/stack/StackFragment.java
@@ -313,19 +313,66 @@ public abstract class StackFragment implements TraceFragment {
 
   private void tracedExceptionSanityChecks(TracedException tracedException) {
     switch (tracedException) {
-      case NONE -> checkArgument(Exceptions.none(exceptions));
-      case INVALID_OPCODE -> checkArgument(Exceptions.invalidOpcode(exceptions));
-      case STACK_UNDERFLOW -> checkArgument(Exceptions.stackUnderflow(exceptions));
-      case STACK_OVERFLOW -> checkArgument(Exceptions.stackOverflow(exceptions));
+      case NONE -> checkArgument(
+          Exceptions.none(exceptions),
+          "tracedException %s not present in exceptions %s",
+          NONE,
+          exceptions);
+      case INVALID_OPCODE -> checkArgument(
+          Exceptions.invalidOpcode(exceptions),
+          "tracedException %s not present in exceptions %s",
+          INVALID_OPCODE,
+          exceptions);
+      case STACK_UNDERFLOW -> checkArgument(
+          Exceptions.stackUnderflow(exceptions),
+          "tracedException %s not present in exceptions %s",
+          STACK_UNDERFLOW,
+          exceptions);
+      case STACK_OVERFLOW -> checkArgument(
+          Exceptions.stackOverflow(exceptions),
+          "tracedException %s not present in exceptions %s",
+          STACK_OVERFLOW,
+          exceptions);
       case MEMORY_EXPANSION_EXCEPTION -> checkArgument(
-          Exceptions.memoryExpansionException(exceptions));
-      case OUT_OF_GAS_EXCEPTION -> checkArgument(Exceptions.outOfGasException(exceptions));
-      case RETURN_DATA_COPY_FAULT -> checkArgument(Exceptions.returnDataCopyFault(exceptions));
-      case JUMP_FAULT -> checkArgument(Exceptions.jumpFault(exceptions));
-      case STATIC_FAULT -> checkArgument(Exceptions.staticFault(exceptions));
-      case OUT_OF_SSTORE -> checkArgument(Exceptions.outOfSStore(exceptions));
-      case INVALID_CODE_PREFIX -> checkArgument(Exceptions.invalidCodePrefix(exceptions));
-      case MAX_CODE_SIZE_EXCEPTION -> checkArgument(Exceptions.maxCodeSizeException(exceptions));
+          Exceptions.memoryExpansionException(exceptions),
+          "tracedException %s not present in exceptions %s",
+          MEMORY_EXPANSION_EXCEPTION,
+          exceptions);
+      case OUT_OF_GAS_EXCEPTION -> checkArgument(
+          Exceptions.outOfGasException(exceptions),
+          "tracedException %s not present in exceptions %s",
+          OUT_OF_GAS_EXCEPTION,
+          exceptions);
+      case RETURN_DATA_COPY_FAULT -> checkArgument(
+          Exceptions.returnDataCopyFault(exceptions),
+          "tracedException %s not present in exceptions %s",
+          RETURN_DATA_COPY_FAULT,
+          exceptions);
+      case JUMP_FAULT -> checkArgument(
+          Exceptions.jumpFault(exceptions),
+          "tracedException %s not present in exceptions %s",
+          JUMP_FAULT,
+          exceptions);
+      case STATIC_FAULT -> checkArgument(
+          Exceptions.staticFault(exceptions),
+          "tracedException %s not present in exceptions %s",
+          STATIC_FAULT,
+          exceptions);
+      case OUT_OF_SSTORE -> checkArgument(
+          Exceptions.outOfSStore(exceptions),
+          "tracedException %s not present in exceptions %s",
+          OUT_OF_SSTORE,
+          exceptions);
+      case INVALID_CODE_PREFIX -> checkArgument(
+          Exceptions.invalidCodePrefix(exceptions),
+          "tracedException %s not present in exceptions %s",
+          INVALID_CODE_PREFIX,
+          exceptions);
+      case MAX_CODE_SIZE_EXCEPTION -> checkArgument(
+          Exceptions.maxCodeSizeException(exceptions),
+          "tracedException %s not present in exceptions %s",
+          MAX_CODE_SIZE_EXCEPTION,
+          exceptions);
       case UNDEFINED -> throw new RuntimeException(
           "tracedException remained UNDEFINED but "
               + Exceptions.prettyStringOf(this.opCode.mnemonic(), exceptions));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/AccountSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/AccountSection.java
@@ -64,7 +64,9 @@ public class AccountSection extends TraceSection implements PostRollbackDefer {
       if (Exceptions.any(exceptions)) {
         // the "squash parent return data" context row is all there is
         // The following is true since we do not enter here in case of a STACK_OVERFLOW_EXCEPTION
-        Preconditions.checkArgument(Exceptions.outOfGasException(exceptions));
+        Preconditions.checkArgument(
+            Exceptions.outOfGasException(exceptions),
+            "SELF_ACCOUNT_OPCODES (SELFBALANCE, CODESIZE) that don't break the stack should only fail with OOGX");
         return;
       }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/CallDataLoadSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/CallDataLoadSection.java
@@ -49,7 +49,9 @@ public class CallDataLoadSection extends TraceSection {
       }
     } else {
       // Sanity check
-      checkArgument(Exceptions.outOfGasException(exception));
+      checkArgument(
+          Exceptions.outOfGasException(exception),
+          "CALLDATALOAD may only throw the OOGX exception");
     }
 
     final ContextFragment context = readCurrentContextData(hub);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/EarlyExceptionSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/EarlyExceptionSection.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.hub.section;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static net.consensys.linea.zktracer.opcode.InstructionFamily.INVALID;
 
 import net.consensys.linea.zktracer.module.hub.Hub;
@@ -32,20 +33,22 @@ public class EarlyExceptionSection extends TraceSection {
 
     final OpCodeData opCode = hub.opCodeData();
     if (Exceptions.stackUnderflow(exceptions)) {
-      assert opCode.mayTriggerStackUnderflow() : "SUX was detected but can't happen for " + opCode;
+      checkArgument(
+          opCode.mayTriggerStackUnderflow(), "SUX was detected but can't happen for " + opCode);
       commonValues.setTracedException(TracedException.STACK_UNDERFLOW);
       return;
     }
 
     if (Exceptions.stackOverflow(exceptions)) {
-      assert opCode.mayTriggerStackOverflow() : "SOX was detected but can't happen for " + opCode;
+      checkArgument(
+          opCode.mayTriggerStackOverflow(), "SOX was detected but can't happen for " + opCode);
       commonValues.setTracedException(TracedException.STACK_OVERFLOW);
       return;
     }
 
     if (hub.opCodeData().instructionFamily() == INVALID) {
-      assert Exceptions.invalidOpcode(exceptions)
-          : "INVALID opcode detected but no INVALID exception";
+      checkArgument(
+          Exceptions.invalidOpcode(exceptions), "INVALID opcode detected but no INVALID exception");
       commonValues.setTracedException(TracedException.INVALID_OPCODE);
     }
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/EarlyExceptionSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/EarlyExceptionSection.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.hub.section;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static net.consensys.linea.zktracer.opcode.InstructionFamily.INVALID;
 
 import net.consensys.linea.zktracer.module.hub.Hub;
@@ -33,19 +32,20 @@ public class EarlyExceptionSection extends TraceSection {
 
     final OpCodeData opCode = hub.opCodeData();
     if (Exceptions.stackUnderflow(exceptions)) {
-      checkArgument(opCode.mayTriggerStackUnderflow());
+      assert opCode.mayTriggerStackUnderflow() : "SUX was detected but can't happen for " + opCode;
       commonValues.setTracedException(TracedException.STACK_UNDERFLOW);
       return;
     }
 
     if (Exceptions.stackOverflow(exceptions)) {
-      checkArgument(opCode.mayTriggerStackOverflow());
+      assert opCode.mayTriggerStackOverflow() : "SOX was detected but can't happen for " + opCode;
       commonValues.setTracedException(TracedException.STACK_OVERFLOW);
       return;
     }
 
     if (hub.opCodeData().instructionFamily() == INVALID) {
-      checkArgument(Exceptions.invalidOpcode(exceptions));
+      assert Exceptions.invalidOpcode(exceptions)
+          : "INVALID opcode detected but no INVALID exception";
       commonValues.setTracedException(TracedException.INVALID_OPCODE);
     }
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/JumpSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/JumpSection.java
@@ -51,7 +51,7 @@ public class JumpSection extends TraceSection {
     final Address codeAddress = hub.messageFrame().getContractAddress();
 
     final boolean warmth = hub.messageFrame().isAddressWarm(codeAddress);
-    assert warmth : "Must be warm when doing a JUMP";
+    checkArgument(warmth, "Must be warm when doing a JUMP");
 
     final AccountSnapshot codeAccount = canonical(hub, codeAddress);
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/JumpSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/JumpSection.java
@@ -51,7 +51,7 @@ public class JumpSection extends TraceSection {
     final Address codeAddress = hub.messageFrame().getContractAddress();
 
     final boolean warmth = hub.messageFrame().isAddressWarm(codeAddress);
-    checkArgument(warmth);
+    assert warmth : "Must be warm when doing a JUMP";
 
     final AccountSnapshot codeAccount = canonical(hub, codeAddress);
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/LogSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/LogSection.java
@@ -15,6 +15,8 @@
 
 package net.consensys.linea.zktracer.module.hub.section;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.defer.EndTransactionDefer;
 import net.consensys.linea.zktracer.module.hub.fragment.ContextFragment;
@@ -42,7 +44,7 @@ public class LogSection extends TraceSection implements EndTransactionDefer {
 
     // Static Case
     if (hub.currentFrame().frame().isStatic()) {
-      assert Exceptions.staticFault(exceptions) : "STATICX not detected";
+      checkArgument(Exceptions.staticFault(exceptions), "STATICX not detected");
       return;
     }
 
@@ -52,8 +54,9 @@ public class LogSection extends TraceSection implements EndTransactionDefer {
     final MxpCall mxpCall = MxpCall.newMxpCall(hub);
     imcFragment.callMxp(mxpCall);
 
-    assert mxpCall.isMxpx() == Exceptions.memoryExpansionException(exceptions)
-        : "MXPX mismatch with MXP call";
+    checkArgument(
+        mxpCall.isMxpx() == Exceptions.memoryExpansionException(exceptions),
+        "MXPX mismatch with MXP call");
 
     // MXPX case
     if (mxpCall.isMxpx()) {
@@ -66,13 +69,14 @@ public class LogSection extends TraceSection implements EndTransactionDefer {
     }
 
     // the unexceptional case
-    assert Exceptions.none(exceptions) : "Unexpected exception code " + exceptions;
+    checkArgument(Exceptions.none(exceptions), "Unexpected exception code " + exceptions);
 
     hub.defers().scheduleForEndTransaction(this);
 
     final LogData logData = new LogData(hub);
-    assert logData.nontrivialLog() == mxpCall.mayTriggerNontrivialMmuOperation
-        : "non trivial LOG / MMU mismatch";
+    checkArgument(
+        logData.nontrivialLog() == mxpCall.mayTriggerNontrivialMmuOperation,
+        "non trivial LOG / MMU mismatch");
     mmuCall = (logData.nontrivialLog()) ? MmuCall.LogX(hub, logData) : null;
 
     if (mmuCall != null) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/LogSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/LogSection.java
@@ -15,8 +15,6 @@
 
 package net.consensys.linea.zktracer.module.hub.section;
 
-import static com.google.common.base.Preconditions.*;
-
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.defer.EndTransactionDefer;
 import net.consensys.linea.zktracer.module.hub.fragment.ContextFragment;
@@ -44,7 +42,7 @@ public class LogSection extends TraceSection implements EndTransactionDefer {
 
     // Static Case
     if (hub.currentFrame().frame().isStatic()) {
-      checkArgument(Exceptions.staticFault(exceptions));
+      assert Exceptions.staticFault(exceptions) : "STATICX not detected";
       return;
     }
 
@@ -54,7 +52,8 @@ public class LogSection extends TraceSection implements EndTransactionDefer {
     final MxpCall mxpCall = MxpCall.newMxpCall(hub);
     imcFragment.callMxp(mxpCall);
 
-    checkArgument(mxpCall.isMxpx() == Exceptions.memoryExpansionException(exceptions));
+    assert mxpCall.isMxpx() == Exceptions.memoryExpansionException(exceptions)
+        : "MXPX mismatch with MXP call";
 
     // MXPX case
     if (mxpCall.isMxpx()) {
@@ -67,12 +66,13 @@ public class LogSection extends TraceSection implements EndTransactionDefer {
     }
 
     // the unexceptional case
-    checkArgument(Exceptions.none(exceptions));
+    assert Exceptions.none(exceptions) : "Unexpected exception code " + exceptions;
 
     hub.defers().scheduleForEndTransaction(this);
 
     final LogData logData = new LogData(hub);
-    checkArgument(logData.nontrivialLog() == mxpCall.mayTriggerNontrivialMmuOperation);
+    assert logData.nontrivialLog() == mxpCall.mayTriggerNontrivialMmuOperation
+        : "non trivial LOG / MMU mismatch";
     mmuCall = (logData.nontrivialLog()) ? MmuCall.LogX(hub, logData) : null;
 
     if (mmuCall != null) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/SstoreSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/SstoreSection.java
@@ -91,7 +91,9 @@ public class SstoreSection extends TraceSection implements PostRollbackDefer {
       return;
     }
 
-    checkArgument(Exceptions.outOfGasException(exceptions) || Exceptions.none(exceptions));
+    checkArgument(
+        Exceptions.outOfGasException(exceptions) || Exceptions.none(exceptions),
+        "SSTORE may only throw STATICX, SSTOREX or OOGX exceptions, in that order of priority");
 
     hub.defers().scheduleForPostRollback(this, hub.currentFrame());
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/StackRamSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/StackRamSection.java
@@ -54,7 +54,9 @@ public class StackRamSection extends TraceSection {
     final MxpCall mxpCall = MxpCall.newMxpCall(hub);
     imcFragment.callMxp(mxpCall);
 
-    checkArgument(mxpCall.isMxpx() == Exceptions.memoryExpansionException(exceptions));
+    checkArgument(
+        mxpCall.isMxpx() == Exceptions.memoryExpansionException(exceptions),
+        "The mxp module's MXPX not seen by the hub's (short) exceptions");
 
     // MXPX or OOGX case
     if (Exceptions.memoryExpansionException(exceptions)
@@ -63,7 +65,11 @@ public class StackRamSection extends TraceSection {
     }
 
     // the unexceptional case
-    checkArgument(Exceptions.none(exceptions));
+    checkArgument(
+        Exceptions.none(exceptions),
+        "STACK_RAM instruction %s throws unexpected exception %s",
+        hub.opCode(),
+        exceptions);
 
     final CallFrame currentFrame = hub.currentFrame();
     final EWord offset = EWord.of(currentFrame.frame().getStackItem(0));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/TraceSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/TraceSection.java
@@ -69,7 +69,9 @@ public class TraceSection {
    * @param fragment the fragment to insert
    */
   public final void addFragment(TraceFragment fragment) {
-    checkArgument(!(fragment instanceof CommonFragment));
+    checkArgument(
+        !(fragment instanceof CommonFragment),
+        "CommonFragment should not be added directly to a trace section");
     fragments.add(fragment);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
@@ -418,7 +418,10 @@ public class CallSection extends TraceSection
   public void resolveUponContextEntry(Hub hub, MessageFrame frame) {
 
     final CallScenarioFragment.CallScenario scenario = scenarioFragment.getScenario();
-    checkState(scenario == CALL_SMC_UNDEFINED | scenario == CALL_PRC_UNDEFINED);
+    checkState(
+        scenario == CALL_SMC_UNDEFINED | scenario == CALL_PRC_UNDEFINED,
+        String.format(
+            "Call scenario %s should be undefined at context entry resolution", scenario));
 
     callerFirstNew = callerFirst.deepCopy();
     calleeFirstNew = calleeFirst.deepCopy().turnOnWarmth();
@@ -434,7 +437,9 @@ public class CallSection extends TraceSection
     }
 
     if (isNonzeroValueSelfCall()) {
-      checkState(scenarioFragment.getScenario() == CALL_SMC_UNDEFINED);
+      checkState(
+          scenarioFragment.getScenario() == CALL_SMC_UNDEFINED,
+          "Self-calls cannot involve precompiles");
       calleeFirst = callerFirstNew.deepCopy();
       calleeFirstNew = callerFirst.deepCopy();
     }
@@ -480,7 +485,10 @@ public class CallSection extends TraceSection
 
     switch (scenarioFragment.getScenario()) {
       case CALL_EOA_UNDEFINED -> {
-        checkState(success);
+        checkState(
+            success,
+            String.format(
+                "EOA calls that are still %s at context re-entry cannot fail", CALL_EOA_UNDEFINED));
         scenarioFragment.setScenario(CALL_EOA_SUCCESS_WONT_REVERT);
         firstAccountRowsEoaOrPrc(hub);
         final long gasAfterCall = frame.frame().getRemainingGas();
@@ -661,7 +669,12 @@ public class CallSection extends TraceSection
   private void completeSmcOrPrcSuccessWillRevert(Hub hub) {
 
     final CallScenarioFragment.CallScenario callScenario = scenarioFragment.getScenario();
-    checkState(callScenario.isAnyOf(CALL_SMC_SUCCESS_WONT_REVERT, CALL_PRC_SUCCESS_WONT_REVERT));
+    checkState(
+        callScenario.isAnyOf(CALL_SMC_SUCCESS_WONT_REVERT, CALL_PRC_SUCCESS_WONT_REVERT),
+        "The only CALL scenarios that can be successful and reverted (down stream) are %s and %s, yet we are given %s",
+        CALL_SMC_SUCCESS_WONT_REVERT,
+        CALL_PRC_SUCCESS_WONT_REVERT,
+        callScenario);
     if (callScenario == CALL_SMC_SUCCESS_WONT_REVERT) {
       scenarioFragment.setScenario(CALL_SMC_SUCCESS_WILL_REVERT);
     } else {
@@ -733,12 +746,16 @@ public class CallSection extends TraceSection
   }
 
   private boolean isSelfCall() {
-    checkState(scenarioFragment.getScenario().isIndefiniteSmcCallScenario());
+    checkState(
+        scenarioFragment.getScenario().isIndefiniteSmcCallScenario(),
+        "self-calls only make sense for SMC call scenarios");
     return calleeAddress.equals(callerAddress);
   }
 
   private boolean isNonzeroValueSelfCall() {
-    checkState(scenarioFragment.getScenario().isIndefiniteSmcCallScenario());
+    checkState(
+        scenarioFragment.getScenario().isIndefiniteSmcCallScenario(),
+        "(nonzero value) self-calls only make sense for SMC call scenarios");
     return isSelfCall() && !value.isZero();
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
@@ -184,7 +184,9 @@ public class CallSection extends TraceSection
 
     final MxpCall mxpCall = MxpCall.newMxpCall(hub);
     firstImcFragment.callMxp(mxpCall);
-    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions));
+    checkArgument(
+        mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions),
+        "mxp module MXPX does not match the hub's MXPX");
 
     // MXPX case
     if (Exceptions.memoryExpansionException(exceptions)) {
@@ -222,7 +224,7 @@ public class CallSection extends TraceSection
     }
 
     // The CALL is now unexceptional
-    checkArgument(Exceptions.none(exceptions));
+    checkArgument(Exceptions.none(exceptions), "Unexpected exception in CallSection");
     currentFrame.childSpanningSection(this);
 
     // the call data span and ``return at'' spans are only required once the CALL is unexceptional
@@ -239,7 +241,9 @@ public class CallSection extends TraceSection
     final CallOobCall oobCall = (CallOobCall) firstImcFragment.callOob(new CallOobCall());
 
     final boolean aborts = hub.pch().abortingConditions().any();
-    checkArgument(oobCall.isAbortingCondition() == aborts);
+    checkArgument(
+        oobCall.isAbortingCondition() == aborts,
+        "oob module ABORT prediction and hub module ABORT prediction mismatch");
 
     hub.defers().scheduleForPostRollback(this, currentFrame);
     hub.defers().scheduleForEndTransaction(this);
@@ -471,7 +475,7 @@ public class CallSection extends TraceSection
   /** Resolution happens as the child context is about to terminate. */
   @Override
   public void resolveUponContextExit(Hub hub, CallFrame frame) {
-    checkArgument(scenarioFragment.getScenario() == CALL_SMC_UNDEFINED);
+    checkArgument(scenarioFragment.getScenario() == CALL_SMC_UNDEFINED, "Illegal CALL scenario at context exit");
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
@@ -425,7 +425,7 @@ public class CallSection extends TraceSection
     checkState(
         scenario == CALL_SMC_UNDEFINED | scenario == CALL_PRC_UNDEFINED,
         String.format(
-            "Call scenario %s should be undefined at context entry resolution", scenario));
+            "CallSection: call scenario %s should be undefined at context entry resolution", scenario));
 
     callerFirstNew = callerFirst.deepCopy();
     calleeFirstNew = calleeFirst.deepCopy().turnOnWarmth();
@@ -443,7 +443,7 @@ public class CallSection extends TraceSection
     if (isNonzeroValueSelfCall()) {
       checkState(
           scenarioFragment.getScenario() == CALL_SMC_UNDEFINED,
-          "Self-calls cannot involve precompiles");
+          "CallSection: self-calls cannot involve precompiles");
       calleeFirst = callerFirstNew.deepCopy();
       calleeFirstNew = callerFirst.deepCopy();
     }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
@@ -475,7 +475,9 @@ public class CallSection extends TraceSection
   /** Resolution happens as the child context is about to terminate. */
   @Override
   public void resolveUponContextExit(Hub hub, CallFrame frame) {
-    checkArgument(scenarioFragment.getScenario() == CALL_SMC_UNDEFINED, "Illegal CALL scenario at context exit");
+    checkArgument(
+        scenarioFragment.getScenario() == CALL_SMC_UNDEFINED,
+        "Illegal CALL scenario at context exit");
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
@@ -425,7 +425,8 @@ public class CallSection extends TraceSection
     checkState(
         scenario == CALL_SMC_UNDEFINED | scenario == CALL_PRC_UNDEFINED,
         String.format(
-            "CallSection: call scenario %s should be undefined at context entry resolution", scenario));
+            "CallSection: call scenario %s should be undefined at context entry resolution",
+            scenario));
 
     callerFirstNew = callerFirst.deepCopy();
     calleeFirstNew = calleeFirst.deepCopy().turnOnWarmth();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/BlakeSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/BlakeSubsection.java
@@ -72,7 +72,7 @@ public class BlakeSubsection extends PrecompileSubsection {
     blake2fParamsOobCall =
         (Blake2fParamsOobCall) secondImcFragment.callOob(new Blake2fParamsOobCall(calleeGas));
 
-    checkArgument(blake2fParamsOobCall.isRamSuccess() == blakeSuccess);
+    checkArgument(blake2fParamsOobCall.isRamSuccess() == blakeSuccess, "BLAKE2f success mismatch");
   }
 
   @Override
@@ -80,8 +80,9 @@ public class BlakeSubsection extends PrecompileSubsection {
     super.resolveAtContextReEntry(hub, callFrame);
 
     // sanity checks
-    checkArgument(blakeCdsOobCall.isHubSuccess() == (callDataSize() == 213));
-    checkArgument(callSuccess == blakeSuccess);
+    checkArgument(
+        blakeCdsOobCall.isHubSuccess() == (callDataSize() == 213), "BLAKE2f hub success mismatch");
+    checkArgument(callSuccess == blakeSuccess, "BLAKE2f call success mismatch");
     this.sanityCheck();
 
     if (!callSuccess) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/EllipticCurvePrecompileSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/EllipticCurvePrecompileSubsection.java
@@ -93,16 +93,20 @@ public class EllipticCurvePrecompileSubsection extends PrecompileSubsection {
     // sanity checks
     switch (flag()) {
       case PRC_ECRECOVER -> {
-        checkArgument(oobCall.isHubSuccess() == callSuccess);
+        checkArgument(oobCall.isHubSuccess() == callSuccess, "ECRECOVER hub success mismatch");
         checkArgument(
             callSuccess
                 ? (returnData == Bytes.EMPTY || returnData.size() == WORD_SIZE)
-                : returnData == Bytes.EMPTY);
+                : returnData == Bytes.EMPTY,
+            "ECRECOVER return data size mismatch");
       }
       case PRC_ECPAIRING -> checkArgument(
-          returnDataRange.extract().size() == (callSuccess ? WORD_SIZE : 0));
+          returnDataRange.extract().size() == (callSuccess ? WORD_SIZE : 0),
+          "ECPAIRING return data size mismatch");
       case PRC_ECADD, PRC_ECMUL -> checkArgument(
-          returnDataRange.extract().size() == (callSuccess ? 2 * WORD_SIZE : 0));
+          returnDataRange.extract().size() == (callSuccess ? 2 * WORD_SIZE : 0),
+          "%s return data size mismatch",
+          flag());
       case PRC_POINT_EVALUATION,
           PRC_BLS_G1_ADD,
           PRC_BLS_G1_MSM,
@@ -136,7 +140,8 @@ public class EllipticCurvePrecompileSubsection extends PrecompileSubsection {
     // BLS precompiles do not accept empty call data
     // This checks should be redundant with OOB checks
     if (flag().isBlsPrecompile()) {
-      Preconditions.checkArgument(nonemptyCallData);
+      Preconditions.checkArgument(
+          nonemptyCallData, "BLS precompile %s called with empty call data", flag());
     }
 
     final boolean successBitMmuCall = flag() == PRC_ECRECOVER ? !returnData.isEmpty() : callSuccess;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/IdentitySubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/IdentitySubsection.java
@@ -54,7 +54,9 @@ public class IdentitySubsection extends PrecompileSubsection {
     super.resolveAtContextReEntry(hub, callFrame);
 
     // sanity check
-    checkArgument(callSuccess == oobCall.isHubSuccess());
+    checkArgument(
+        callSuccess == oobCall.isHubSuccess(),
+        "oob and hub disagree on IDENTITY precompile success");
 
     if (!callSuccess) {
       return;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/ModexpSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/ModexpSubsection.java
@@ -15,7 +15,6 @@
 
 package net.consensys.linea.zktracer.module.hub.section.call.precompileSubsection;
 
-import static com.google.common.base.Preconditions.*;
 import static net.consensys.linea.zktracer.module.hub.fragment.imc.mmu.MmuCall.forModexpExtractBase;
 import static net.consensys.linea.zktracer.module.hub.fragment.imc.mmu.MmuCall.forModexpExtractBbs;
 import static net.consensys.linea.zktracer.module.hub.fragment.imc.mmu.MmuCall.forModexpExtractEbs;
@@ -122,7 +121,7 @@ public class ModexpSubsection extends PrecompileSubsection {
     super.resolveAtContextReEntry(hub, callFrame);
 
     // sanity check
-    checkArgument(callSuccess == sixthOobCall.isRamSuccess());
+    assert callSuccess == sixthOobCall.isRamSuccess() : "Inconsistent Modexp success status";
 
     if (!callSuccess) {
       precompileScenarioFragment.scenario(PRC_FAILURE_KNOWN_TO_RAM);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/ModexpSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/ModexpSubsection.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.hub.section.call.precompileSubsection;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static net.consensys.linea.zktracer.module.hub.fragment.imc.mmu.MmuCall.forModexpExtractBase;
 import static net.consensys.linea.zktracer.module.hub.fragment.imc.mmu.MmuCall.forModexpExtractBbs;
 import static net.consensys.linea.zktracer.module.hub.fragment.imc.mmu.MmuCall.forModexpExtractEbs;
@@ -121,7 +122,7 @@ public class ModexpSubsection extends PrecompileSubsection {
     super.resolveAtContextReEntry(hub, callFrame);
 
     // sanity check
-    assert callSuccess == sixthOobCall.isRamSuccess() : "Inconsistent Modexp success status";
+    checkArgument(callSuccess == sixthOobCall.isRamSuccess(), "Inconsistent Modexp success status");
 
     if (!callSuccess) {
       precompileScenarioFragment.scenario(PRC_FAILURE_KNOWN_TO_RAM);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/PrecompileSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/PrecompileSubsection.java
@@ -116,9 +116,15 @@ public class PrecompileSubsection
 
   public void sanityCheck() {
     if (callSuccess) {
-      checkArgument(precompileScenarioFragment.scenario.isSuccess());
+      checkArgument(
+          precompileScenarioFragment.scenario.isSuccess(),
+          "precompile scenario %s not success scenario",
+          precompileScenarioFragment.scenario());
     } else {
-      checkArgument(precompileScenarioFragment.scenario.isFailure());
+      checkArgument(
+          precompileScenarioFragment.scenario.isFailure(),
+          "precompile scenario %s not failure scenario",
+          precompileScenarioFragment.scenario());
     }
   }
 
@@ -126,7 +132,8 @@ public class PrecompileSubsection
   public void resolveUponRollback(Hub hub, MessageFrame messageFrame, CallFrame callFrame) {
 
     // only successful PRC calls should enter here
-    checkArgument(precompileScenarioFragment.scenario() == PRC_SUCCESS_WONT_REVERT);
+    checkArgument(precompileScenarioFragment.scenario() == PRC_SUCCESS_WONT_REVERT,
+            "precompile scenario %s incompatible with being rolled back");
 
     precompileScenarioFragment.scenario(PRC_SUCCESS_WILL_REVERT);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/PrecompileSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/PrecompileSubsection.java
@@ -132,8 +132,9 @@ public class PrecompileSubsection
   public void resolveUponRollback(Hub hub, MessageFrame messageFrame, CallFrame callFrame) {
 
     // only successful PRC calls should enter here
-    checkArgument(precompileScenarioFragment.scenario() == PRC_SUCCESS_WONT_REVERT,
-            "precompile scenario %s incompatible with being rolled back");
+    checkArgument(
+        precompileScenarioFragment.scenario() == PRC_SUCCESS_WONT_REVERT,
+        "precompile scenario %s incompatible with being rolled back");
 
     precompileScenarioFragment.scenario(PRC_SUCCESS_WILL_REVERT);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/PrecompileSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/PrecompileSubsection.java
@@ -161,10 +161,10 @@ public class PrecompileSubsection
     final Bytes returnData = frame.getReturnData();
     checkState(
         0 <= mbs && mbs <= MODEXP_COMPONENT_BYTE_SIZE,
-        "MODEXP: invalid mbs: %s not in range [0,%s]",
+        "MODEXP PrecompileSubsection: invalid mbs: %s not in range [0,%s]",
         mbs,
         MODEXP_COMPONENT_BYTE_SIZE);
-    checkState(returnData.size() == mbs, "invalid MODEXP return data size");
+    checkState(returnData.size() == mbs, "MODEXP PrecompileSubsection: return data size %s does not agree with mbs %s", returnData.size(), mbs);
     final Bytes leftPaddedReturnData = leftPadTo(returnData, MODEXP_COMPONENT_BYTE_SIZE);
 
     returnDataRange =

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/PrecompileSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/PrecompileSubsection.java
@@ -164,7 +164,11 @@ public class PrecompileSubsection
         "MODEXP PrecompileSubsection: invalid mbs: %s not in range [0,%s]",
         mbs,
         MODEXP_COMPONENT_BYTE_SIZE);
-    checkState(returnData.size() == mbs, "MODEXP PrecompileSubsection: return data size %s does not agree with mbs %s", returnData.size(), mbs);
+    checkState(
+        returnData.size() == mbs,
+        "MODEXP PrecompileSubsection: return data size %s does not agree with mbs %s",
+        returnData.size(),
+        mbs);
     final Bytes leftPaddedReturnData = leftPadTo(returnData, MODEXP_COMPONENT_BYTE_SIZE);
 
     returnDataRange =

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/PrecompileSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/PrecompileSubsection.java
@@ -151,8 +151,12 @@ public class PrecompileSubsection
     // successful PRC_CALL to MODEXP
     final int mbs = ((ModexpSubsection) this).modexpMetaData.mbsInt();
     final Bytes returnData = frame.getReturnData();
-    checkState(0 <= mbs && mbs <= MODEXP_COMPONENT_BYTE_SIZE);
-    checkState(returnData.size() == mbs);
+    checkState(
+        0 <= mbs && mbs <= MODEXP_COMPONENT_BYTE_SIZE,
+        "MODEXP: invalid mbs: %s not in range [0,%s]",
+        mbs,
+        MODEXP_COMPONENT_BYTE_SIZE);
+    checkState(returnData.size() == mbs, "invalid MODEXP return data size");
     final Bytes leftPaddedReturnData = leftPadTo(returnData, MODEXP_COMPONENT_BYTE_SIZE);
 
     returnDataRange =

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/ShaTwoOrRipemdSubSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/ShaTwoOrRipemdSubSection.java
@@ -63,7 +63,7 @@ public class ShaTwoOrRipemdSubSection extends PrecompileSubsection {
     super.resolveAtContextReEntry(hub, callFrame);
 
     // sanity check
-    checkArgument(callSuccess == oobCall.isHubSuccess());
+    checkArgument(callSuccess == oobCall.isHubSuccess(), "oob and hub disagree on precompile %s success", flag());
 
     if (!callSuccess) {
       return;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/ShaTwoOrRipemdSubSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/ShaTwoOrRipemdSubSection.java
@@ -63,7 +63,10 @@ public class ShaTwoOrRipemdSubSection extends PrecompileSubsection {
     super.resolveAtContextReEntry(hub, callFrame);
 
     // sanity check
-    checkArgument(callSuccess == oobCall.isHubSuccess(), "oob and hub disagree on precompile %s success", flag());
+    checkArgument(
+        callSuccess == oobCall.isHubSuccess(),
+        "oob and hub disagree on precompile %s success",
+        flag());
 
     if (!callSuccess) {
       return;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/CallDataCopySection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/CallDataCopySection.java
@@ -48,7 +48,8 @@ public class CallDataCopySection extends TraceSection {
     ////////////////////////////////////
 
     final short exceptions = hub.pch().exceptions();
-    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions));
+    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions),
+            "CALLDATACOPY: mxp and hub disagree on MXPX");
 
     // The MXPX case
     if (mxpCall.mxpx) {
@@ -57,7 +58,8 @@ public class CallDataCopySection extends TraceSection {
 
     // The OOGX case
     if (Exceptions.any(exceptions)) {
-      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION);
+      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION,
+              "CALLDATACOPY: unexpected exception");
       return;
     }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/CallDataCopySection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/CallDataCopySection.java
@@ -48,8 +48,9 @@ public class CallDataCopySection extends TraceSection {
     ////////////////////////////////////
 
     final short exceptions = hub.pch().exceptions();
-    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions),
-            "CALLDATACOPY: mxp and hub disagree on MXPX");
+    checkArgument(
+        mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions),
+        "CALLDATACOPY: mxp and hub disagree on MXPX");
 
     // The MXPX case
     if (mxpCall.mxpx) {
@@ -58,8 +59,7 @@ public class CallDataCopySection extends TraceSection {
 
     // The OOGX case
     if (Exceptions.any(exceptions)) {
-      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION,
-              "CALLDATACOPY: unexpected exception");
+      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION, "CALLDATACOPY: unexpected exception");
       return;
     }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/CodeCopySection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/CodeCopySection.java
@@ -48,7 +48,9 @@ public class CodeCopySection extends TraceSection {
     imcFragment.callMxp(mxpCall);
 
     final short exceptions = hub.pch().exceptions();
-    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions), "CODECOPY: mxp and hub disagree on MXPX");
+    checkArgument(
+        mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions),
+        "CODECOPY: mxp and hub disagree on MXPX");
 
     // The MXPX case
     if (mxpCall.mxpx) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/CodeCopySection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/CodeCopySection.java
@@ -48,7 +48,7 @@ public class CodeCopySection extends TraceSection {
     imcFragment.callMxp(mxpCall);
 
     final short exceptions = hub.pch().exceptions();
-    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions));
+    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions), "CODECOPY: mxp and hub disagree on MXPX");
 
     // The MXPX case
     if (mxpCall.mxpx) {
@@ -57,7 +57,7 @@ public class CodeCopySection extends TraceSection {
 
     // The OOGX case
     if (Exceptions.any(exceptions)) {
-      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION);
+      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION, "CODECOPY: unexpected exception %s");
       return;
     }
 
@@ -68,7 +68,7 @@ public class CodeCopySection extends TraceSection {
     // Account row
     final AccountSnapshot codeAccountSnapshot =
         AccountSnapshot.canonical(hub, hub.messageFrame().getContractAddress());
-    checkArgument(codeAccountSnapshot.isWarm());
+    checkArgument(codeAccountSnapshot.isWarm(), "CODECOPY: code account should be warm but isn't");
 
     final DomSubStampsSubFragment doingDomSubStamps =
         DomSubStampsSubFragment.standardDomSubStamps(this.hubStamp(), 0); // Specifics for CODECOPY

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/ExtCodeCopySection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/ExtCodeCopySection.java
@@ -70,7 +70,7 @@ public class ExtCodeCopySection extends TraceSection implements PostRollbackDefe
     imcFragment.callMxp(mxpCall);
 
     final short exceptions = hub.pch().exceptions();
-    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions));
+    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions), "EXTCODECOPY: mxp and hub disagree on MXPX");
 
     // The MXPX case
     if (mxpCall.mxpx) {
@@ -106,7 +106,7 @@ public class ExtCodeCopySection extends TraceSection implements PostRollbackDefe
     }
 
     // The unexceptional case
-    checkArgument(Exceptions.none(exceptions));
+    checkArgument(Exceptions.none(exceptions), "EXTCODECOPY: unexpected exception");
 
     final boolean triggerMmu = mxpCall.mayTriggerNontrivialMmuOperation;
     if (triggerMmu) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/ExtCodeCopySection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/ExtCodeCopySection.java
@@ -70,7 +70,9 @@ public class ExtCodeCopySection extends TraceSection implements PostRollbackDefe
     imcFragment.callMxp(mxpCall);
 
     final short exceptions = hub.pch().exceptions();
-    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions), "EXTCODECOPY: mxp and hub disagree on MXPX");
+    checkArgument(
+        mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions),
+        "EXTCODECOPY: mxp and hub disagree on MXPX");
 
     // The MXPX case
     if (mxpCall.mxpx) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/ReturnDataCopySection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/ReturnDataCopySection.java
@@ -45,7 +45,7 @@ public class ReturnDataCopySection extends TraceSection {
 
     final short exceptions = hub.pch().exceptions();
     final boolean returnDataCopyException = oobCall.isRdcx();
-    checkArgument(returnDataCopyException == Exceptions.returnDataCopyFault(exceptions));
+    checkArgument(returnDataCopyException == Exceptions.returnDataCopyFault(exceptions), "RETURN_DATA_COPY: oob and hub disagree on RDCX");
 
     // returnDataCopyException case
     if (returnDataCopyException) {
@@ -55,7 +55,8 @@ public class ReturnDataCopySection extends TraceSection {
     final MxpCall mxpCall = MxpCall.newMxpCall(hub);
     imcFragment.callMxp(mxpCall);
 
-    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions));
+    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions)
+    , "RETURN_DATA_COPY: mxp and hub disagree on MXPX");
 
     // memoryExpansionException case
     if (mxpCall.mxpx) {
@@ -64,7 +65,7 @@ public class ReturnDataCopySection extends TraceSection {
 
     // outOfGasException case
     if (Exceptions.any(exceptions)) {
-      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION);
+      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION, "RETURN_DATA_COPY: unexpected exception, %s does not match %s", exceptions, OUT_OF_GAS_EXCEPTION);
       return;
     }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/ReturnDataCopySection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/copy/ReturnDataCopySection.java
@@ -45,7 +45,9 @@ public class ReturnDataCopySection extends TraceSection {
 
     final short exceptions = hub.pch().exceptions();
     final boolean returnDataCopyException = oobCall.isRdcx();
-    checkArgument(returnDataCopyException == Exceptions.returnDataCopyFault(exceptions), "RETURN_DATA_COPY: oob and hub disagree on RDCX");
+    checkArgument(
+        returnDataCopyException == Exceptions.returnDataCopyFault(exceptions),
+        "RETURN_DATA_COPY: oob and hub disagree on RDCX");
 
     // returnDataCopyException case
     if (returnDataCopyException) {
@@ -55,8 +57,9 @@ public class ReturnDataCopySection extends TraceSection {
     final MxpCall mxpCall = MxpCall.newMxpCall(hub);
     imcFragment.callMxp(mxpCall);
 
-    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions)
-    , "RETURN_DATA_COPY: mxp and hub disagree on MXPX");
+    checkArgument(
+        mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions),
+        "RETURN_DATA_COPY: mxp and hub disagree on MXPX");
 
     // memoryExpansionException case
     if (mxpCall.mxpx) {
@@ -65,7 +68,11 @@ public class ReturnDataCopySection extends TraceSection {
 
     // outOfGasException case
     if (Exceptions.any(exceptions)) {
-      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION, "RETURN_DATA_COPY: unexpected exception, %s does not match %s", exceptions, OUT_OF_GAS_EXCEPTION);
+      checkArgument(
+          exceptions == OUT_OF_GAS_EXCEPTION,
+          "RETURN_DATA_COPY: unexpected exception, %s does not match %s",
+          exceptions,
+          OUT_OF_GAS_EXCEPTION);
       return;
     }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/create/CreateSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/create/CreateSection.java
@@ -138,7 +138,8 @@ public abstract class CreateSection extends TraceSection
     // MXPX case
     final MxpCall mxpCall = MxpCall.newMxpCall(hub);
     imcFragment.callMxp(mxpCall);
-    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions));
+    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions),
+            "CREATE(2): mxp and hub disagree on MXPX");
     if (mxpCall.mxpx) {
       return;
     }
@@ -146,13 +147,14 @@ public abstract class CreateSection extends TraceSection
     // OOGX case
     final StpCall stpCall = new StpCall(hub, frame, mxpCall.getGasMxp());
     imcFragment.callStp(stpCall);
-    checkArgument(stpCall.outOfGasException() == Exceptions.outOfGasException(exceptions));
+    checkArgument(stpCall.outOfGasException() == Exceptions.outOfGasException(exceptions),
+            "CREATE(2): stp and hub disagree on OOGX");
     if (Exceptions.outOfGasException(exceptions)) {
       return;
     }
 
     // The CREATE(2) is now unexceptional
-    checkArgument(Exceptions.none(exceptions));
+    checkArgument(Exceptions.none(exceptions), "CREATE(2): unexpectedly exceptional");
     hub.currentFrame().childSpanningSection(this);
 
     final CreateOobCall oobCall = (CreateOobCall) imcFragment.callOob(createOobCall());
@@ -165,7 +167,7 @@ public abstract class CreateSection extends TraceSection
     final boolean emptyInitCode =
         scenarioFragment.getScenario() == CREATE_EMPTY_INIT_CODE_WONT_REVERT;
 
-    checkArgument(oobCall.isAbortingCondition() == aborts);
+    checkArgument(oobCall.isAbortingCondition() == aborts, "CREATE(2): oob and hub disagree on ABORT");
     if (aborts) {
       this.traceAbort(hub);
       return;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/create/CreateSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/create/CreateSection.java
@@ -138,8 +138,9 @@ public abstract class CreateSection extends TraceSection
     // MXPX case
     final MxpCall mxpCall = MxpCall.newMxpCall(hub);
     imcFragment.callMxp(mxpCall);
-    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions),
-            "CREATE(2): mxp and hub disagree on MXPX");
+    checkArgument(
+        mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions),
+        "CREATE(2): mxp and hub disagree on MXPX");
     if (mxpCall.mxpx) {
       return;
     }
@@ -147,8 +148,9 @@ public abstract class CreateSection extends TraceSection
     // OOGX case
     final StpCall stpCall = new StpCall(hub, frame, mxpCall.getGasMxp());
     imcFragment.callStp(stpCall);
-    checkArgument(stpCall.outOfGasException() == Exceptions.outOfGasException(exceptions),
-            "CREATE(2): stp and hub disagree on OOGX");
+    checkArgument(
+        stpCall.outOfGasException() == Exceptions.outOfGasException(exceptions),
+        "CREATE(2): stp and hub disagree on OOGX");
     if (Exceptions.outOfGasException(exceptions)) {
       return;
     }
@@ -167,7 +169,8 @@ public abstract class CreateSection extends TraceSection
     final boolean emptyInitCode =
         scenarioFragment.getScenario() == CREATE_EMPTY_INIT_CODE_WONT_REVERT;
 
-    checkArgument(oobCall.isAbortingCondition() == aborts, "CREATE(2): oob and hub disagree on ABORT");
+    checkArgument(
+        oobCall.isAbortingCondition() == aborts, "CREATE(2): oob and hub disagree on ABORT");
     if (aborts) {
       this.traceAbort(hub);
       return;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/create/CreateSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/create/CreateSection.java
@@ -264,8 +264,18 @@ public abstract class CreateSection extends TraceSection
 
     switch (scenario) {
       case CREATE_FAILURE_CONDITION_WONT_REVERT, CREATE_EMPTY_INIT_CODE_WONT_REVERT -> {
-        if (scenario == CREATE_FAILURE_CONDITION_WONT_REVERT) checkState(!success);
-        if (scenario == CREATE_EMPTY_INIT_CODE_WONT_REVERT) checkState(success);
+        if (scenario == CREATE_FAILURE_CONDITION_WONT_REVERT)
+          checkState(
+              !success,
+              "%s scenario requires CREATE failure, yet success = %s",
+              CREATE_FAILURE_CONDITION_WONT_REVERT,
+              success);
+        if (scenario == CREATE_EMPTY_INIT_CODE_WONT_REVERT)
+          checkState(
+              success,
+              "%s scenario requires CREATE success, yet success = %s",
+              CREATE_EMPTY_INIT_CODE_WONT_REVERT,
+              success);
 
         firstCreatorNew =
             AccountSnapshot.canonical(hub, frame.frame().getWorldUpdater(), creatorAddress);
@@ -337,7 +347,9 @@ public abstract class CreateSection extends TraceSection
                 CREATE_FAILURE_CONDITION_WONT_REVERT,
                 CREATE_EMPTY_INIT_CODE_WONT_REVERT,
                 CREATE_NON_EMPTY_INIT_CODE_SUCCESS_WONT_REVERT,
-                CREATE_NON_EMPTY_INIT_CODE_FAILURE_WONT_REVERT));
+                CREATE_NON_EMPTY_INIT_CODE_FAILURE_WONT_REVERT),
+        "%s CREATE-scenario not allowed when resolving upon rollback",
+        scenarioFragment.getScenario());
 
     final int revertStamp = callFrame.revertStamp();
 
@@ -502,7 +514,10 @@ public abstract class CreateSection extends TraceSection
   @Override
   public void resolvePostExecution(
       Hub hub, MessageFrame frame, Operation.OperationResult operationResult) {
-    checkState(scenarioFragment.isAbortedCreate());
+    checkState(
+        scenarioFragment.isAbortedCreate(),
+        "We resolve a CREATE(2) post execution only if it's an aborted CREATE(2), yet scenario = %s",
+        scenarioFragment.getScenario());
     hub.unlatchStack(frame, this);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/create/CreateSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/create/CreateSection.java
@@ -272,13 +272,13 @@ public abstract class CreateSection extends TraceSection
         if (scenario == CREATE_FAILURE_CONDITION_WONT_REVERT)
           checkState(
               !success,
-              "%s scenario requires CREATE failure, yet success = %s",
+              "CreateSection: %s scenario requires CREATE failure, yet success = %s",
               CREATE_FAILURE_CONDITION_WONT_REVERT,
               success);
         if (scenario == CREATE_EMPTY_INIT_CODE_WONT_REVERT)
           checkState(
               success,
-              "%s scenario requires CREATE success, yet success = %s",
+              "CreateSection: %s scenario requires CREATE success, yet success = %s",
               CREATE_EMPTY_INIT_CODE_WONT_REVERT,
               success);
 
@@ -353,7 +353,7 @@ public abstract class CreateSection extends TraceSection
                 CREATE_EMPTY_INIT_CODE_WONT_REVERT,
                 CREATE_NON_EMPTY_INIT_CODE_SUCCESS_WONT_REVERT,
                 CREATE_NON_EMPTY_INIT_CODE_FAILURE_WONT_REVERT),
-        "%s CREATE-scenario not allowed when resolving upon rollback",
+        "CreateSection: %s CREATE-scenario not allowed when resolving upon rollback",
         scenarioFragment.getScenario());
 
     final int revertStamp = callFrame.revertStamp();
@@ -521,7 +521,7 @@ public abstract class CreateSection extends TraceSection
       Hub hub, MessageFrame frame, Operation.OperationResult operationResult) {
     checkState(
         scenarioFragment.isAbortedCreate(),
-        "We resolve a CREATE(2) post execution only if it's an aborted CREATE(2), yet scenario = %s",
+        "CreateSection: we resolve a CREATE(2) post execution only if it's an aborted CREATE(2), yet scenario = %s",
         scenarioFragment.getScenario());
     hub.unlatchStack(frame, this);
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/create/LondonCreateSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/create/LondonCreateSection.java
@@ -30,8 +30,9 @@ public class LondonCreateSection extends CreateSection {
 
   protected boolean maxCodeSizeExceptionalCreate(final short exceptions) {
     // Max Code Size exception appears in EIP-3860, in Shanghai
-    checkArgument(!Exceptions.maxCodeSizeException(exceptions),
-            "LONDON CREATE: max code size exception should not happen in London");
+    checkArgument(
+        !Exceptions.maxCodeSizeException(exceptions),
+        "LONDON CREATE: max code size exception should not happen in London");
     return false;
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/create/LondonCreateSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/create/LondonCreateSection.java
@@ -30,7 +30,8 @@ public class LondonCreateSection extends CreateSection {
 
   protected boolean maxCodeSizeExceptionalCreate(final short exceptions) {
     // Max Code Size exception appears in EIP-3860, in Shanghai
-    checkArgument(!Exceptions.maxCodeSizeException(exceptions));
+    checkArgument(!Exceptions.maxCodeSizeException(exceptions),
+            "LONDON CREATE: max code size exception should not happen in London");
     return false;
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/finalization/TxFinalizationSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/finalization/TxFinalizationSection.java
@@ -57,8 +57,9 @@ public abstract class TxFinalizationSection extends TraceSection implements EndT
   public void resolveAtEndTransaction(
       Hub hub, WorldView world, Transaction tx, boolean isSuccessful) {
 
-    checkArgument(isSuccessful == txMetadata.statusCode(),
-            "Transaction status code does not match with eponymous metadata field");
+    checkArgument(
+        isSuccessful == txMetadata.statusCode(),
+        "Transaction status code does not match with eponymous metadata field");
 
     final DeploymentInfo deploymentInfo = hub.transients().conflation().deploymentInfo();
     checkArgument(

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/finalization/TxFinalizationSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/finalization/TxFinalizationSection.java
@@ -57,7 +57,8 @@ public abstract class TxFinalizationSection extends TraceSection implements EndT
   public void resolveAtEndTransaction(
       Hub hub, WorldView world, Transaction tx, boolean isSuccessful) {
 
-    checkArgument(isSuccessful == txMetadata.statusCode());
+    checkArgument(isSuccessful == txMetadata.statusCode(),
+            "Transaction status code does not match with eponymous metadata field");
 
     final DeploymentInfo deploymentInfo = hub.transients().conflation().deploymentInfo();
     checkArgument(

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/ReturnSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/ReturnSection.java
@@ -82,8 +82,9 @@ public class ReturnSection extends TraceSection
     returnFromMessageCall = frame.getType().equals(MESSAGE_CALL);
     returnFromDeployment = frame.getType().equals(CONTRACT_CREATION);
 
-    checkArgument(callFrame.isDeployment() == (frame.getType().equals(CONTRACT_CREATION)),
-            "ReturnSection: CallFrame and MessageFrame inconsistent on whether frame is deployment or not");
+    checkArgument(
+        callFrame.isDeployment() == (frame.getType().equals(CONTRACT_CREATION)),
+        "ReturnSection: CallFrame and MessageFrame inconsistent on whether frame is deployment or not");
 
     checkArgument(
         returnFromDeployment
@@ -91,7 +92,7 @@ public class ReturnSection extends TraceSection
                 .conflation()
                 .deploymentInfo()
                 .getDeploymentStatus(frame.getContractAddress()),
-            "ReturnSection: Frame and RomLex disagree whether frame is deployment or not, for RomLex that's via the deployment status of the contract address");
+        "ReturnSection: Frame and RomLex disagree whether frame is deployment or not, for RomLex that's via the deployment status of the contract address");
 
     returnScenarioFragment = new ReturnScenarioFragment();
     final ContextFragment currentContextFragment = ContextFragment.readCurrentContextData(hub);
@@ -108,8 +109,9 @@ public class ReturnSection extends TraceSection
       returnScenarioFragment.setScenario(RETURN_EXCEPTION);
     }
 
-    checkArgument(mxpCall.mxpx == memoryExpansionException(exceptions),
-            "RETURN: mxp and hub disagree on MXPX");
+    checkArgument(
+        mxpCall.mxpx == memoryExpansionException(exceptions),
+        "RETURN: mxp and hub disagree on MXPX");
 
     if (mxpCall.mxpx) {
       commonValues.setTracedException(TracedException.MEMORY_EXPANSION_EXCEPTION);
@@ -120,13 +122,17 @@ public class ReturnSection extends TraceSection
     // In case of returnFromDeployment, we check for maxCodeSize & invalidCodePrefixException before
     // OOGX.
     if (Exceptions.outOfGasException(exceptions) && returnFromMessageCall) {
-      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION, "RETURN from message call: last exception should be OOGX");
+      checkArgument(
+          exceptions == OUT_OF_GAS_EXCEPTION,
+          "RETURN from message call: last exception should be OOGX");
       commonValues.setTracedException(TracedException.OUT_OF_GAS_EXCEPTION);
       return;
     }
 
     if (Exceptions.any(exceptions)) {
-      checkArgument(returnFromDeployment, "RETURN from message call: exceptions should have already been handled");
+      checkArgument(
+          returnFromDeployment,
+          "RETURN from message call: exceptions should have already been handled");
     }
 
     // maxCodeSizeException case
@@ -141,22 +147,27 @@ public class ReturnSection extends TraceSection
     final boolean nontrivialMmuOperation = mxpCall.mayTriggerNontrivialMmuOperation;
     final boolean triggerMmuForInvalidCodePrefix = Exceptions.invalidCodePrefix(exceptions);
     if (triggerMmuForInvalidCodePrefix) {
-      checkArgument(returnFromDeployment && nontrivialMmuOperation,
-              "invalidCodePrefixException triggered yet returnFromDeployment = %s and nontrivialMmuOperation = %s", returnFromDeployment, nontrivialMmuOperation);
+      checkArgument(
+          returnFromDeployment && nontrivialMmuOperation,
+          "invalidCodePrefixException triggered yet returnFromDeployment = %s and nontrivialMmuOperation = %s",
+          returnFromDeployment,
+          nontrivialMmuOperation);
 
       final MmuCall actuallyInvalidCodePrefixMmuCall = MmuCall.invalidCodePrefix(hub);
       firstImcFragment.callMmu(actuallyInvalidCodePrefixMmuCall);
 
-      checkArgument(actuallyInvalidCodePrefixMmuCall.successBit(),
-              "RETURN from deployment: invalidCodePrefixException incorrectly picked up by MMU");
+      checkArgument(
+          actuallyInvalidCodePrefixMmuCall.successBit(),
+          "RETURN from deployment: invalidCodePrefixException incorrectly picked up by MMU");
       commonValues.setTracedException(TracedException.INVALID_CODE_PREFIX);
       return;
     }
 
     // OOGX case
     if (Exceptions.outOfGasException(exceptions) && returnFromDeployment) {
-      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION,
-              "RETURN from deployment: last exception should be OOGX");
+      checkArgument(
+          exceptions == OUT_OF_GAS_EXCEPTION,
+          "RETURN from deployment: last exception should be OOGX");
       commonValues.setTracedException(TracedException.OUT_OF_GAS_EXCEPTION);
       return;
     }
@@ -220,8 +231,11 @@ public class ReturnSection extends TraceSection
               : RETURN_FROM_DEPLOYMENT_EMPTY_CODE_WONT_REVERT);
 
       final Bytes byteCodeSize = frame.getStackItem(1);
-      checkArgument(nonemptyByteCode == (!byteCodeSize.isZero()),
-              "RETURN from deployment: mxp nonemptyByteCode = %s disagrees with byteCoedeSize = %s", nonemptyByteCode, byteCodeSize);
+      checkArgument(
+          nonemptyByteCode == (!byteCodeSize.isZero()),
+          "RETURN from deployment: mxp nonemptyByteCode = %s disagrees with byteCoedeSize = %s",
+          nonemptyByteCode,
+          byteCodeSize);
 
       // Empty deployments
       if (!nonemptyByteCode) {
@@ -240,8 +254,12 @@ public class ReturnSection extends TraceSection
           (DeploymentOobCall) firstImcFragment.callOob(new DeploymentOobCall());
 
       // sanity checks
-      checkArgument(!invalidCodePrefixCheckMmuCall.successBit(), "RETURN shouldn't throw invalidCodePrefixException at this stage, but does");
-      checkArgument(!maxCodeSizeOobCall.isMaxCodeSizeException(), "RETURN shouldn't throw maxCodeSizeException at this stage, but does");
+      checkArgument(
+          !invalidCodePrefixCheckMmuCall.successBit(),
+          "RETURN shouldn't throw invalidCodePrefixException at this stage, but does");
+      checkArgument(
+          !maxCodeSizeOobCall.isMaxCodeSizeException(),
+          "RETURN shouldn't throw maxCodeSizeException at this stage, but does");
 
       final ImcFragment secondImcFragment = ImcFragment.empty(hub);
       this.addFragment(secondImcFragment);
@@ -285,8 +303,7 @@ public class ReturnSection extends TraceSection
   @Override
   public void resolveUponRollback(Hub hub, MessageFrame messageFrame, CallFrame callFrame) {
 
-    checkArgument(returnFromDeployment,
-            "rollback sensitive RETURNs should stem from deployments");
+    checkArgument(returnFromDeployment, "rollback sensitive RETURNs should stem from deployments");
     returnScenarioFragment.setScenario(
         nonemptyByteCode
             ? RETURN_FROM_DEPLOYMENT_NONEMPTY_CODE_WILL_REVERT
@@ -312,8 +329,9 @@ public class ReturnSection extends TraceSection
   public void resolveAtEndTransaction(
       Hub hub, WorldView state, Transaction tx, boolean isSuccessful) {
 
-    checkArgument(returnFromDeployment,
-            "RETURNs which trigger resolveAtEndTransaction should stem from deployments");
+    checkArgument(
+        returnFromDeployment,
+        "RETURNs which trigger resolveAtEndTransaction should stem from deployments");
     this.addFragment(squashParentContextReturnData);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/ReturnSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/ReturnSection.java
@@ -281,7 +281,7 @@ public class ReturnSection extends TraceSection
 
     checkState(
         returnFromDeployment,
-        "RETURN requires resolution at context re-entry only for deployments");
+        "ReturnSection: a RETURN requires resolution at context re-entry only for deployments");
 
     firstCreateeNew = AccountSnapshot.canonical(hub, deploymentAddress);
     final AccountFragment deploymentAccountFragment =

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/ReturnSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/ReturnSection.java
@@ -82,14 +82,16 @@ public class ReturnSection extends TraceSection
     returnFromMessageCall = frame.getType().equals(MESSAGE_CALL);
     returnFromDeployment = frame.getType().equals(CONTRACT_CREATION);
 
-    checkArgument(callFrame.isDeployment() == (frame.getType().equals(CONTRACT_CREATION)));
+    checkArgument(callFrame.isDeployment() == (frame.getType().equals(CONTRACT_CREATION)),
+            "ReturnSection: CallFrame and MessageFrame inconsistent on whether frame is deployment or not");
 
     checkArgument(
         returnFromDeployment
             == hub.transients()
                 .conflation()
                 .deploymentInfo()
-                .getDeploymentStatus(frame.getContractAddress()));
+                .getDeploymentStatus(frame.getContractAddress()),
+            "ReturnSection: Frame and RomLex disagree whether frame is deployment or not, for RomLex that's via the deployment status of the contract address");
 
     returnScenarioFragment = new ReturnScenarioFragment();
     final ContextFragment currentContextFragment = ContextFragment.readCurrentContextData(hub);
@@ -106,7 +108,8 @@ public class ReturnSection extends TraceSection
       returnScenarioFragment.setScenario(RETURN_EXCEPTION);
     }
 
-    checkArgument(mxpCall.mxpx == memoryExpansionException(exceptions));
+    checkArgument(mxpCall.mxpx == memoryExpansionException(exceptions),
+            "RETURN: mxp and hub disagree on MXPX");
 
     if (mxpCall.mxpx) {
       commonValues.setTracedException(TracedException.MEMORY_EXPANSION_EXCEPTION);
@@ -117,13 +120,13 @@ public class ReturnSection extends TraceSection
     // In case of returnFromDeployment, we check for maxCodeSize & invalidCodePrefixException before
     // OOGX.
     if (Exceptions.outOfGasException(exceptions) && returnFromMessageCall) {
-      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION);
+      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION, "RETURN from message call: last exception should be OOGX");
       commonValues.setTracedException(TracedException.OUT_OF_GAS_EXCEPTION);
       return;
     }
 
     if (Exceptions.any(exceptions)) {
-      checkArgument(returnFromDeployment);
+      checkArgument(returnFromDeployment, "RETURN from message call: exceptions should have already been handled");
     }
 
     // maxCodeSizeException case
@@ -138,19 +141,22 @@ public class ReturnSection extends TraceSection
     final boolean nontrivialMmuOperation = mxpCall.mayTriggerNontrivialMmuOperation;
     final boolean triggerMmuForInvalidCodePrefix = Exceptions.invalidCodePrefix(exceptions);
     if (triggerMmuForInvalidCodePrefix) {
-      checkArgument(returnFromDeployment && nontrivialMmuOperation);
+      checkArgument(returnFromDeployment && nontrivialMmuOperation,
+              "invalidCodePrefixException triggered yet returnFromDeployment = %s and nontrivialMmuOperation = %s", returnFromDeployment, nontrivialMmuOperation);
 
       final MmuCall actuallyInvalidCodePrefixMmuCall = MmuCall.invalidCodePrefix(hub);
       firstImcFragment.callMmu(actuallyInvalidCodePrefixMmuCall);
 
-      checkArgument(actuallyInvalidCodePrefixMmuCall.successBit());
+      checkArgument(actuallyInvalidCodePrefixMmuCall.successBit(),
+              "RETURN from deployment: invalidCodePrefixException incorrectly picked up by MMU");
       commonValues.setTracedException(TracedException.INVALID_CODE_PREFIX);
       return;
     }
 
     // OOGX case
     if (Exceptions.outOfGasException(exceptions) && returnFromDeployment) {
-      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION);
+      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION,
+              "RETURN from deployment: last exception should be OOGX");
       commonValues.setTracedException(TracedException.OUT_OF_GAS_EXCEPTION);
       return;
     }
@@ -158,7 +164,7 @@ public class ReturnSection extends TraceSection
     // Unexceptional RETURN's
     // (we have exceptions ≡ ∅ by the checkArgument below)
     //////////////////////////////////////////////////////
-    checkArgument(Exceptions.none(exceptions));
+    checkArgument(Exceptions.none(exceptions), "RETURN: unexpected exception");
 
     // RETURN_FROM_MESSAGE_CALL cases
     if (returnFromMessageCall) {
@@ -214,7 +220,8 @@ public class ReturnSection extends TraceSection
               : RETURN_FROM_DEPLOYMENT_EMPTY_CODE_WONT_REVERT);
 
       final Bytes byteCodeSize = frame.getStackItem(1);
-      checkArgument(nonemptyByteCode == (!byteCodeSize.isZero()));
+      checkArgument(nonemptyByteCode == (!byteCodeSize.isZero()),
+              "RETURN from deployment: mxp nonemptyByteCode = %s disagrees with byteCoedeSize = %s", nonemptyByteCode, byteCodeSize);
 
       // Empty deployments
       if (!nonemptyByteCode) {
@@ -233,8 +240,8 @@ public class ReturnSection extends TraceSection
           (DeploymentOobCall) firstImcFragment.callOob(new DeploymentOobCall());
 
       // sanity checks
-      checkArgument(!invalidCodePrefixCheckMmuCall.successBit());
-      checkArgument(!maxCodeSizeOobCall.isMaxCodeSizeException());
+      checkArgument(!invalidCodePrefixCheckMmuCall.successBit(), "RETURN shouldn't throw invalidCodePrefixException at this stage, but does");
+      checkArgument(!maxCodeSizeOobCall.isMaxCodeSizeException(), "RETURN shouldn't throw maxCodeSizeException at this stage, but does");
 
       final ImcFragment secondImcFragment = ImcFragment.empty(hub);
       this.addFragment(secondImcFragment);
@@ -278,7 +285,8 @@ public class ReturnSection extends TraceSection
   @Override
   public void resolveUponRollback(Hub hub, MessageFrame messageFrame, CallFrame callFrame) {
 
-    checkArgument(returnFromDeployment);
+    checkArgument(returnFromDeployment,
+            "rollback sensitive RETURNs should stem from deployments");
     returnScenarioFragment.setScenario(
         nonemptyByteCode
             ? RETURN_FROM_DEPLOYMENT_NONEMPTY_CODE_WILL_REVERT
@@ -304,7 +312,8 @@ public class ReturnSection extends TraceSection
   public void resolveAtEndTransaction(
       Hub hub, WorldView state, Transaction tx, boolean isSuccessful) {
 
-    checkArgument(returnFromDeployment);
+    checkArgument(returnFromDeployment,
+            "RETURNs which trigger resolveAtEndTransaction should stem from deployments");
     this.addFragment(squashParentContextReturnData);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/ReturnSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/ReturnSection.java
@@ -254,7 +254,9 @@ public class ReturnSection extends TraceSection
   @Override
   public void resolveAtContextReEntry(Hub hub, CallFrame frame) {
 
-    checkState(returnFromDeployment);
+    checkState(
+        returnFromDeployment,
+        "RETURN requires resolution at context re-entry only for deployments");
 
     firstCreateeNew = AccountSnapshot.canonical(hub, deploymentAddress);
     final AccountFragment deploymentAccountFragment =
@@ -308,7 +310,9 @@ public class ReturnSection extends TraceSection
 
   private void addDeploymentAccountFragmentIfRoot(Hub hub, MxpCall mxpCall) {
 
-    checkState(returnFromDeployment);
+    checkState(
+        returnFromDeployment,
+        "RETURN associated addDeploymentAccountFragmentIfRoot should be called only for deployments");
 
     firstCreateeNew = AccountSnapshot.canonical(hub, deploymentAddress);
     firstCreateeNew.code(

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/RevertSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/RevertSection.java
@@ -50,7 +50,7 @@ public class RevertSection extends TraceSection {
     // triggerMxp = true
     final MxpCall mxpCall = MxpCall.newMxpCall(hub);
     imcFragment.callMxp(mxpCall);
-    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions));
+    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions), "REVERT: mxp and hub disagree on MXPX");
 
     if (Exceptions.memoryExpansionException(exceptions)) {
       return;
@@ -61,7 +61,7 @@ public class RevertSection extends TraceSection {
     }
 
     // The XAHOY = 0 case
-    checkArgument(Exceptions.none(exceptions));
+    checkArgument(Exceptions.none(exceptions), "REVERT: unexpected exception %s", exceptions);
 
     final CallFrame callFrame = hub.currentFrame();
     final Bytes offset = frame.getStackItem(0);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/RevertSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/RevertSection.java
@@ -50,7 +50,9 @@ public class RevertSection extends TraceSection {
     // triggerMxp = true
     final MxpCall mxpCall = MxpCall.newMxpCall(hub);
     imcFragment.callMxp(mxpCall);
-    checkArgument(mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions), "REVERT: mxp and hub disagree on MXPX");
+    checkArgument(
+        mxpCall.mxpx == Exceptions.memoryExpansionException(exceptions),
+        "REVERT: mxp and hub disagree on MXPX");
 
     if (Exceptions.memoryExpansionException(exceptions)) {
       return;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/StopSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/StopSection.java
@@ -73,7 +73,9 @@ public class StopSection extends TraceSection implements PostRollbackDefer, EndT
     deploymentStatus = deploymentInfo.getDeploymentStatus(address);
     parentContextReturnDataReset = executionProvidesEmptyReturnData(hub);
 
-    checkArgument(hub.currentFrame().isDeployment() == deploymentStatus, "CallFrame and code running in frame disagree on deployment / deployment status of byte code"); // sanity check
+    checkArgument(
+        hub.currentFrame().isDeployment() == deploymentStatus,
+        "CallFrame and code running in frame disagree on deployment / deployment status of byte code"); // sanity check
 
     // Message call case
     if (!deploymentStatus) {
@@ -121,7 +123,9 @@ public class StopSection extends TraceSection implements PostRollbackDefer, EndT
       return;
     }
 
-    checkArgument(this.fragments().getLast() instanceof AccountFragment, "STOP's which trigger a rollback (in deployment context) should terminate on an fragment as last fragment before rollback");
+    checkArgument(
+        this.fragments().getLast() instanceof AccountFragment,
+        "STOP's which trigger a rollback (in deployment context) should terminate on an fragment as last fragment before rollback");
 
     final AccountFragment lastAccountFragment = (AccountFragment) this.fragments().getLast();
     final DomSubStampsSubFragment undoingDomSubStamps =

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/StopSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/StopSection.java
@@ -73,7 +73,7 @@ public class StopSection extends TraceSection implements PostRollbackDefer, EndT
     deploymentStatus = deploymentInfo.getDeploymentStatus(address);
     parentContextReturnDataReset = executionProvidesEmptyReturnData(hub);
 
-    checkArgument(hub.currentFrame().isDeployment() == deploymentStatus); // sanity check
+    checkArgument(hub.currentFrame().isDeployment() == deploymentStatus, "CallFrame and code running in frame disagree on deployment / deployment status of byte code"); // sanity check
 
     // Message call case
     if (!deploymentStatus) {
@@ -121,7 +121,7 @@ public class StopSection extends TraceSection implements PostRollbackDefer, EndT
       return;
     }
 
-    checkArgument(this.fragments().getLast() instanceof AccountFragment);
+    checkArgument(this.fragments().getLast() instanceof AccountFragment, "STOP's which trigger a rollback (in deployment context) should terminate on an fragment as last fragment before rollback");
 
     final AccountFragment lastAccountFragment = (AccountFragment) this.fragments().getLast();
     final DomSubStampsSubFragment undoingDomSubStamps =

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/selfdestruct/SelfdestructSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/selfdestruct/SelfdestructSection.java
@@ -114,7 +114,10 @@ public abstract class SelfdestructSection extends TraceSection
 
     // OOGX case
     if (Exceptions.any(exceptions)) {
-      checkArgument(exceptions == OUT_OF_GAS_EXCEPTION);
+      checkArgument(
+          exceptions == OUT_OF_GAS_EXCEPTION,
+          "SELFDESTRUCT: lowest priority exception should be %s",
+          OUT_OF_GAS_EXCEPTION);
 
       recipient =
           selfdestructTargetsItself()
@@ -287,7 +290,9 @@ public abstract class SelfdestructSection extends TraceSection
     final EphemeralAccount ephemeralAccount =
         new EphemeralAccount(selfdestructor.address(), selfdestructorNew.deploymentNumber());
 
-    checkArgument(effectiveSelfDestructMap.containsKey(ephemeralAccount));
+    checkArgument(
+        effectiveSelfDestructMap.containsKey(ephemeralAccount),
+        "If SELFDESTRUCT was not reverted, the effectiveSelfDestructMap should contain the selfdestructor");
 
     if (accountFragmentWiping()) {
       // This grabs the accounts right after the coinbase and sender got their gas money back
@@ -301,7 +306,9 @@ public abstract class SelfdestructSection extends TraceSection
       // We modify the account fragment to reflect the self-destruct time
       final int hubStampOfTheActionableSelfDestruct =
           effectiveSelfDestructMap.get(ephemeralAccount);
-      checkArgument(hubStamp >= hubStampOfTheActionableSelfDestruct);
+      checkArgument(
+          hubStamp >= hubStampOfTheActionableSelfDestruct,
+          "The hub stamp of any SELFDESTRUCT in need of resolving at transaction end should be >= the stamp of the actionable SELFDESTRUCT");
 
       if (hubStamp == hubStampOfTheActionableSelfDestruct) {
         selfdestructScenarioFragment.setScenario(SELFDESTRUCT_WONT_REVERT_NOT_YET_MARKED);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/selfdestruct/SelfdestructSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/selfdestruct/SelfdestructSection.java
@@ -197,9 +197,15 @@ public abstract class SelfdestructSection extends TraceSection
     if (!selfdestructorNew.balance().isZero()) {
 
       // sanity checks
-      checkState(selfdestructTargetsItself(), "If post SELFDESTRUCT the seldestructor's balance is nonzero then SELFDESTRUCT targets self");
-      checkState(softAccountWiping(), "If post SELFDESTRUCT the seldestructor's balance is nonzero then it is a soft account wipe");
-      checkState(selfdestructorNew.balance().equals(selfdestructor.balance()), "If post SELFDESTRUCT the seldestructor's balance is nonzero then the balance should not have changed");
+      checkState(
+          selfdestructTargetsItself(),
+          "If post SELFDESTRUCT the seldestructor's balance is nonzero then SELFDESTRUCT targets self");
+      checkState(
+          softAccountWiping(),
+          "If post SELFDESTRUCT the seldestructor's balance is nonzero then it is a soft account wipe");
+      checkState(
+          selfdestructorNew.balance().equals(selfdestructor.balance()),
+          "If post SELFDESTRUCT the seldestructor's balance is nonzero then the balance should not have changed");
 
       selfdestructorNew.setBalanceToZero();
     }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/selfdestruct/SelfdestructSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/halt/selfdestruct/SelfdestructSection.java
@@ -182,7 +182,11 @@ public abstract class SelfdestructSection extends TraceSection
       Hub hub, MessageFrame frame, Operation.OperationResult operationResult) {
 
     final boolean isDeployment = frame.getType() == MessageFrame.Type.CONTRACT_CREATION;
-    checkState(isDeployment == selfdestructor.deploymentStatus());
+    checkState(
+        isDeployment == selfdestructor.deploymentStatus(),
+        "SELFDESTRUCT inconsistency: frame deployment = %s but selfdestructor's deployment status = %s",
+        isDeployment,
+        selfdestructor.deploymentStatus());
 
     selfdestructorNew = AccountSnapshot.canonical(hub, selfdestructor.address());
     if (isDeployment) {
@@ -193,9 +197,9 @@ public abstract class SelfdestructSection extends TraceSection
     if (!selfdestructorNew.balance().isZero()) {
 
       // sanity checks
-      checkState(selfdestructTargetsItself());
-      checkState(softAccountWiping());
-      checkState(selfdestructorNew.balance().equals(selfdestructor.balance()));
+      checkState(selfdestructTargetsItself(), "If post SELFDESTRUCT the seldestructor's balance is nonzero then SELFDESTRUCT targets self");
+      checkState(softAccountWiping(), "If post SELFDESTRUCT the seldestructor's balance is nonzero then it is a soft account wipe");
+      checkState(selfdestructorNew.balance().equals(selfdestructor.balance()), "If post SELFDESTRUCT the seldestructor's balance is nonzero then the balance should not have changed");
 
       selfdestructorNew.setBalanceToZero();
     }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/skip/TxSkipSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/skip/TxSkipSection.java
@@ -85,8 +85,10 @@ public abstract class TxSkipSection extends TraceSection implements EndTransacti
 
     // deployments are local to a transaction, every address should have deploymentStatus == false
     // at the start of every transaction
-    checkArgument(!hub.deploymentStatusOf(senderAddress));
-    checkArgument(!hub.deploymentStatusOf(recipientAddress));
+    checkArgument(
+        !hub.deploymentStatusOf(senderAddress), "TX_SKIP: Sender address under deployment");
+    checkArgument(
+        !hub.deploymentStatusOf(recipientAddress), "TX_SKIP: Recipient address under deployment");
 
     // the updated deployment info appears in the "updated" account fragment
     if (txMetadata.isDeployment()) {
@@ -103,7 +105,8 @@ public abstract class TxSkipSection extends TraceSection implements EndTransacti
     coinbase =
         canonical(
             hub, frame.getWorldUpdater(), coinbaseAddress, isPrecompile(hub.fork, coinbaseAddress));
-    checkArgument(!hub.deploymentStatusOf(coinbaseAddress));
+    checkArgument(
+        !hub.deploymentStatusOf(coinbaseAddress), "TX_SKIP: Coinbase address under deployment");
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/transients/TLoadSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/transients/TLoadSection.java
@@ -43,7 +43,8 @@ public class TLoadSection extends TraceSection implements PostOpcodeDefer {
 
     if (Exceptions.any(exceptions)) {
       checkArgument(
-          Exceptions.outOfGasException(exceptions), "The only possible exception is OOGX");
+          Exceptions.outOfGasException(exceptions),
+          "TLOAD: The only possible (non stack) exception is OOGX");
       storageKey = Bytes32.ZERO; // OOGX, no transient row
       return;
     }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/transients/TStoreSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/transients/TStoreSection.java
@@ -47,7 +47,7 @@ public class TStoreSection extends TraceSection implements PostRollbackDefer {
     if (Exceptions.any(exceptions)) {
       checkArgument(
           Exceptions.staticFault(exceptions) || Exceptions.outOfGasException(exceptions),
-          "The only possible exceptions are STATICX or OOGX");
+          "TSTORE: may only throw STATICX and OOGX exceptions");
       return;
     }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/txInitializationSection/TxInitializationSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/txInitializationSection/TxInitializationSection.java
@@ -123,7 +123,7 @@ public abstract class TxInitializationSection extends TraceSection implements En
 
     checkState(
         !recipientValueReception.deploymentStatus(),
-        "recipient should not have been undergoing deployment before transaction start");
+        "TxInitializationSection: recipient should not have been undergoing deployment before transaction start");
 
     recipientValueReceptionNew = recipientValueReception.deepCopy();
 
@@ -131,10 +131,10 @@ public abstract class TxInitializationSection extends TraceSection implements En
       if (recipientAccount != null) {
         checkState(
             recipientAccount.getCode().equals(Bytes.EMPTY),
-            "the recipient of a deployment transaction must have empty code");
+            "TxInitializationSection: the recipient of a deployment transaction must have empty code");
         checkState(
             recipientAccount.getNonce() == 0,
-            "the recipient of a deployment transaction must have zero nonce");
+            "TxInitializationSection: the recipient of a deployment transaction must have zero nonce");
       }
 
       deploymentInfo.newDeploymentWithExecutionAt(

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/state/Block.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/state/Block.java
@@ -44,7 +44,7 @@ public class Block {
   public void addStorageSeenByHub(final Address address, final Bytes32 storage) {
     checkState(
         addressesSeenByHub.contains(address),
-        "attempt to access storage slot of account not yet touched by the HUB");
+        "Block: attempt to access storage slot of account not yet touched by the HUB");
     final Set<Bytes32> storageSet =
         storagesSeenByHub.computeIfAbsent(address, k -> new HashSet<>());
     storageSet.add(storage);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/state/TraceSections.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/state/TraceSections.java
@@ -48,17 +48,6 @@ public class TraceSections {
   }
 
   /**
-   * Returns the previous trace section, i.e., the one before the most recent.
-   *
-   * @return the previous trace section
-   * @throws IllegalArgumentException if there are fewer than two sections in the trace
-   */
-  public TraceSection previousSection() {
-    Preconditions.checkArgument(trace.size() > 1);
-    return trace.get(size() - 2);
-  }
-
-  /**
    * Returns the trace section that is `n` positions before the most recent one.
    *
    * @param n the number of positions before the most recent trace section
@@ -66,7 +55,11 @@ public class TraceSections {
    * @throws IllegalArgumentException if there are fewer than `n + 1` sections in the trace
    */
   public TraceSection previousSection(int n) {
-    Preconditions.checkArgument(trace.size() > n);
+    Preconditions.checkArgument(
+        trace.size() > n,
+        "Trace has only %s sections, cannot access %s sections back",
+        trace.size(),
+        n);
     return trace.get(size() - 1 - n);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/state/TransactionStack.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/state/TransactionStack.java
@@ -64,7 +64,7 @@ public class TransactionStack {
     relativeTransactionNumber -= numberOfTransactionToPop;
     checkState(
         relativeTransactionNumber >= 0,
-        "relativeTransactionNumber = %s < 0",
+        "TransactionStack: relativeTransactionNumber = %s < 0",
         relativeTransactionNumber);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/state/TransactionStack.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/state/TransactionStack.java
@@ -62,7 +62,7 @@ public class TransactionStack {
     transactions.popTransactionBundle();
     currentAbsNumber -= numberOfTransactionToPop;
     relativeTransactionNumber -= numberOfTransactionToPop;
-    checkState(relativeTransactionNumber >= 0);
+    checkState(relativeTransactionNumber >= 0, "relativeTransactionNumber = %s < 0", relativeTransactionNumber);
   }
 
   public void resetBlock() {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/state/TransactionStack.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/state/TransactionStack.java
@@ -62,7 +62,10 @@ public class TransactionStack {
     transactions.popTransactionBundle();
     currentAbsNumber -= numberOfTransactionToPop;
     relativeTransactionNumber -= numberOfTransactionToPop;
-    checkState(relativeTransactionNumber >= 0, "relativeTransactionNumber = %s < 0", relativeTransactionNumber);
+    checkState(
+        relativeTransactionNumber >= 0,
+        "relativeTransactionNumber = %s < 0",
+        relativeTransactionNumber);
   }
 
   public void resetBlock() {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/transients/StackHeightCheck.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/transients/StackHeightCheck.java
@@ -33,7 +33,11 @@ public class StackHeightCheck {
    * @param delta greatest depth at which touched stack items
    */
   public StackHeightCheck(int height, int delta) {
-    checkArgument(0 <= height && height <= MAX_STACK_SIZE && 0 <= delta && delta <= 17);
+    checkArgument(
+        0 <= height && height <= MAX_STACK_SIZE && 0 <= delta && delta <= 17,
+        "StackHeightCheck constructor provided with Invalid height %s or delta %s",
+        height,
+        delta);
     comparison = height << SHIFT_FACTOR | delta;
   }
 
@@ -43,7 +47,10 @@ public class StackHeightCheck {
    * @param heightNew stack height post opcode execution
    */
   public StackHeightCheck(int heightNew) {
-    checkArgument(0 <= heightNew && heightNew <= MAX_STACK_SIZE + 1);
+    checkArgument(
+        0 <= heightNew && heightNew <= MAX_STACK_SIZE + 1,
+        "StackHeightCheck constructor provided with Invalid heightNew %s",
+        heightNew);
     comparison = heightNew;
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/RipemdBlocks.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/precompiles/RipemdBlocks.java
@@ -36,11 +36,11 @@ public final class RipemdBlocks extends CountingOnlyModule {
 
   @Override
   public void updateTally(final int count) {
-    final int blockCount = numberOfRipemd160locks(count);
+    final int blockCount = numberOfRipemd160Blocks(count);
     counts.add(blockCount);
   }
 
-  public static int numberOfRipemd160locks(final int dataByteLength) {
+  public static int numberOfRipemd160Blocks(final int dataByteLength) {
     final long tmp =
         dataByteLength * 8L
             + RIPEMD160_ND_PADDED_ONE

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/instructions/LimbToRamTwoTarget.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/instructions/LimbToRamTwoTarget.java
@@ -37,7 +37,7 @@ public class LimbToRamTwoTarget extends MmioInstruction {
 
     checkArgument(
         mmioData.targetLimbIsTouchedTwice(),
-        "The MMIO instruction LimbToRamTwoTarget must temporary update the target limb");
+        "The MMIO instruction LimbToRamTwoTarget must temporarily update the target limb");
 
     mmioData.cnA(mmioData.targetContext());
     mmioData.cnB(mmioData.targetContext());

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/instructions/RamToRamTwoTarget.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/instructions/RamToRamTwoTarget.java
@@ -37,7 +37,7 @@ public class RamToRamTwoTarget extends MmioInstruction {
 
     checkArgument(
         mmioData.targetLimbIsTouchedTwice(),
-        "The MMIO instruction RamToRamTwoTarget must temporary update the target limb");
+        "The MMIO instruction RamToRamTwoTarget must temporarily update the target limb");
 
     mmioData.cnA(mmioData.sourceContext());
     mmioData.cnB(mmioData.targetContext());

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/Mmu.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/Mmu.java
@@ -62,7 +62,7 @@ public class Mmu implements OperationListModule<MmuOperation> {
     int mmioStamp = 0;
 
     for (MmuOperation mmuOperation : operations.getAll()) {
-      checkState(mmuOperation.traceMe(), "Cannot compute if traceMe is false");
+      checkState(mmuOperation.traceMe(), "Cannot commit MMU operation with false 'traceMe'");
       mmuOperation.getCFI();
       mmuOperation.fillLimb();
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/MmuOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/MmuOperation.java
@@ -75,12 +75,12 @@ public class MmuOperation extends ModuleOperation {
 
   @Override
   protected int computeLineCount() {
-    checkState(traceMe(), "Cannot compute if traceMe is false");
+    checkState(traceMe(), "Cannot compute line count of MMU operation if traceMe is false");
     return 1 + mmuData.numberMmuPreprocessingRows() + mmuData.numberMmioInstructions();
   }
 
   public int mmioLineCount() {
-    checkState(traceMe(), "Cannot compute if traceMe is false");
+    checkState(traceMe(), "Cannot compute MMIO line count of MMU operation if traceMe is false");
     int mmioLineCount = 0;
     for (int i = 0; i < mmuData().numberMmioInstructions(); i++) {
       mmioLineCount +=

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/moduleOperation/LondonMxpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/moduleOperation/LondonMxpOperation.java
@@ -291,7 +291,10 @@ public class LondonMxpOperation extends MxpOperation {
       if (maxOffset1.compareTo(TWO_POW_32) >= 0) {
         acc1 = maxOffset1.subtract(TWO_POW_32);
       } else {
-        checkArgument(maxOffset2.compareTo(TWO_POW_32) >= 0);
+        checkArgument(
+            maxOffset2.compareTo(TWO_POW_32) >= 0,
+            "London MXP error: maxOffset2 = %s < 2^32",
+            maxOffset2);
         acc2 = maxOffset2.subtract(TWO_POW_32);
       }
     } else {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/StpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/StpOperation.java
@@ -40,7 +40,11 @@ public final class StpOperation extends ModuleOperation {
   }
 
   long getGDiff() {
-    checkArgument(!stpCall.outOfGasException());
+    checkArgument(
+        !stpCall.outOfGasException(),
+        "STP: attempting to compute gDiff = gasActual - gasUpfront, yet gasActual = %s < %s =gasUpfront",
+        stpCall.gasActual(),
+        stpCall.upfrontGasCost());
     return stpCall.gasActual() - stpCall.upfrontGasCost();
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnDataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnDataOperation.java
@@ -48,7 +48,11 @@ public abstract class CancunTxnDataOperation extends TxnDataOperation {
 
   @Override
   public int computeLineCount() {
-    checkState(rows.size() == 1 + ctMax(), "Cancun TXN_DATA operation has rows size = %s != 1 + ctMax = %s", rows.size(), ctMax() + 1);
+    checkState(
+        rows.size() == 1 + ctMax(),
+        "Cancun TXN_DATA operation has rows size = %s != 1 + ctMax = %s",
+        rows.size(),
+        ctMax() + 1);
     return rows.size();
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnDataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnDataOperation.java
@@ -48,7 +48,7 @@ public abstract class CancunTxnDataOperation extends TxnDataOperation {
 
   @Override
   public int computeLineCount() {
-    checkState(rows.size() == 1 + ctMax());
+    checkState(rows.size() == 1 + ctMax(), "Cancun TXN_DATA operation has rows size = %s != 1 + ctMax = %s", rows.size(), ctMax() + 1);
     return rows.size();
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/SysiEip2935Transaction.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/SysiEip2935Transaction.java
@@ -40,7 +40,9 @@ public class SysiEip2935Transaction extends CancunTxnDataOperation {
 
   public SysiEip2935Transaction(final CancunTxnData txnData) {
     super(txnData, SYSI);
-    checkState(isPostPrague(txnData.hub().fork), "EIP-2935 system transaction not allowed before Prague fork");
+    checkState(
+        isPostPrague(txnData.hub().fork),
+        "EIP-2935 system transaction not allowed before Prague fork");
     process();
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/SysiEip2935Transaction.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/SysiEip2935Transaction.java
@@ -40,7 +40,7 @@ public class SysiEip2935Transaction extends CancunTxnDataOperation {
 
   public SysiEip2935Transaction(final CancunTxnData txnData) {
     super(txnData, SYSI);
-    checkState(isPostPrague(txnData.hub().fork));
+    checkState(isPostPrague(txnData.hub().fork), "EIP-2935 system transaction not allowed before Prague fork");
     process();
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/SysiEip4788Transaction.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/SysiEip4788Transaction.java
@@ -40,7 +40,9 @@ public class SysiEip4788Transaction extends CancunTxnDataOperation {
 
   public SysiEip4788Transaction(final CancunTxnData txnData) {
     super(txnData, SYSI);
-    checkState(isPostCancun(txnData.hub().fork), "EIP-4788 system transaction not allowed before Cancun fork");
+    checkState(
+        isPostCancun(txnData.hub().fork),
+        "EIP-4788 system transaction not allowed before Cancun fork");
     process();
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/SysiEip4788Transaction.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/SysiEip4788Transaction.java
@@ -40,7 +40,7 @@ public class SysiEip4788Transaction extends CancunTxnDataOperation {
 
   public SysiEip4788Transaction(final CancunTxnData txnData) {
     super(txnData, SYSI);
-    checkState(isPostCancun(txnData.hub().fork));
+    checkState(isPostCancun(txnData.hub().fork), "EIP-4788 system transaction not allowed before Cancun fork");
     process();
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/london/LondonTxnData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/london/LondonTxnData.java
@@ -56,7 +56,9 @@ public class LondonTxnData extends TxnData<LondonTxnDataOperation> {
 
   @Override
   public void traceEndBlock(final BlockHeader blockHeader, final BlockBody blockBody) {
-    checkState(currentTx() instanceof LondonTxnDataOperation, "non London transaction in LondonTxnData module");
+    checkState(
+        currentTx() instanceof LondonTxnDataOperation,
+        "non London transaction in LondonTxnData module");
     currentBlock()
         .setNbOfTxsInBlock(
             ((LondonTxnDataOperation) currentTx()).tx.getRelativeTransactionNumber());

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/london/LondonTxnData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/london/LondonTxnData.java
@@ -56,7 +56,7 @@ public class LondonTxnData extends TxnData<LondonTxnDataOperation> {
 
   @Override
   public void traceEndBlock(final BlockHeader blockHeader, final BlockBody blockBody) {
-    checkState(currentTx() instanceof LondonTxnDataOperation);
+    checkState(currentTx() instanceof LondonTxnDataOperation, "non London transaction in LondonTxnData module");
     currentBlock()
         .setNbOfTxsInBlock(
             ((LondonTxnDataOperation) currentTx()).tx.getRelativeTransactionNumber());

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/gas/projector/GasProjection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/opcode/gas/projector/GasProjection.java
@@ -24,7 +24,9 @@ import net.consensys.linea.zktracer.Fork;
 public abstract class GasProjection {
 
   long linearCost(long costPerUnit, long size, long unit) {
-    checkArgument((unit == 1) || (unit == WORD_SIZE));
+    checkArgument(
+        (unit == 1) || (unit == WORD_SIZE),
+        "GasProjection.linearCost: unit must be 1 (per byte) or 32 (per word)");
     return clampedMultiply(costPerUnit, clampedAdd(size, unit - 1) / unit);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/callstack/CallFrame.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/callstack/CallFrame.java
@@ -91,12 +91,12 @@ public class CallFrame {
   @Getter @Setter private long lastValidGasNext = 0;
 
   public void pauseCurrentFrame() {
-    Preconditions.checkState(!executionPaused);
+    Preconditions.checkState(!executionPaused, "cannot pause frame as frame already paused");
     executionPaused = true;
   }
 
   public void unpauseCurrentFrame() {
-    Preconditions.checkState(executionPaused);
+    Preconditions.checkState(executionPaused, "cannot unpause frame as frame is not paused");
     executionPaused = false;
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/callstack/CallStack.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/callstack/CallStack.java
@@ -208,7 +208,7 @@ public final class CallStack {
    */
   public void exit() {
     this.depth -= 1;
-    Preconditions.checkState(this.depth >= 0);
+    Preconditions.checkState(this.depth >= 0, "call stack underflow");
     this.currentId = this.currentCallFrame().parentId();
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/stack/Stack.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/runtime/stack/Stack.java
@@ -398,7 +398,8 @@ public class Stack {
     final short delta = (short) currentOpcodeData.stackSettings().delta();
     final short alpha = (short) currentOpcodeData.stackSettings().alpha();
 
-    checkArgument(heightNew == frame.stackSize());
+    checkArgument(
+        heightNew == frame.stackSize(), "stack height prediction and frame value mismatch");
     height = (short) frame.stackSize();
     heightNew -= delta;
     heightNew += alpha;
@@ -415,7 +416,8 @@ public class Stack {
         hub.transients().conflation().stackHeightChecksForStackUnderflows().add(checkForUnderflow);
     if (isNewCheckForStackUnderflow) {
       final boolean underflowDetected = hub.wcp().callLT(height, delta);
-      checkArgument(underflowDetected == (status == Status.UNDERFLOW));
+      checkArgument(
+          underflowDetected == (status == Status.UNDERFLOW), "stack underflow detection mismatch");
     }
 
     // stack overflow checks happen only if no stack underflow was detected
@@ -425,7 +427,8 @@ public class Stack {
           hub.transients().conflation().stackHeightChecksForStackOverflows().add(checkForOverflow);
       if (isNewCheckForStackOverflow) {
         final boolean overflowDetected = hub.wcp().callGT(heightNew, MAX_STACK_SIZE);
-        checkArgument(overflowDetected == (status == Status.OVERFLOW));
+        checkArgument(
+            overflowDetected == (status == Status.OVERFLOW), "stack overflow detection mismatch");
       }
     }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/types/Conversions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/types/Conversions.java
@@ -15,8 +15,8 @@
 
 package net.consensys.linea.zktracer.types;
 
-import static com.google.common.base.Preconditions.*;
 import static net.consensys.linea.zktracer.Trace.LLARGE;
+import static net.consensys.linea.zktracer.types.Checks.checkArgument;
 
 import java.math.BigInteger;
 
@@ -110,13 +110,13 @@ public class Conversions {
 
   public static long bytesToLong(final Bytes input) {
     final Bytes trimmedBytes = input.trimLeadingZeros();
-    checkArgument(trimmedBytes.size() <= 8, "Input bytes must be at most 8 bytes long");
+    assert trimmedBytes.size() <= 8 : "Input bytes must be at most 8 bytes long";
     return trimmedBytes.toLong();
   }
 
   public static short bytesToShort(final Bytes input) {
     final Bytes trimmedBytes = input.trimLeadingZeros();
-    checkArgument(trimmedBytes.size() <= 2, "Input bytes must be at most 2 bytes long");
+    assert trimmedBytes.size() <= 2 : "Input bytes must be at most 2 bytes long";
     return (short) trimmedBytes.toInt();
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/types/Conversions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/types/Conversions.java
@@ -110,13 +110,13 @@ public class Conversions {
 
   public static long bytesToLong(final Bytes input) {
     final Bytes trimmedBytes = input.trimLeadingZeros();
-    assert trimmedBytes.size() <= 8 : "Input bytes must be at most 8 bytes long";
+    checkArgument(trimmedBytes.size() <= 8, "Input bytes must be at most 8 bytes long");
     return trimmedBytes.toLong();
   }
 
   public static short bytesToShort(final Bytes input) {
     final Bytes trimmedBytes = input.trimLeadingZeros();
-    assert trimmedBytes.size() <= 2 : "Input bytes must be at most 2 bytes long";
+    checkArgument(trimmedBytes.size() <= 2, "Input bytes must be at most 2 bytes long");
     return (short) trimmedBytes.toInt();
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/types/Utils.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/types/Utils.java
@@ -44,7 +44,7 @@ public class Utils {
   }
 
   public static int fromDataSizeToLimbNbRows(int dataSize) {
-    assert dataSize >= 0 : "Data size must be non-negative";
+    checkArgument(dataSize >= 0, "Data size must be non-negative");
     return (int) Math.ceil((double) dataSize / LLARGE);
   }
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/MemoryContents.java
@@ -101,8 +101,8 @@ public enum MemoryContents implements PrecompileCallMemoryContents {
           case MAX -> MAX_WORD.repeat(4);
         };
 
-    final boolean correctLength = pointData.length() == 4 * WORD_HEX_SIZE;
-    checkState(correctLength);
+
+    checkState(pointData.length() == 4 * WORD_HEX_SIZE, "bad point data length");
 
     String memoryContentsString = pointData + MAX_WORD;
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/MemoryContents.java
@@ -101,7 +101,11 @@ public enum MemoryContents implements PrecompileCallMemoryContents {
           case MAX -> MAX_WORD.repeat(4);
         };
 
-    checkState(pointData.length() == 4 * WORD_HEX_SIZE, "bad point data length");
+    checkState(
+        pointData.length() == 4 * WORD_HEX_SIZE,
+        "ECADD memory contents: point data size %s is not the expected one %s",
+        pointData.length(),
+        4 * WORD_HEX_SIZE);
 
     String memoryContentsString = pointData + MAX_WORD;
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecadd/MemoryContents.java
@@ -101,7 +101,6 @@ public enum MemoryContents implements PrecompileCallMemoryContents {
           case MAX -> MAX_WORD.repeat(4);
         };
 
-
     checkState(pointData.length() == 4 * WORD_HEX_SIZE, "bad point data length");
 
     String memoryContentsString = pointData + MAX_WORD;

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/MemoryContents.java
@@ -80,16 +80,16 @@ public enum MemoryContents implements PrecompileCallMemoryContents {
           case RANDOM -> RND.substring(36, 36 + 3 * WORD_HEX_SIZE);
         };
 
-    checkState(pointData.length() == 3 * WORD_HEX_SIZE, "ECADD memory contents: point data size %s is not the expected one %s", pointData.length(), 3 * WORD_HEX_SIZE);
-        pointData.length(), 3 * WORD_HEX_SIZE);
+    checkState(
+        pointData.length() == 3 * WORD_HEX_SIZE,
+        "ECADD memory contents: point data size %s is not the expected one %s",
+        pointData.length(),
+        3 * WORD_HEX_SIZE);
 
     String memoryContentsString = pointData + MAX_WORD;
 
     BytecodeCompiler memoryContents = BytecodeCompiler.newProgram(chainConfig);
     memoryContents.immediate(Bytes.fromHexString(memoryContentsString));
-
-
-    
 
     return memoryContents;
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/MemoryContents.java
@@ -80,7 +80,8 @@ public enum MemoryContents implements PrecompileCallMemoryContents {
           case RANDOM -> RND.substring(36, 36 + 3 * WORD_HEX_SIZE);
         };
 
-    checkState(pointData.length() == 3 * WORD_HEX_SIZE, "Bad point data length");
+    checkState(pointData.length() == 3 * WORD_HEX_SIZE, "ECADD memory contents: point data size %s is not the expected one %s", pointData.length(), 3 * WORD_HEX_SIZE);
+        pointData.length(), 3 * WORD_HEX_SIZE);
 
     String memoryContentsString = pointData + MAX_WORD;
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/MemoryContents.java
@@ -88,6 +88,9 @@ public enum MemoryContents implements PrecompileCallMemoryContents {
     BytecodeCompiler memoryContents = BytecodeCompiler.newProgram(chainConfig);
     memoryContents.immediate(Bytes.fromHexString(memoryContentsString));
 
+
+    
+
     return memoryContents;
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecmul/MemoryContents.java
@@ -80,7 +80,7 @@ public enum MemoryContents implements PrecompileCallMemoryContents {
           case RANDOM -> RND.substring(36, 36 + 3 * WORD_HEX_SIZE);
         };
 
-    checkState(pointData.length() == 3 * WORD_HEX_SIZE);
+    checkState(pointData.length() == 3 * WORD_HEX_SIZE, "Bad point data length");
 
     String memoryContentsString = pointData + MAX_WORD;
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecpairing/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecpairing/MemoryContents.java
@@ -83,10 +83,9 @@ public class MemoryContents implements PrecompileCallMemoryContents {
   public BytecodeCompiler memoryContents(ChainConfig chainConfig) {
     Bytes memoryContentsBytes =
         Bytes.fromHexString(leftPairs() + CenterPair() + rightPairs() + RETURN_DATA_STRIP);
-    // TODO: replace 192 with the appropriate constant (maybe add to GlobalConstants)
     checkState(
         memoryContentsBytes.size()
-            == TOTAL_NUMBER_OF_PAIRS_OF_POINTS * SIZE_OF_PAIR_OF_POINTS + WORD_SIZE);
+            == TOTAL_NUMBER_OF_PAIRS_OF_POINTS * SIZE_OF_PAIR_OF_POINTS + WORD_SIZE, "ECPAIRING memory contents size is incorrect");
 
     BytecodeCompiler memoryContents = BytecodeCompiler.newProgram(chainConfig);
     return memoryContents.immediate(memoryContentsBytes);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecpairing/MemoryContents.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecpairing/MemoryContents.java
@@ -85,7 +85,8 @@ public class MemoryContents implements PrecompileCallMemoryContents {
         Bytes.fromHexString(leftPairs() + CenterPair() + rightPairs() + RETURN_DATA_STRIP);
     checkState(
         memoryContentsBytes.size()
-            == TOTAL_NUMBER_OF_PAIRS_OF_POINTS * SIZE_OF_PAIR_OF_POINTS + WORD_SIZE, "ECPAIRING memory contents size is incorrect");
+            == TOTAL_NUMBER_OF_PAIRS_OF_POINTS * SIZE_OF_PAIR_OF_POINTS + WORD_SIZE,
+        "ECPAIRING memory contents size is incorrect");
 
     BytecodeCompiler memoryContents = BytecodeCompiler.newProgram(chainConfig);
     return memoryContents.immediate(memoryContentsBytes);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/EcRecoverTuple.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/EcRecoverTuple.java
@@ -53,7 +53,11 @@ public record EcRecoverTuple(String h, String v, String r, String s) {
     Bytes pointData =
         Bytes.concatenate(hBytes, vBytes, rBytes, sBytes, Bytes.fromHexString(MAX_WORD));
 
-    checkState(pointData.size() == 5 * WORD_SIZE, "ECRECOVER input vector size %s is not the expected one %s", pointData.size(), 5 * WORD_SIZE);
+    checkState(
+        pointData.size() == 5 * WORD_SIZE,
+        "ECRECOVER input vector size %s is not the expected one %s",
+        pointData.size(),
+        5 * WORD_SIZE);
 
     BytecodeCompiler memoryContents = BytecodeCompiler.newProgram(chainConfig);
     memoryContents.immediate(pointData);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/EcRecoverTuple.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/prc/ecrecover/EcRecoverTuple.java
@@ -53,7 +53,7 @@ public record EcRecoverTuple(String h, String v, String r, String s) {
     Bytes pointData =
         Bytes.concatenate(hBytes, vBytes, rBytes, sBytes, Bytes.fromHexString(MAX_WORD));
 
-    checkState(pointData.size() == 5 * WORD_SIZE);
+    checkState(pointData.size() == 5 * WORD_SIZE, "ECRECOVER input vector size %s is not the expected one %s", pointData.size(), 5 * WORD_SIZE);
 
     BytecodeCompiler memoryContents = BytecodeCompiler.newProgram(chainConfig);
     memoryContents.immediate(pointData);

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/RipTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/RipTests.java
@@ -16,7 +16,7 @@
 package net.consensys.linea.zktracer.precompiles;
 
 import static net.consensys.linea.zktracer.module.limits.precompiles.RipemdBlocks.RIPEMD160_BLOCKSIZE;
-import static net.consensys.linea.zktracer.module.limits.precompiles.RipemdBlocks.numberOfRipemd160locks;
+import static net.consensys.linea.zktracer.module.limits.precompiles.RipemdBlocks.numberOfRipemd160Blocks;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
@@ -67,7 +67,7 @@ public class RipTests extends TracerTestBase {
     // if size is huge, we get an OOGX, so no RIP call made
     final boolean noRipCAll = size == 0 || size == HUGE_SIZE;
     assertEquals(
-        noRipCAll ? 0 : numberOfRipemd160locks(size),
+        noRipCAll ? 0 : numberOfRipemd160Blocks(size),
         bytecodeRunner.getHub().ripemdBlocks().lineCount(),
         "Fail at size: " + size);
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds explicit error messages to numerous precondition checks, renames RIPEMD block counter helper, and performs small API/cleanup tweaks (e.g., computePcNew signature).
> 
> - **Diagnostics / Assertions**:
>   - Add explicit messages to `checkArgument`/`checkState` across `hub` sections, precompile ops (BLS/EC/EXP), MMU/MXP/STP, txndata, utils, and runtime classes for clearer failures.
> - **Precompile Limits (RIPEMD)**:
>   - Rename `numberOfRipemd160locks` -> `numberOfRipemd160Blocks` and update usages/tests (`RipemdBlocks`, `RipTests`).
> - **APIs / Cleanups**:
>   - Change `CommonFragmentValues.computePcNew(...)` signature (drop `Hub` param) and update callers.
>   - Remove `TraceSections.previousSection()`; tighten `previousSection(int)` with a message.
>   - Minor import and message wording tweaks (e.g., “temporarily update the target limb”, more specific module/tag prefixes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb66a431fe3a284f4385b0a4f5f20ab282a6076b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->