### PR TITLE
feat: add logging for ZkTracer and ZkCounter

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
@@ -115,8 +115,6 @@ public class GenerateConflatedTracesV2 {
       // Retrieve fork from Besu plugin API with block number
       final Fork fork = getForkFromBesuBlockchainService(besuContext, fromBlock, toBlock);
 
-      log.debug("[TRACING] computing trace for {}-{} on fork {}", fromBlock, toBlock, fork);
-
       final ZkTracer tracer =
           new ZkTracer(
               fork,
@@ -132,7 +130,12 @@ public class GenerateConflatedTracesV2 {
           tracer::traceEndConflation,
           tracer);
 
-      log.info("[TRACING] trace for {}-{} computed in {}", fromBlock, toBlock, sw);
+      log.info(
+          "[TRACING] trace on fork {} for blocks {}-{} computed in {}",
+          fork,
+          fromBlock,
+          toBlock,
+          sw);
       sw.reset().start();
       // Generate trace file
       path =

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
@@ -88,6 +88,7 @@ import static org.hyperledger.besu.evm.frame.MessageFrame.State.COMPLETED_SUCCES
 import java.util.*;
 import java.util.stream.Stream;
 
+import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
 import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
 import net.consensys.linea.zktracer.container.module.IncrementAndDetectModule;
@@ -130,6 +131,7 @@ import org.hyperledger.besu.evm.worldstate.WorldView;
 import org.hyperledger.besu.plugin.data.BlockBody;
 import org.hyperledger.besu.plugin.data.BlockHeader;
 
+@Slf4j
 public class ZkCounter implements LineCountingTracer {
 
   public static final Fork FORK_TO_USE_FOR_ZK_COUNTER = PRAGUE;
@@ -366,6 +368,8 @@ public class ZkCounter implements LineCountingTracer {
             bridgeConfiguration.contract(),
             LogTopic.of(bridgeConfiguration.topic()));
     moduleToCount = Stream.concat(checkedModules().stream(), uncheckedModules().stream()).toList();
+
+    log.info("[ZkCounter] Created ZkCounter");
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -98,6 +98,8 @@ public class ZkTracer implements LineCountingTracer {
     final DebugMode.PinLevel debugLevel = new DebugMode.PinLevel();
     this.debugMode =
         debugLevel.none() ? Optional.empty() : Optional.of(new DebugMode(debugLevel, this.hub));
+
+    log.info("[ZkTracer] Created ZkTracer for fork {}", chain.fork);
   }
 
   public void writeToFile(final Path filename, long startBlock, long endBlock) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add creation info logs for ZkTracer/ZkCounter and include fork in trace-completion logging, removing a redundant debug log.
> 
> - **Logging**:
>   - `zktracer/ZkTracer`: add `@Slf4j` and info log on creation with fork.
>   - `zktracer/ZkCounter`: add `@Slf4j` and info log on creation.
>   - `plugins/rpc/tracegeneration/GenerateConflatedTracesV2`: replace completion log to include fork and block range; remove redundant debug log.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5819656f76714864d0b13206f7e2abc09dbca88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->