### PR TITLE
fix: avoid passing stamp from blake2fmodexp operation to unsignedByte…

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/BlakeModexpDataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/BlakeModexpDataOperation.java
@@ -85,21 +85,21 @@ public class BlakeModexpDataOperation extends ModuleOperation {
     final UnsignedByte stampByte = UnsignedByte.of(stamp);
 
     if (modexpMetaData.isPresent()) {
-      traceBase(trace, stampByte);
-      traceExponent(trace, stampByte);
-      traceModulus(trace, stampByte);
-      traceModexpResult(trace, stampByte);
+      traceBase(trace, stamp);
+      traceExponent(trace, stamp);
+      traceModulus(trace, stamp);
+      traceModexpResult(trace, stamp);
       return;
     }
 
     if (blake2fComponents.isPresent()) {
-      traceData(trace, stampByte);
-      traceParameter(trace, stampByte);
-      traceBlakeResult(trace, stampByte);
+      traceData(trace, stamp);
+      traceParameter(trace, stamp);
+      traceBlakeResult(trace, stamp);
     }
   }
 
-  private void traceData(Trace.Blake2fmodexpdata trace, UnsignedByte stamp) {
+  private void traceData(Trace.Blake2fmodexpdata trace, int stamp) {
     final Bytes input = blake2fComponents.get().getHashInput();
     for (int index = 0; index <= INDEX_MAX_BLAKE_DATA; index++) {
       commonTrace(trace, stamp, index, input, INDEX_MAX_BLAKE_DATA);
@@ -107,7 +107,7 @@ public class BlakeModexpDataOperation extends ModuleOperation {
     }
   }
 
-  private void traceParameter(Trace.Blake2fmodexpdata trace, UnsignedByte stamp) {
+  private void traceParameter(Trace.Blake2fmodexpdata trace, int stamp) {
     // r
     commonTrace(
         trace, stamp, 0, leftPadTo(blake2fComponents.get().r(), LLARGE), INDEX_MAX_BLAKE_PARAMS);
@@ -123,7 +123,7 @@ public class BlakeModexpDataOperation extends ModuleOperation {
     trace.phase(UnsignedByte.of(PHASE_BLAKE_PARAMS)).isBlakeParams(true).fillAndValidateRow();
   }
 
-  private void traceBlakeResult(Trace.Blake2fmodexpdata trace, UnsignedByte stamp) {
+  private void traceBlakeResult(Trace.Blake2fmodexpdata trace, int stamp) {
     final Bytes hash = computeBlake2fResult();
     for (int index = 0; index <= INDEX_MAX_BLAKE_RESULT; index++) {
       commonTrace(trace, stamp, index, hash, INDEX_MAX_BLAKE_RESULT);
@@ -131,7 +131,7 @@ public class BlakeModexpDataOperation extends ModuleOperation {
     }
   }
 
-  private void traceBase(Trace.Blake2fmodexpdata trace, final UnsignedByte stamp) {
+  private void traceBase(Trace.Blake2fmodexpdata trace, final int stamp) {
     final Bytes input = leftPadTo(modexpMetaData.get().base(), MODEXP_COMPONENT_BYTE_SIZE);
     for (int index = 0; index <= INDEX_MAX_MODEXP_BASE; index++) {
       commonTrace(trace, stamp, index, input, INDEX_MAX_MODEXP_BASE);
@@ -139,7 +139,7 @@ public class BlakeModexpDataOperation extends ModuleOperation {
     }
   }
 
-  private void traceExponent(Trace.Blake2fmodexpdata trace, final UnsignedByte stamp) {
+  private void traceExponent(Trace.Blake2fmodexpdata trace, final int stamp) {
     final Bytes input = leftPadTo(modexpMetaData.get().exp(), MODEXP_COMPONENT_BYTE_SIZE);
     for (int index = 0; index <= INDEX_MAX_MODEXP_EXPONENT; index++) {
       commonTrace(trace, stamp, index, input, INDEX_MAX_MODEXP_EXPONENT);
@@ -150,7 +150,7 @@ public class BlakeModexpDataOperation extends ModuleOperation {
     }
   }
 
-  private void traceModulus(Trace.Blake2fmodexpdata trace, final UnsignedByte stamp) {
+  private void traceModulus(Trace.Blake2fmodexpdata trace, final int stamp) {
     final Bytes input = leftPadTo(modexpMetaData.get().mod(), MODEXP_COMPONENT_BYTE_SIZE);
     for (int index = 0; index <= INDEX_MAX_MODEXP_MODULUS; index++) {
       commonTrace(trace, stamp, index, input, INDEX_MAX_MODEXP_MODULUS);
@@ -158,7 +158,7 @@ public class BlakeModexpDataOperation extends ModuleOperation {
     }
   }
 
-  private void traceModexpResult(Trace.Blake2fmodexpdata trace, final UnsignedByte stamp) {
+  private void traceModexpResult(Trace.Blake2fmodexpdata trace, final int stamp) {
     final Bytes input = leftPadTo(modexpMetaData.get().rawResult(), MODEXP_COMPONENT_BYTE_SIZE);
     for (int index = 0; index <= INDEX_MAX_MODEXP_RESULT; index++) {
       commonTrace(trace, stamp, index, input, INDEX_MAX_MODEXP_RESULT);
@@ -167,9 +167,9 @@ public class BlakeModexpDataOperation extends ModuleOperation {
   }
 
   private void commonTrace(
-      Trace.Blake2fmodexpdata trace, UnsignedByte stamp, int index, Bytes input, int indexMax) {
+      Trace.Blake2fmodexpdata trace, int stamp, int index, Bytes input, int indexMax) {
     trace
-        .stamp(stamp.toInteger())
+        .stamp(stamp)
         .id(id)
         .index(UnsignedByte.of(index))
         .indexMax(UnsignedByte.of(indexMax))


### PR DESCRIPTION
… and back to int

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use int `stamp` throughout `BlakeModexpDataOperation` tracing and update `linea-constraints` submodule.
> 
> - **arithmetization**:
>   - `BlakeModexpDataOperation`: use `int stamp` across tracing methods (`traceData`, `traceParameter`, `traceBlakeResult`, `traceBase`, `traceExponent`, `traceModulus`, `traceModexpResult`, `commonTrace`); pass `stamp` directly to `trace.stamp(...)`; remove `UnsignedByte` stamp conversions at call sites.
> - **Submodule**:
>   - Update `linea-constraints` to `507f8fe`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ed0af22313c8f9fc8f6a946db2e215c0135623c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->