### PR TITLE
cleaning moduleKey()

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
@@ -801,7 +801,7 @@ public class ZkCounter implements LineCountingTracer {
     final HashMap<String, Integer> modulesLineCount = HashMap.newHashMap(moduleToCount.size());
 
     for (Module m : moduleToCount) {
-      modulesLineCount.put(m.moduleKey(), m.lineCount() + m.spillage(trace));
+      modulesLineCount.put(m.moduleKey().toString(), m.lineCount() + m.spillage(trace));
     }
     return modulesLineCount;
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -121,7 +121,7 @@ public class ZkTracer implements LineCountingTracer {
     // include line counts
     final Map<String, String> lineCounts = new HashMap<>();
     for (Module m : hub.getTracelessModules()) {
-      lineCounts.put(m.moduleKey(), Integer.toString(m.lineCount()));
+      lineCounts.put(m.moduleKey().toString(), Integer.toString(m.lineCount()));
     }
     trace.addMetadata("lineCounts", lineCounts);
     //
@@ -330,7 +330,7 @@ public class ZkTracer implements LineCountingTracer {
     final HashMap<String, Integer> modulesLineCount = new HashMap<>();
 
     for (Module m : hub.getModulesToCount()) {
-      modulesLineCount.put(m.moduleKey(), m.lineCount() + m.spillage(this.trace));
+      modulesLineCount.put(m.moduleKey().toString(), m.lineCount() + m.spillage(this.trace));
     }
     //
     return modulesLineCount;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/CountingOnlyModule.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/CountingOnlyModule.java
@@ -45,8 +45,8 @@ public class CountingOnlyModule implements Module {
   }
 
   @Override
-  public String moduleKey() {
-    return moduleKey.toString();
+  public ModuleName moduleKey() {
+    return moduleKey;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/Module.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/container/module/Module.java
@@ -18,6 +18,7 @@ package net.consensys.linea.zktracer.container.module;
 import java.util.List;
 
 import net.consensys.linea.zktracer.Trace;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
 import org.hyperledger.besu.datatypes.Address;
@@ -28,7 +29,7 @@ import org.hyperledger.besu.plugin.data.BlockHeader;
 import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 
 public interface Module {
-  String moduleKey();
+  ModuleName moduleKey();
 
   default void traceStartConflation(final long blockCount) {}
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ModuleName.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ModuleName.java
@@ -18,11 +18,14 @@ package net.consensys.linea.zktracer.module;
 public enum ModuleName {
   // tracing Modules
   ADD,
+  BIN,
   BLAKE_MODEXP_DATA,
   BLOCK_DATA,
   BLOCK_HASH,
   BLS_DATA,
   EC_DATA,
+  EUC,
+  EXP,
   EXT,
   GAS,
   HUB,
@@ -31,6 +34,7 @@ public enum ModuleName {
   MMIO,
   MMU,
   MOD,
+  MUL,
   MXP,
   OOB,
   RLP_ADDR,
@@ -40,9 +44,11 @@ public enum ModuleName {
   ROM,
   ROM_LEX,
   SHAKIRA_DATA,
+  SHF,
   STP,
   TRM,
   TXN_DATA,
+  WCP,
 
   // precompiles
   // ecdata:
@@ -88,6 +94,8 @@ public enum ModuleName {
   BLOCK_KECCAK,
 
   // reference tables
+  BIN_REFERENCE_TABLE,
   BLS_REFERENCE_TABLE,
+  INSTRUCTION_DECODER,
   POWER_REFERENCE_TABLE
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/Add.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/add/Add.java
@@ -29,6 +29,7 @@ import net.consensys.linea.zktracer.container.module.Module;
 import net.consensys.linea.zktracer.container.module.OperationSetWithAdditionalRowsModule;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -45,8 +46,8 @@ public class Add implements OperationSetWithAdditionalRowsModule<AddOperation> {
   private final CountOnlyOperation additionalRows = new CountOnlyOperation();
 
   @Override
-  public String moduleKey() {
-    return ADD.toString();
+  public ModuleName moduleKey() {
+    return ModuleName.ADD;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/bin/Bin.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/bin/Bin.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.bin;
 
+import static net.consensys.linea.zktracer.module.ModuleName.BIN;
 import static net.consensys.linea.zktracer.opcode.OpCode.*;
 
 import java.util.List;
@@ -27,6 +28,7 @@ import net.consensys.linea.zktracer.bytestheta.BaseBytes;
 import net.consensys.linea.zktracer.container.module.Module;
 import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -41,8 +43,8 @@ public class Bin implements OperationSetModule<BinOperation> {
       new ModuleOperationStackedSet<>();
 
   @Override
-  public String moduleKey() {
-    return "BIN";
+  public ModuleName moduleKey() {
+    return BIN;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/BlakeModexpData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/BlakeModexpData.java
@@ -27,6 +27,7 @@ import net.consensys.linea.zktracer.container.module.IncrementAndDetectModule;
 import net.consensys.linea.zktracer.container.module.IncrementingModule;
 import net.consensys.linea.zktracer.container.module.OperationListModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedList;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.hub.precompiles.ModexpMetadata;
 import net.consensys.linea.zktracer.module.limits.precompiles.BlakeRounds;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
@@ -47,8 +48,8 @@ public class BlakeModexpData implements OperationListModule<BlakeModexpDataOpera
   private long previousID = 0;
 
   @Override
-  public String moduleKey() {
-    return BLAKE_MODEXP_DATA.toString();
+  public ModuleName moduleKey() {
+    return BLAKE_MODEXP_DATA;
   }
 
   public void callModexp(final ModexpMetadata modexpMetaData, final int operationID) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/module/Blockdata.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/module/Blockdata.java
@@ -26,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 import net.consensys.linea.zktracer.ChainConfig;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.Module;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.blockdata.moduleOperation.BlockdataOperation;
 import net.consensys.linea.zktracer.module.euc.Euc;
 import net.consensys.linea.zktracer.module.hub.Hub;
@@ -51,8 +52,8 @@ public abstract class Blockdata implements Module {
   @Getter private final OpCode[] opCodes = setOpCodes();
 
   @Override
-  public String moduleKey() {
-    return BLOCK_DATA.toString();
+  public ModuleName moduleKey() {
+    return BLOCK_DATA;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Blockhash.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Blockhash.java
@@ -28,6 +28,7 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.defer.PostOpcodeDefer;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
@@ -64,8 +65,8 @@ public class Blockhash implements OperationSetModule<BlockhashOperation>, PostOp
   }
 
   @Override
-  public String moduleKey() {
-    return BLOCK_HASH.toString();
+  public ModuleName moduleKey() {
+    return BLOCK_HASH;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blsdata/BlsData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blsdata/BlsData.java
@@ -27,6 +27,7 @@ import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
 import net.consensys.linea.zktracer.container.module.IncrementingModule;
 import net.consensys.linea.zktracer.container.module.OperationListModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedList;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.hub.fragment.scenario.PrecompileScenarioFragment;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
 import org.apache.tuweni.bytes.Bytes;
@@ -56,8 +57,8 @@ public class BlsData implements OperationListModule<BlsDataOperation> {
   @Getter private BlsDataOperation blsDataOperation;
 
   @Override
-  public String moduleKey() {
-    return BLS_DATA.toString();
+  public ModuleName moduleKey() {
+    return BLS_DATA;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/EcData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ecdata/EcData.java
@@ -27,6 +27,7 @@ import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
 import net.consensys.linea.zktracer.container.module.IncrementingModule;
 import net.consensys.linea.zktracer.container.module.OperationListModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedList;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.ext.Ext;
 import net.consensys.linea.zktracer.module.hub.fragment.scenario.PrecompileScenarioFragment;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
@@ -53,8 +54,8 @@ public class EcData implements OperationListModule<EcDataOperation> {
   @Getter private EcDataOperation ecDataOperation;
 
   @Override
-  public String moduleKey() {
-    return EC_DATA.toString();
+  public ModuleName moduleKey() {
+    return EC_DATA;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Euc.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Euc.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.euc;
 
+import static net.consensys.linea.zktracer.module.ModuleName.EUC;
 import static net.consensys.linea.zktracer.types.Conversions.bigIntegerToBytes;
 
 import java.math.BigInteger;
@@ -27,6 +28,7 @@ import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -46,8 +48,8 @@ public class Euc implements OperationSetModule<EucOperation> {
   public final CountOnlyOperation additionalRows = new CountOnlyOperation();
 
   @Override
-  public String moduleKey() {
-    return "EUC";
+  public ModuleName moduleKey() {
+    return EUC;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/Exp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/Exp.java
@@ -15,6 +15,8 @@
 
 package net.consensys.linea.zktracer.module.exp;
 
+import static net.consensys.linea.zktracer.module.ModuleName.EXP;
+
 import java.util.List;
 
 import lombok.Getter;
@@ -24,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.hub.fragment.imc.exp.ExpCall;
 
 @Slf4j
@@ -36,8 +39,8 @@ public class Exp implements OperationSetModule<ExpOperation> {
       new ModuleOperationStackedSet<>();
 
   @Override
-  public String moduleKey() {
-    return "EXP";
+  public ModuleName moduleKey() {
+    return EXP;
   }
 
   public void call(ExpCall expCall) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ext/Ext.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ext/Ext.java
@@ -28,6 +28,7 @@ import net.consensys.linea.zktracer.container.module.OperationSetWithAdditionalR
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationAdder;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -43,8 +44,8 @@ public class Ext implements OperationSetWithAdditionalRowsModule<ExtOperation> {
   private final CountOnlyOperation additionalRows = new CountOnlyOperation();
 
   @Override
-  public String moduleKey() {
-    return EXT.toString();
+  public ModuleName moduleKey() {
+    return EXT;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/gas/Gas.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/gas/Gas.java
@@ -26,6 +26,7 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.defer.PostOpcodeDefer;
 import net.consensys.linea.zktracer.module.hub.fragment.common.CommonFragmentValues;
@@ -46,8 +47,8 @@ public class Gas implements OperationSetModule<GasOperation>, PostOpcodeDefer {
   private GasParameters gasParameters;
 
   @Override
-  public String moduleKey() {
-    return GAS.toString();
+  public ModuleName moduleKey() {
+    return GAS;
   }
 
   public void call(GasParameters gasParameters, Hub hub, CommonFragmentValues commonValues) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -45,6 +45,7 @@ import net.consensys.linea.zktracer.container.module.CountingOnlyModule;
 import net.consensys.linea.zktracer.container.module.IncrementAndDetectModule;
 import net.consensys.linea.zktracer.container.module.IncrementingModule;
 import net.consensys.linea.zktracer.container.module.Module;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.add.Add;
 import net.consensys.linea.zktracer.module.bin.Bin;
 import net.consensys.linea.zktracer.module.blake2fmodexpdata.BlakeModexpData;
@@ -176,8 +177,8 @@ public abstract class Hub implements Module {
   private final PlatformController pch = new PlatformController(this);
 
   @Override
-  public String moduleKey() {
-    return HUB.toString();
+  public ModuleName moduleKey() {
+    return HUB;
   }
 
   @Override
@@ -451,7 +452,7 @@ public abstract class Hub implements Module {
         new L1BlockSize(
             blockTransactions, keccak, l2L1Logs, l2l1ContractAddress, LogTopic.of(l2l1Topic));
     shakiraData = new ShakiraData(wcp, sha256Blocks, keccak, ripemdBlocks);
-    trm = new Trm(fork, wcp);
+    trm = new Trm(fork);
     rlpTxn = setRlpTxn(this);
     rlpAddr = new RlpAddr(this, trm, keccak);
     blockdata = setBlockData(this, wcp, euc, chain);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L1BlockSize.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L1BlockSize.java
@@ -26,6 +26,7 @@ import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.IncrementingModule;
 import net.consensys.linea.zktracer.container.module.Module;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
@@ -59,8 +60,8 @@ public class L1BlockSize implements Module {
   private short nbBlock = 0;
 
   @Override
-  public String moduleKey() {
-    return BLOCK_L1_SIZE.toString();
+  public ModuleName moduleKey() {
+    return BLOCK_L1_SIZE;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L1BlockSizeForLimitless.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/limits/L1BlockSizeForLimitless.java
@@ -26,6 +26,7 @@ import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.IncrementingModule;
 import net.consensys.linea.zktracer.container.module.Module;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
+import net.consensys.linea.zktracer.module.ModuleName;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
@@ -59,8 +60,8 @@ public class L1BlockSizeForLimitless implements Module {
   private short nbBlock = 0;
 
   @Override
-  public String moduleKey() {
-    return BLOCK_L1_SIZE.toString();
+  public ModuleName moduleKey() {
+    return BLOCK_L1_SIZE;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/logdata/LogData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/logdata/LogData.java
@@ -25,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.Module;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.rlptxrcpt.RlpTxnRcpt;
 import net.consensys.linea.zktracer.module.rlptxrcpt.RlpTxrcptOperation;
 import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
@@ -37,8 +38,8 @@ public class LogData implements Module {
   private final CountOnlyOperation lineCounter = new CountOnlyOperation();
 
   @Override
-  public String moduleKey() {
-    return LOG_DATA.toString();
+  public ModuleName moduleKey() {
+    return LOG_DATA;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/loginfo/LogInfo.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/loginfo/LogInfo.java
@@ -29,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.Module;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.rlptxrcpt.RlpTxnRcpt;
 import net.consensys.linea.zktracer.module.rlptxrcpt.RlpTxrcptOperation;
 import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
@@ -43,8 +44,8 @@ public class LogInfo implements Module {
   private final CountOnlyOperation lineCounter = new CountOnlyOperation();
 
   @Override
-  public String moduleKey() {
-    return LOG_INFO.toString();
+  public ModuleName moduleKey() {
+    return LOG_INFO;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Mmio.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Mmio.java
@@ -38,6 +38,7 @@ import lombok.RequiredArgsConstructor;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.Module;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.mmu.Mmu;
 import net.consensys.linea.zktracer.module.mmu.MmuData;
 import net.consensys.linea.zktracer.module.mmu.MmuOperation;
@@ -50,8 +51,8 @@ public class Mmio implements Module {
   private final CountOnlyOperation lineCounter = new CountOnlyOperation();
 
   @Override
-  public String moduleKey() {
-    return MMIO.toString();
+  public ModuleName moduleKey() {
+    return MMIO;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/Mmu.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmu/Mmu.java
@@ -26,6 +26,7 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationListModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedList;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.euc.Euc;
 import net.consensys.linea.zktracer.module.hub.fragment.imc.mmu.MmuCall;
 import net.consensys.linea.zktracer.module.mmu.values.HubToMmuValues;
@@ -42,8 +43,8 @@ public class Mmu implements OperationListModule<MmuOperation> {
   private final Wcp wcp;
 
   @Override
-  public String moduleKey() {
-    return MMU.toString();
+  public ModuleName moduleKey() {
+    return MMU;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mod/Mod.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mod/Mod.java
@@ -27,6 +27,7 @@ import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationSetWithAdditionalRowsModule;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -39,8 +40,8 @@ public class Mod implements OperationSetWithAdditionalRowsModule<ModOperation> {
   private final CountOnlyOperation additionalRows = new CountOnlyOperation();
 
   @Override
-  public String moduleKey() {
-    return MOD.toString();
+  public ModuleName moduleKey() {
+    return ModuleName.MOD;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mul/Mul.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mul/Mul.java
@@ -25,6 +25,7 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -38,8 +39,8 @@ public class Mul implements OperationSetModule<MulOperation> {
       new ModuleOperationStackedSet<>();
 
   @Override
-  public String moduleKey() {
-    return "MUL";
+  public ModuleName moduleKey() {
+    return ModuleName.MUL;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/module/Mxp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/module/Mxp.java
@@ -26,6 +26,7 @@ import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.Module;
 import net.consensys.linea.zktracer.container.module.OperationListModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedList;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.hub.fragment.imc.MxpCall;
 import net.consensys.linea.zktracer.module.mxp.moduleOperation.MxpOperation;
 
@@ -57,8 +58,8 @@ public abstract class Mxp implements OperationListModule<MxpOperation> {
   }
 
   @Override
-  public String moduleKey() {
-    return MXP.toString();
+  public ModuleName moduleKey() {
+    return MXP;
   }
 
   public abstract void call(MxpCall mxpCall);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/oob/Oob.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/oob/Oob.java
@@ -23,10 +23,10 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
-import net.consensys.linea.zktracer.container.module.OperationSetWithAdditionalRowsModule;
-import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
+import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationAdder;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.add.Add;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.fragment.imc.oob.OobCall;
@@ -36,7 +36,7 @@ import net.consensys.linea.zktracer.module.wcp.Wcp;
 /** Implementation of a {@link Module} for out of bounds. */
 @RequiredArgsConstructor
 @Accessors(fluent = true)
-public class Oob implements OperationSetWithAdditionalRowsModule<OobOperation> {
+public class Oob implements OperationSetModule<OobOperation> {
 
   private final Hub hub;
   private final Add add;
@@ -47,11 +47,9 @@ public class Oob implements OperationSetWithAdditionalRowsModule<OobOperation> {
   private final ModuleOperationStackedSet<OobOperation> operations =
       new ModuleOperationStackedSet<>();
 
-  @Getter private final CountOnlyOperation additionalRows = new CountOnlyOperation();
-
   @Override
-  public String moduleKey() {
-    return OOB.toString();
+  public ModuleName moduleKey() {
+    return OOB;
   }
 
   public OobCall call(OobCall oobCall) {
@@ -93,7 +91,6 @@ public class Oob implements OperationSetWithAdditionalRowsModule<OobOperation> {
 
   @Override
   public void commit(Trace trace) {
-    OperationSetWithAdditionalRowsModule.super.commit(trace);
     int stamp = 0;
     for (OobOperation op : operations.getAll()) {
       traceOperation(op, ++stamp, trace.oob());

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpUtils/RlpUtils.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpUtils/RlpUtils.java
@@ -28,6 +28,7 @@ import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationAdder;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
 import net.consensys.linea.zktracer.types.Bytes16;
 import org.apache.tuweni.bytes.Bytes;
@@ -55,8 +56,8 @@ public class RlpUtils implements OperationSetModule<RlpUtilsCall> {
       new ModuleOperationStackedSet<>();
 
   @Override
-  public String moduleKey() {
-    return RLP_UTILS.toString();
+  public ModuleName moduleKey() {
+    return RLP_UTILS;
   }
 
   public RlpUtilsCall call(RlpUtilsCall call) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpaddr/RlpAddr.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlpaddr/RlpAddr.java
@@ -41,6 +41,7 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.limits.Keccak;
 import net.consensys.linea.zktracer.module.rlputilsOld.ByteCountAndPowerOutput;
@@ -72,8 +73,8 @@ public class RlpAddr implements OperationSetModule<RlpAddrOperation> {
   private final Keccak keccak;
 
   @Override
-  public String moduleKey() {
-    return RLP_ADDR.toString();
+  public ModuleName moduleKey() {
+    return RLP_ADDR;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/RlpTxn.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/RlpTxn.java
@@ -24,6 +24,7 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationListModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedList;
+import net.consensys.linea.zktracer.module.ModuleName;
 
 @Accessors(fluent = true)
 public abstract class RlpTxn implements OperationListModule<RlpTxnOperation> {
@@ -33,8 +34,8 @@ public abstract class RlpTxn implements OperationListModule<RlpTxnOperation> {
       new ModuleOperationStackedList<>();
 
   @Override
-  public String moduleKey() {
-    return RLP_TXN.toString();
+  public ModuleName moduleKey() {
+    return RLP_TXN;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxrcpt/RlpTxnRcpt.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxrcpt/RlpTxnRcpt.java
@@ -39,6 +39,7 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationListModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedList;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.rlputilsOld.ByteCountAndPowerOutput;
 import net.consensys.linea.zktracer.types.BitDecOutput;
 import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
@@ -61,8 +62,8 @@ public class RlpTxnRcpt implements OperationListModule<RlpTxrcptOperation> {
   private int absLogNum = 0;
 
   @Override
-  public String moduleKey() {
-    return RLP_TXN_RCPT.toString();
+  public ModuleName moduleKey() {
+    return RLP_TXN_RCPT;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rom/Rom.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rom/Rom.java
@@ -22,6 +22,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.Module;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.romlex.RomLex;
 import net.consensys.linea.zktracer.module.romlex.RomOperation;
 
@@ -30,8 +31,8 @@ public class Rom implements Module {
   private final RomLex romLex;
 
   @Override
-  public String moduleKey() {
-    return ROM.toString();
+  public ModuleName moduleKey() {
+    return ROM;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/RomLex.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/RomLex.java
@@ -31,6 +31,7 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.defer.ContextEntryDefer;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
@@ -62,8 +63,8 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
   @Getter private final DeferRegistry createDefers = new DeferRegistry();
 
   @Override
-  public String moduleKey() {
-    return ROM_LEX.toString();
+  public ModuleName moduleKey() {
+    return ROM_LEX;
   }
 
   public int getCodeFragmentIndexByMetadata(

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shakiradata/ShakiraData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shakiradata/ShakiraData.java
@@ -26,6 +26,7 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationListModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedList;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.limits.Keccak;
 import net.consensys.linea.zktracer.module.limits.precompiles.RipemdBlocks;
 import net.consensys.linea.zktracer.module.limits.precompiles.Sha256Blocks;
@@ -47,8 +48,8 @@ public class ShakiraData implements OperationListModule<ShakiraDataOperation> {
   private long previousID = 0;
 
   @Override
-  public String moduleKey() {
-    return SHAKIRA_DATA.toString();
+  public ModuleName moduleKey() {
+    return SHAKIRA_DATA;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Shf.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/shf/Shf.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.shf;
 
+import static net.consensys.linea.zktracer.module.ModuleName.SHF;
 import static net.consensys.linea.zktracer.opcode.OpCode.*;
 
 import java.util.List;
@@ -24,6 +25,7 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -36,8 +38,8 @@ public class Shf implements OperationSetModule<ShfOperation> {
       new ModuleOperationStackedSet<>();
 
   @Override
-  public String moduleKey() {
-    return "SHF";
+  public ModuleName moduleKey() {
+    return SHF;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/Stp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/stp/Stp.java
@@ -26,6 +26,7 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.hub.fragment.imc.StpCall;
 
 @RequiredArgsConstructor
@@ -46,8 +47,8 @@ public class Stp implements OperationSetModule<StpOperation> {
   }
 
   @Override
-  public String moduleKey() {
-    return STP.toString();
+  public ModuleName moduleKey() {
+    return STP;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/PowerRt.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/PowerRt.java
@@ -22,13 +22,14 @@ import java.util.List;
 
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.Module;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.types.Bytes16;
 import org.apache.tuweni.bytes.Bytes;
 
 public class PowerRt implements Module {
   @Override
-  public String moduleKey() {
-    return POWER_REFERENCE_TABLE.toString();
+  public ModuleName moduleKey() {
+    return POWER_REFERENCE_TABLE;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/bin/BinRt.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/bin/BinRt.java
@@ -15,18 +15,21 @@
 
 package net.consensys.linea.zktracer.module.tables.bin;
 
+import static net.consensys.linea.zktracer.module.ModuleName.BIN_REFERENCE_TABLE;
+
 import java.util.List;
 
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.Module;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.types.UnsignedByte;
 import org.apache.tuweni.bytes.Bytes;
 
 public class BinRt implements Module {
   @Override
-  public String moduleKey() {
-    return "BIN_REFERENCE_TABLE";
+  public ModuleName moduleKey() {
+    return BIN_REFERENCE_TABLE;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/bls/BlsRt.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/bls/BlsRt.java
@@ -27,11 +27,12 @@ import java.util.Map;
 import com.google.common.base.Preconditions;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.Module;
+import net.consensys.linea.zktracer.module.ModuleName;
 
 public class BlsRt implements Module {
   @Override
-  public String moduleKey() {
-    return BLS_REFERENCE_TABLE.toString();
+  public ModuleName moduleKey() {
+    return BLS_REFERENCE_TABLE;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/InstructionDecoder.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/tables/instructionDecoder/InstructionDecoder.java
@@ -15,10 +15,13 @@
 
 package net.consensys.linea.zktracer.module.tables.instructionDecoder;
 
+import static net.consensys.linea.zktracer.module.ModuleName.INSTRUCTION_DECODER;
+
 import java.util.List;
 
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.Module;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.opcode.InstructionFamily;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
 import net.consensys.linea.zktracer.opcode.OpCodes;
@@ -101,8 +104,8 @@ public abstract class InstructionDecoder implements Module {
   }
 
   @Override
-  public String moduleKey() {
-    return "INSTRUCTION_DECODER";
+  public ModuleName moduleKey() {
+    return INSTRUCTION_DECODER;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/trm/Trm.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/trm/Trm.java
@@ -26,7 +26,7 @@ import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
-import net.consensys.linea.zktracer.module.wcp.Wcp;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.types.EWord;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -37,17 +37,16 @@ import org.hyperledger.besu.datatypes.Address;
 @RequiredArgsConstructor
 public class Trm implements OperationSetModule<TrmOperation> {
   private final Fork fork;
-  private final Wcp wcp;
   private final ModuleOperationStackedSet<TrmOperation> operations =
       new ModuleOperationStackedSet<>();
 
   @Override
-  public String moduleKey() {
-    return TRM.toString();
+  public ModuleName moduleKey() {
+    return TRM;
   }
 
   public Address callTrimming(final Bytes32 rawAddress) {
-    operations.add(new TrmOperation(fork, EWord.of(rawAddress), wcp));
+    operations.add(new TrmOperation(fork, EWord.of(rawAddress)));
     return Address.extract(rawAddress);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/trm/TrmOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/trm/TrmOperation.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.trm;
 
+import static net.consensys.linea.zktracer.types.AddressUtils.highPart;
 import static net.consensys.linea.zktracer.types.AddressUtils.isPrecompile;
 
 import lombok.EqualsAndHashCode;
@@ -23,9 +24,7 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.ModuleOperation;
-import net.consensys.linea.zktracer.module.wcp.Wcp;
 import net.consensys.linea.zktracer.types.EWord;
-import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 
 @Accessors(fluent = true)
@@ -34,16 +33,15 @@ public class TrmOperation extends ModuleOperation {
   private final Fork fork;
   @EqualsAndHashCode.Include @Getter private final EWord rawAddress;
 
-  public TrmOperation(Fork fork, EWord rawAddress, Wcp wcp) {
+  public TrmOperation(Fork fork, EWord rawAddress) {
     this.fork = fork;
     this.rawAddress = rawAddress;
-    final Bytes trmAddress = rawAddress.toAddress();
   }
 
   void trace(Trace.Trm trace) {
     final Address trmAddress = rawAddress.toAddress();
     final boolean isPrec = isPrecompile(fork, trmAddress);
-    final long trmAddrHi = trmAddress.slice(0, 4).toLong();
+    final long trmAddrHi = highPart(trmAddress);
 
     trace.rawAddress(rawAddress).addressHi(trmAddrHi).isPrecompile(isPrec).validateRow();
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/TxnData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/TxnData.java
@@ -25,6 +25,7 @@ import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationListModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedList;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.module.euc.Euc;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.fragment.transaction.system.SystemTransactionType;
@@ -42,8 +43,8 @@ public abstract class TxnData<T extends TxnDataOperation> implements OperationLi
   @Getter private final Euc euc;
 
   @Override
-  public String moduleKey() {
-    return TXN_DATA.toString();
+  public ModuleName moduleKey() {
+    return TXN_DATA;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Wcp.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/wcp/Wcp.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.wcp;
 
+import static net.consensys.linea.zktracer.module.ModuleName.WCP;
 import static net.consensys.linea.zktracer.module.wcp.WcpOperation.EQbv;
 import static net.consensys.linea.zktracer.module.wcp.WcpOperation.GEQbv;
 import static net.consensys.linea.zktracer.module.wcp.WcpOperation.GTbv;
@@ -32,6 +33,7 @@ import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.Module;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
+import net.consensys.linea.zktracer.module.ModuleName;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -79,8 +81,8 @@ public class Wcp implements Module {
   public final CountOnlyOperation additionalRows = new CountOnlyOperation();
 
   @Override
-  public String moduleKey() {
-    return "WCP";
+  public ModuleName moduleKey() {
+    return WCP;
   }
 
   @Override

--- a/arithmetization/src/test/java/net/consensys/linea/LineCountingTracerTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/LineCountingTracerTest.java
@@ -32,7 +32,6 @@ import net.consensys.linea.zktracer.ChainConfig;
 import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.ZkCounter;
 import net.consensys.linea.zktracer.ZkTracer;
-import net.consensys.linea.zktracer.container.module.Module;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.evm.worldstate.WorldView;
 import org.junit.jupiter.api.Test;
@@ -43,11 +42,15 @@ public class LineCountingTracerTest extends TracerTestBase {
   void noDuplicateNamesInModules() {
     final ZkTracer tracer = new ZkTracer(chainConfig);
     final List<String> tracerToCount =
-        tracer.getModulesToCount().stream().map(Module::moduleKey).toList();
+        tracer.getModulesToCount().stream().map(module -> module.moduleKey().toString()).toList();
     final List<String> tracedModules =
-        tracer.getHub().getModulesToTrace().stream().map(Module::moduleKey).toList();
+        tracer.getHub().getModulesToTrace().stream()
+            .map(module -> module.moduleKey().toString())
+            .toList();
     final List<String> refTables =
-        tracer.getHub().refTableModules().stream().map(Module::moduleKey).toList();
+        tracer.getHub().refTableModules().stream()
+            .map(module -> module.moduleKey().toString())
+            .toList();
 
     // Check that all traced modules are counted or reference tables
     checkArgument(
@@ -62,7 +65,7 @@ public class LineCountingTracerTest extends TracerTestBase {
         "Duplicate has been found");
     final ZkCounter counter = new ZkCounter(chainConfig.bridgeConfiguration);
     final List<String> counterToCount =
-        counter.getModulesToCount().stream().map(Module::moduleKey).toList();
+        counter.getModulesToCount().stream().map(module -> module.moduleKey().toString()).toList();
     checkArgument(
         counterToCount.size() == counterToCount.stream().distinct().toList().size(),
         "Duplicate has been found");
@@ -72,7 +75,7 @@ public class LineCountingTracerTest extends TracerTestBase {
   void sameModuleAcrossAllForkWithZkCounterAndTracer() {
     final ZkCounter counter = new ZkCounter(chainConfig.bridgeConfiguration);
     final List<String> counterModules =
-        counter.getModulesToCount().stream().map(Module::moduleKey).toList();
+        counter.getModulesToCount().stream().map(module -> module.moduleKey().toString()).toList();
 
     for (Fork fork : Fork.values()) {
       if (forkNotSupported(fork)) {
@@ -81,7 +84,7 @@ public class LineCountingTracerTest extends TracerTestBase {
       final ChainConfig config = MAINNET_TESTCONFIG(fork);
       final ZkTracer tracer = new ZkTracer(config);
       final List<String> tracerModules =
-          tracer.getModulesToCount().stream().map(Module::moduleKey).toList();
+          tracer.getModulesToCount().stream().map(module -> module.moduleKey().toString()).toList();
 
       // check that counter ⊆ tracer(fork)
       for (String module : counterModules) {

--- a/testing/src/main/java/net/consensys/linea/testing/DynamicTests.java
+++ b/testing/src/main/java/net/consensys/linea/testing/DynamicTests.java
@@ -179,7 +179,10 @@ public class DynamicTests {
               String testName =
                   "[%s][%s] Test bytecode for opcode %s with opArgs %s"
                       .formatted(
-                          module.moduleKey().toUpperCase(), testCaseName, e.opCode(), e.args());
+                          module.moduleKey().toString().toUpperCase(),
+                          testCaseName,
+                          e.opCode(),
+                          e.args());
 
               return DynamicTest.dynamicTest(
                   testName,

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
@@ -37,7 +37,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.zktracer.ChainConfig;
 import net.consensys.linea.zktracer.ZkCounter;
 import net.consensys.linea.zktracer.ZkTracer;
-import net.consensys.linea.zktracer.container.module.Module;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import org.hyperledger.besu.datatypes.*;
 import org.hyperledger.besu.ethereum.core.*;
@@ -141,7 +140,9 @@ public class ToyExecutionEnvironmentV2 {
               copyEnvironment.zkCounter.getModulesLineCount();
 
           final List<String> moduleToCheck =
-              copyEnvironment.zkCounter.checkedModules().stream().map(Module::moduleKey).toList();
+              copyEnvironment.zkCounter.checkedModules().stream()
+                  .map(module -> module.moduleKey().toString())
+                  .toList();
 
           // There is no point to check for conflation where an excluded PRC has been triggered:
           if (lightCounterCount.get(POINT_EVAL.toString()) != 0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches module identifiers from String to ModuleName across the codebase, updates all modules/usages (including ZkTracer/ZkCounter, tests), extends ModuleName, simplifies OOB, and removes Wcp from TRM.
> 
> - **Core API**:
>   - Change `Module.moduleKey()` return type from `String` to `ModuleName`; update all implementations/usages.
>   - Use `m.moduleKey().toString()` where string keys are required (e.g., metadata, maps, tests).
> - **Enums**:
>   - Extend `ModuleName` with additional entries (e.g., `BIN`, `EUC`, `EXP`, `MUL`, `SHF`, `WCP`, `BIN_REFERENCE_TABLE`, `INSTRUCTION_DECODER`).
> - **Modules**:
>   - Update all modules to return `ModuleName` (e.g., `Add`, `Bin`, `Ext`, `Gas`, `Blockhash`, `Mmu`, `Rlp*`, `Rom*`, etc.).
>   - Refactor `Oob` to implement `OperationSetModule` (remove `additionalRows` and related commit logic).
>   - `Trm` no longer depends on `Wcp`; constructor and `TrmOperation` adjusted; use `AddressUtils.highPart`.
> - **Tracing/Counting**:
>   - `ZkTracer`/`ZkCounter`: line-count maps and metadata now use `moduleKey().toString()`.
> - **Tests/Utils**:
>   - Adjust tests and dynamic test names to use `moduleKey().toString()`; ensure no duplicate names checks align with new type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfe7a4c92ea360ceb447bb36c5c0137376e65b8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->