### PR TITLE
fix: access list can be empty for Cancun

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/cancun/CancunRlpTxnOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/cancun/CancunRlpTxnOperation.java
@@ -76,8 +76,7 @@ public class CancunRlpTxnOperation extends RlpTxnOperation {
     phaseSectionList.add(new DataPhaseSection(rlpUtils, tx));
 
     // Phase Access List
-    if (tx.getBesuTransaction().getType() != FRONTIER
-        && tx.getBesuTransaction().getAccessList().isPresent()) {
+    if (tx.getBesuTransaction().getType() != FRONTIER) {
       phaseSectionList.add(new AccessListPhaseSection(rlpUtils, trm, tx));
     }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/cancun/CancunRlpTxnOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/cancun/CancunRlpTxnOperation.java
@@ -76,7 +76,8 @@ public class CancunRlpTxnOperation extends RlpTxnOperation {
     phaseSectionList.add(new DataPhaseSection(rlpUtils, tx));
 
     // Phase Access List
-    if (tx.getBesuTransaction().getType() != FRONTIER) {
+    if (tx.getBesuTransaction().getType() != FRONTIER
+        && tx.getBesuTransaction().getAccessList().isPresent()) {
       phaseSectionList.add(new AccessListPhaseSection(rlpUtils, trm, tx));
     }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/cancun/phaseSection/AccessListPhaseSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/cancun/phaseSection/AccessListPhaseSection.java
@@ -49,7 +49,8 @@ public class AccessListPhaseSection extends PhaseSection {
   private static final short RLP_ADDRESS_BYTE_SIZE = 1 + Address.SIZE;
 
   public AccessListPhaseSection(RlpUtils rlpUtils, Trm trm, TransactionProcessingMetadata tx) {
-    final List<AccessListEntry> accessList = tx.getBesuTransaction().getAccessList().get();
+    final List<AccessListEntry> accessList =
+        tx.getBesuTransaction().getAccessList().orElse(List.of());
 
     final List<Short> accessListTupleSizes = new ArrayList<>(accessList.size());
     for (AccessListEntry entry : accessList) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use an empty list when a transaction's access list is absent, avoiding reliance on a present Optional.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea6269ee265dfec3f19a6d7eacb909922d87bf8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->