### PR TITLE
fix: unexpected cast too short

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/logdata/LogData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/logdata/LogData.java
@@ -15,8 +15,8 @@
 
 package net.consensys.linea.zktracer.module.logdata;
 
-import static net.consensys.linea.zktracer.Trace.LLARGE;
 import static net.consensys.linea.zktracer.module.ModuleName.LOG_DATA;
+import static net.consensys.linea.zktracer.types.Utils.fromDataSizeToLimbCtMax;
 import static net.consensys.linea.zktracer.types.Utils.rightPadTo;
 
 import java.util.List;
@@ -84,8 +84,8 @@ public class LogData implements Module {
     }
   }
 
-  private static short indexMax(Log log) {
-    return log.getData().isEmpty() ? 0 : (short) ((log.getData().size() - 1) / LLARGE);
+  private static int indexMax(Log log) {
+    return log.getData().isEmpty() ? 0 : fromDataSizeToLimbCtMax(log.getData().size());
   }
 
   @Override


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors `indexMax` in `LogData` to return `int` and compute via `Utils.fromDataSizeToLimbCtMax`, replacing short cast and `LLARGE` division.
> 
> - **LogData module (`LogData.java`)**:
>   - Refactors `indexMax` to return `int` and compute via `Utils.fromDataSizeToLimbCtMax`, replacing short cast and `LLARGE`-based division.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78fd3ac831ddcaddeb23a54a902dfb9cc7218193. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->