### PR TITLE
feat: set Paris as zkevm fork as merge is handled in toPascalCase method

### DIFF
--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/reusable-blockchain-tests.yml
     secrets: inherit
     with:
-      zkevm_fork: London
+      zkevm_fork: LONDON
       test_filter: ${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}
       failed_module: ${{ inputs.failed_module || '' }}
       failed_constraint: ${{ inputs.failed_constraint || '' }}
@@ -44,7 +44,7 @@ jobs:
     uses: ./.github/workflows/reusable-blockchain-tests.yml
     secrets: inherit
     with:
-      zkevm_fork: Merge
+      zkevm_fork: PARIS
       test_filter: ${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}
       failed_module: ${{ inputs.failed_module || '' }}
       failed_constraint: ${{ inputs.failed_constraint || '' }}
@@ -54,7 +54,7 @@ jobs:
     uses: ./.github/workflows/reusable-blockchain-tests.yml
     secrets: inherit
     with:
-      zkevm_fork: Shanghai
+      zkevm_fork: SHANGHAI
       test_filter: ${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}
       failed_module: ${{ inputs.failed_module || '' }}
       failed_constraint: ${{ inputs.failed_constraint || '' }}
@@ -64,7 +64,7 @@ jobs:
     uses: ./.github/workflows/reusable-blockchain-tests.yml
     secrets: inherit
     with:
-      zkevm_fork: Cancun
+      zkevm_fork: CANCUN
       test_filter: ${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}
       failed_module: ${{ inputs.failed_module || '' }}
       failed_constraint: ${{ inputs.failed_constraint || '' }}
@@ -74,7 +74,7 @@ jobs:
     uses: ./.github/workflows/reusable-blockchain-tests.yml
     secrets: inherit
     with:
-      zkevm_fork: Prague
+      zkevm_fork: PRAGUE
       test_filter: ${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}
       failed_module: ${{ inputs.failed_module || '' }}
       failed_constraint: ${{ inputs.failed_constraint || '' }}

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/Fork.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/Fork.java
@@ -187,6 +187,7 @@ public enum Fork {
     };
   }
 
+  // Used for blockchain ref tests with the Paris exception of "Merge"
   public static String toPascalCase(Fork fork) {
     return switch (fork) {
       case LONDON -> "London";

--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -20,8 +20,7 @@ import static net.consensys.linea.BlockchainReferenceTestJson.readBlockchainRefe
 import static net.consensys.linea.ReferenceTestOutcomeRecorderTool.JSON_INPUT_FILENAME;
 import static net.consensys.linea.reporting.TracerTestBase.getForkOrDefault;
 import static net.consensys.linea.testing.ToyExecutionTools.addSystemAccountsIfRequired;
-import static net.consensys.linea.zktracer.Fork.LONDON;
-import static net.consensys.linea.zktracer.Fork.toPascalCase;
+import static net.consensys.linea.zktracer.Fork.*;
 import static net.consensys.linea.zktracer.container.module.IncrementAndDetectModule.ERROR_MESSAGE_TRIED_TO_COMMIT_UNPROVABLE_TX;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -584,7 +583,6 @@ public class BlockchainReferenceTestTools {
 
     final ProtocolSchedule schedule =
         REFERENCE_TEST_PROTOCOL_SCHEDULES.getByName(spec.getNetwork());
-    final Fork fork = getForkFromNetwork(spec.getNetwork());
     final ChainConfig chain = ChainConfig.ETHEREUM_CHAIN(fork);
     final MutableBlockchain blockchain = spec.getBlockchain();
     final ProtocolContext context = spec.getProtocolContext();
@@ -683,12 +681,5 @@ public class BlockchainReferenceTestTools {
             corsetBlockProcessor);
 
     return new MainnetBlockImporter(blockValidator);
-  }
-
-  private static Fork getForkFromNetwork(String string) {
-    if (string.equals("Merge")) {
-      return Fork.PARIS;
-    }
-    return Fork.fromString(string);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes fork names to uppercase enum values (using PARIS instead of Merge) across CI and tests, with toPascalCase mapping PARIS -> "Merge" for reference tests.
> 
> - **CI**:
>   - Update `zkevm_fork` values in `.github/workflows/reference-blockchain-tests.yml` to uppercase enum names: `LONDON`, `PARIS` (replacing `Merge`), `SHANGHAI`, `CANCUN`, `PRAGUE`.
> - **Core**:
>   - `Fork.toPascalCase` used for reference tests; note added about Paris being represented as "Merge".
> - **Tests**:
>   - `BlockchainReferenceTestTools`: use class-level `fork` (configured via `getForkOrDefault(LONDON)`) instead of deriving from `spec.getNetwork()`; remove `getForkFromNetwork` helper; simplify static imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 787f9afb5d3eab916cb6c0cb161b7bc26272d4ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->