### PR TITLE
fix: account for BEACON_ROOTS_ADDRESS access

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/Fork.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/Fork.java
@@ -187,6 +187,22 @@ public enum Fork {
     };
   }
 
+  /**
+   * Return the number of contract addresses seen by the system transaction during execution. This
+   * is primary to testing purposes to ensure the right number were seen.
+   *
+   * @param fork
+   * @return
+   */
+  public static int numberOfAddressesSeenBySystemTransaction(Fork fork) {
+    return switch (fork) {
+      case LONDON, PARIS, SHANGHAI -> 0;
+      case CANCUN -> 1;
+      case PRAGUE -> 2;
+      default -> throw new IllegalArgumentException("Unknown fork: " + fork);
+    };
+  }
+
   // Used for blockchain ref tests with the Paris exception of "Merge"
   public static String toPascalCase(Fork fork) {
     return switch (fork) {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/HubShomeiTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/HubShomeiTests.java
@@ -17,8 +17,6 @@ package net.consensys.linea.zktracer.statemanager;
 
 import static net.consensys.linea.testing.BytecodeCompiler.newProgram;
 import static net.consensys.linea.testing.ToyExecutionEnvironmentV2.DEFAULT_COINBASE_ADDRESS;
-import static net.consensys.linea.zktracer.Fork.isPostCancun;
-import static net.consensys.linea.zktracer.module.hub.section.systemTransaction.EIP4788BeaconBlockRootSection.EIP4788_BEACONROOT_ADDRESS;
 
 import java.util.List;
 import java.util.Map;
@@ -30,6 +28,7 @@ import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.ToyTransaction;
 import net.consensys.linea.zktracer.ChainConfig;
+import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.ZkTracer;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
@@ -129,12 +128,7 @@ public class HubShomeiTests extends TracerTestBase {
     final Set<Address> addressSeen = tracer.getAddressesSeenByHubForRelativeBlock(1);
     final Map<Address, Set<Bytes32>> storageSeen = tracer.getStoragesSeenByHubForRelativeBlock(1);
 
-    if (isPostCancun(fork)) {
-      assert (addressSeen.size() == 5);
-      assert (addressSeen.contains(EIP4788_BEACONROOT_ADDRESS));
-    } else {
-      assert (addressSeen.size() == 4);
-    }
+    assert (addressSeen.size() == 4 + Fork.numberOfAddressesSeenBySystemTransaction(fork));
     assert (addressSeen.contains(senderAddress));
     assert (addressSeen.contains(recipientAccount.getAddress()));
     assert (addressSeen.contains(DEFAULT_COINBASE_ADDRESS));
@@ -189,12 +183,7 @@ public class HubShomeiTests extends TracerTestBase {
     final Set<Address> addressSeen = tracer.getAddressesSeenByHubForRelativeBlock(1);
     final Map<Address, Set<Bytes32>> storageSeen = tracer.getStoragesSeenByHubForRelativeBlock(1);
 
-    if (isPostCancun(fork)) {
-      assert (addressSeen.size() == 4);
-      assert (addressSeen.contains(EIP4788_BEACONROOT_ADDRESS));
-    } else {
-      assert (addressSeen.size() == 3);
-    }
+    assert (addressSeen.size() == 3 + Fork.numberOfAddressesSeenBySystemTransaction(fork));
     assert (addressSeen.contains(senderAddress));
     assert (addressSeen.contains(recipientAccount.getAddress()));
     assert (addressSeen.contains(DEFAULT_COINBASE_ADDRESS));

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/HubShomeiTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/statemanager/HubShomeiTests.java
@@ -17,6 +17,8 @@ package net.consensys.linea.zktracer.statemanager;
 
 import static net.consensys.linea.testing.BytecodeCompiler.newProgram;
 import static net.consensys.linea.testing.ToyExecutionEnvironmentV2.DEFAULT_COINBASE_ADDRESS;
+import static net.consensys.linea.zktracer.Fork.isPostCancun;
+import static net.consensys.linea.zktracer.module.hub.section.systemTransaction.EIP4788BeaconBlockRootSection.EIP4788_BEACONROOT_ADDRESS;
 
 import java.util.List;
 import java.util.Map;
@@ -127,7 +129,12 @@ public class HubShomeiTests extends TracerTestBase {
     final Set<Address> addressSeen = tracer.getAddressesSeenByHubForRelativeBlock(1);
     final Map<Address, Set<Bytes32>> storageSeen = tracer.getStoragesSeenByHubForRelativeBlock(1);
 
-    assert (addressSeen.size() == 4);
+    if (isPostCancun(fork)) {
+      assert (addressSeen.size() == 5);
+      assert (addressSeen.contains(EIP4788_BEACONROOT_ADDRESS));
+    } else {
+      assert (addressSeen.size() == 4);
+    }
     assert (addressSeen.contains(senderAddress));
     assert (addressSeen.contains(recipientAccount.getAddress()));
     assert (addressSeen.contains(DEFAULT_COINBASE_ADDRESS));
@@ -182,7 +189,12 @@ public class HubShomeiTests extends TracerTestBase {
     final Set<Address> addressSeen = tracer.getAddressesSeenByHubForRelativeBlock(1);
     final Map<Address, Set<Bytes32>> storageSeen = tracer.getStoragesSeenByHubForRelativeBlock(1);
 
-    assert (addressSeen.size() == 3);
+    if (isPostCancun(fork)) {
+      assert (addressSeen.size() == 4);
+      assert (addressSeen.contains(EIP4788_BEACONROOT_ADDRESS));
+    } else {
+      assert (addressSeen.size() == 3);
+    }
     assert (addressSeen.contains(senderAddress));
     assert (addressSeen.contains(recipientAccount.getAddress()));
     assert (addressSeen.contains(DEFAULT_COINBASE_ADDRESS));


### PR DESCRIPTION
It seems that, post CANCUN, both SSTORE and SLOAD invoke the system transaction and that this results in the BEACON_ROOTS_ADDRESS being accessed.  The existing tests did not account for this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add fork-aware helper for system-transaction address count and adjust HubShomei tests to include it.
> 
> - **Core**:
>   - Add `Fork.numberOfAddressesSeenBySystemTransaction(fork)` returning fork-specific counts (`0` pre-Cancun, `1` Cancun, `2` Prague).
> - **Tests**:
>   - Update `HubShomeiTests` to import `Fork` and adjust `addressSeen.size()` assertions to include `Fork.numberOfAddressesSeenBySystemTransaction(fork)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32f11a392eef9f98c5c4151285d1dd704461f836. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->