### PR TITLE
fix: loosen requirements to count EcData.callEcData()

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
@@ -695,7 +695,7 @@ public class ZkCounter implements LineCountingTracer {
     switch (precompile) {
       case PRC_ECRECOVER, PRC_ECADD, PRC_ECMUL -> {
         // trigger EcData to count the underlying EC operations
-        if (prcSuccess && callDataSize != 0) {
+        if (callDataSize != 0) {
           // Note: we can't know the id (and we don't care)
           ecdata.callEcData(0, precompile, frame.getInputData(), returnData);
         }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/moduleOperation/CancunMxpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mxp/moduleOperation/CancunMxpOperation.java
@@ -40,8 +40,24 @@ public class CancunMxpOperation extends MxpOperation {
     this.cancunMxpCall = (CancunMxpCall) mxpCall;
   }
 
-  public static short MXP_FROM_CTMAX_TO_LINECOUNT =
-      4; // 3 for decoder, macro and scenario rows + 1 for computation row (from ctMax to nRow)
+  /**
+   * {@link CancunMxpOperation#MXP_FROM_CTMAX_TO_LINECOUNT} is used to convert <b>ctMax</b>, which
+   * accounts only for computation rows, to the full line count of the MXP instruction, i.e. number
+   * of rows of MXP instruction as a whole.
+   *
+   * <p>The conversion is
+   *
+   * <pre> nRows = ctMax + {@link CancunMxpOperation#MXP_FROM_CTMAX_TO_LINECOUNT} </pre>
+   *
+   * <p>{@link CancunMxpOperation#MXP_FROM_CTMAX_TO_LINECOUNT} is the sum of the following
+   * components:
+   *
+   * <ul>
+   *   <li>3 ≡ 1 decoder row + 1 macro row + 1 scenario row
+   *   <li>1 ≡ to convert <b>ctMax</b> (of computation rows) to "<b>nComputationRows</b>"
+   * </ul>
+   */
+  public static short MXP_FROM_CTMAX_TO_LINECOUNT = 4;
 
   @Override
   protected int computeLineCount() {


### PR DESCRIPTION
This loosens the requirements for counting an `EcData.callEcData()` call for the ECRECOVER, ECADD and ECMUL cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Count EC precompile `EcData` calls on any non-empty input (regardless of success) and document MXP ctMax-to-line-count conversion.
> 
> - **zktracer**:
>   - `ZkCounter.tracePrecompileCall`: invoke `EcData.callEcData(...)` for `PRC_ECRECOVER`, `PRC_ECADD`, `PRC_ECMUL` whenever call data is non-empty (no longer requires `COMPLETED_SUCCESS`).
> - **Docs**:
>   - Add detailed Javadoc explaining `CancunMxpOperation.MXP_FROM_CTMAX_TO_LINECOUNT` and its role in converting `ctMax` to full MXP line count.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90b6c546b0ab8003eb9d83fc688157276ee533b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->