### PR TITLE
Update Ethereum Foundation tests for Prague

### DIFF
--- a/.github/workflows/reusable-blockchain-tests.yml
+++ b/.github/workflows/reusable-blockchain-tests.yml
@@ -59,7 +59,7 @@ jobs:
         run: mv ${{ github.workspace }}/tmp/${{ steps.extract_branch.outputs.branch }}/failedBlockchainReferenceTests.json ${{ github.workspace }}/tmp/${{ steps.extract_branch.outputs.branch }}/failedBlockchainReferenceTests-input.json
 
       - name: Run reference blockchain tests
-        run: GOMAXPROCS=10 GOMEMLIMIT=20GiB ./gradlew referenceBlockchainTests -x spotlessCheck --tests "${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}"
+        run: GOMAXPROCS=10 GOMEMLIMIT=20GiB ./gradlew referenceBlockchainTests -x spotlessCheck --tests "${{ inputs.test_filter || 'ExecutionSpecBlockchainTest_*' }}"
         timeout-minutes: 360
         env:
           REFERENCE_TESTS_PARALLELISM: 3

--- a/.github/workflows/reusable-blockchain-tests.yml
+++ b/.github/workflows/reusable-blockchain-tests.yml
@@ -9,7 +9,7 @@ on:
       test_filter:
         required: false
         type: string
-        default: "BlockchainReferenceTest_*"
+        default: "ExecutionSpecBlockchainTest_*"
       failed_module:
         required: false
         type: string

--- a/.github/workflows/reusable-blockchain-tests.yml
+++ b/.github/workflows/reusable-blockchain-tests.yml
@@ -40,7 +40,7 @@ jobs:
         uses: ./.github/actions/setup-environment
 
       - name: Generate block chain reference tests
-        run: ./gradlew :reference-tests:generateBlockchainReferenceTests -Dorg.gradle.caching=true
+        run: ./gradlew :reference-tests:generateExecutionSpecTests -Dorg.gradle.caching=true
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,23 @@ plugins {
   id "org.sonarqube" version "4.3.1.3277"
 }
 
+repositories {
+  // ethereum execution spec tests fixtures. Exclusively for ethereum submodule to run ref tests
+  def ethExecSpecTestsRepo = ivy {
+    url = 'https://github.com'
+    patternLayout {
+      artifact '/[organisation]/[module]/releases/download/v[revision]/[classifier].[ext]'
+    }
+    metadataSources {
+      artifact()
+    }
+  }
+  exclusiveContent {
+    forRepositories(ethExecSpecTestsRepo)
+    filter { includeModule('reference-tests', 'execution-spec-tests')}
+  }
+}
+
 sonar {
   def tests = System.getProperty("tests")
   def xmlTestReport = ""

--- a/reference-tests/build.gradle
+++ b/reference-tests/build.gradle
@@ -67,7 +67,6 @@ tasks.register("generateExecutionSpecTests", RefTestGenerationTask) {
 tasks.register('referenceBlockchainTests', Test) {
   finalizedBy(jacocoReferenceBlockchainTestsReport)
   description = 'Runs ETH reference blockchain tests.'
-  dependsOn generateBlockchainReferenceTests
   dependsOn generateExecutionSpecTests
   environment.put("REFERENCE_TEST_OUTCOME_OUTPUT_FILE", "BlockchainReferenceTestOutcome.json")
 

--- a/reference-tests/build.gradle
+++ b/reference-tests/build.gradle
@@ -44,10 +44,31 @@ tasks.register("generateBlockchainReferenceTests", RefTestGenerationTask) {
   failedConstraint = System.getenv('FAILED_CONSTRAINT') ?: ""
 }
 
+tasks.register("generateExecutionSpecTests", RefTestGenerationTask) {
+/*  def tarPath = configurations.tarConfig.files.find{ it.name.startsWith('execution-spec-tests')}
+    if (tarPath == null) {
+        throw new GradleException("Could not find execution-spec-tests tarball in configurations.tarConfig. Ensure you have run 'gradle :reference-tests:dependencies' to download it.")
+    }*/
+  copy {
+    from tarTree("fixtures_develop.tar.gz")
+    into "$buildDir/execution-spec-tests"
+  }
+  refTestTemplateFilePath = "src/test/resources/templates/BlockchainReferenceTest.java.template"
+  refTests = "$buildDir/execution-spec-tests/fixtures/blockchain_tests"
+  refTestJsonParamsDirectory = "fixtures"
+  refTestJsonParamsExcludedPath = "" // exclude test for test filling tool
+  refTestNamePrefix = "ExecutionSpecBlockchainTest"
+  generatedRefTestsOutput = "src/test/java/net/consensys/linea/generated/blockchain"
+  failedTestsFilePath = System.getenv('FAILED_TEST_JSON_DIRECTORY') ?: "../tmp/local/"
+  failedModule = System.getenv('FAILED_MODULE') ?: ""
+  failedConstraint = System.getenv('FAILED_CONSTRAINT') ?: ""
+}
+
 tasks.register('referenceBlockchainTests', Test) {
   finalizedBy(jacocoReferenceBlockchainTestsReport)
   description = 'Runs ETH reference blockchain tests.'
   dependsOn generateBlockchainReferenceTests
+  dependsOn generateExecutionSpecTests
   environment.put("REFERENCE_TEST_OUTCOME_OUTPUT_FILE", "BlockchainReferenceTestOutcome.json")
 
   it.configure {
@@ -100,9 +121,19 @@ dependencies {
 
   testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
   testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
+  // testImplementation 'ethereum:execution-spec-tests:4.5.0:fixtures_develop@tar.gz'
 
   implementation project(":arithmetization")
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   implementation project(path: ':testing')
   implementation 'org.junit.platform:junit-platform-launcher'
+}
+
+configurations {
+  // we need this because referenceTestImplementation defaults to 'canBeResolved=false'.
+  tarConfig.extendsFrom testImplementation
+  tarConfig {
+    canBeResolved = true
+    canBeConsumed = false
+  }
 }

--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -87,6 +87,16 @@ public class BlockchainReferenceTestTools {
     if (NETWORKS_TO_RUN.isEmpty()) {
       PARAMS.ignoreAll();
     }
+    // ignore for v1.0 Prague release
+    PARAMS.ignore("/prague/eip6110_deposits/");
+    PARAMS.ignore("/prague/eip7002_el_triggerable_withdrawals/");
+    PARAMS.ignore("/prague/eip7251_consolidations/");
+    PARAMS.ignore("/prague/eip7685_general_purpose_el_requests/");
+
+    // TODO: should be re-enabled for Prague v2.0
+    PARAMS.ignore("/prague/eip2537_bls_12_381_precompiles/");
+    PARAMS.ignore("/prague/eip7702_set_code_tx/");
+
     // ignore tests that are failing in Besu too
     PARAMS.ignore("RevertInCreateInInitCreate2_d0g0v0_*");
     PARAMS.ignore("RevertInCreateInInit_d0g0v0_*");

--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -87,24 +87,40 @@ public class BlockchainReferenceTestTools {
     if (NETWORKS_TO_RUN.isEmpty()) {
       PARAMS.ignoreAll();
     }
+    // TODO: should be re-enabled for Prague v2.0
+    PARAMS.ignore("/prague/eip2537_bls_12_381_precompiles/");
+    PARAMS.ignore("/prague/eip7702_set_code_tx/");
+
     // ignore type 3 and 4 transactions
     PARAMS.ignore(
-        "prague/eip7623_increase_calldata_cost/test_transaction_validity/transaction_validity_type_3.json");
+        "prague/eip7623_increase_calldata_cost/test_transaction_validity.py::test_transaction_validity_type_3");
     PARAMS.ignore(
-        "prague/eip7623_increase_calldata_cost/test_transaction_validity/transaction_validity_type_4.json");
+        "prague/eip7623_increase_calldata_cost/test_transaction_validity.py::test_transaction_validity_type_4");
     PARAMS.ignore(
-        "/cancun/eip4788_beacon_root/test_beacon_root_contract/tx_to_beacon_root_contract\\[fork_Prague-tx_type_3.*");
+        "/cancun/eip4788_beacon_root/test_beacon_root_contract.py::test_tx_to_beacon_root_contract\\[fork_Prague-tx_type_3-blockchain_test-call_beacon_root_contract_True-auto_access_list_\\w+");
+    PARAMS.ignore(
+        "prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumption::test_full_gas_consumption\\[fork_Prague-blockchain_test_from_state_test-exact_gas-type_3\\w+");
+    PARAMS.ignore(
+        "prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumption::test_full_gas_consumption\\[fork_Prague-blockchain_test_from_state_test-exact_gas-type_4\\w+");
+    PARAMS.ignore(
+        "prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumption::test_full_gas_consumption\\[fork_Prague-blockchain_test_from_state_test-extra_gas-type_3\\w+");
+    PARAMS.ignore(
+        "prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumption::test_full_gas_consumption\\[fork_Prague-blockchain_test_from_state_test-extra_gas-type_4\\w+");
+    PARAMS.ignore(
+        "prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumptionBelowDataFloor::test_gas_consumption_below_data_floor\\[fork_Prague-blockchain_test_from_state_test-exact_gas-type_3\\w+");
+    PARAMS.ignore(
+        "prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumptionBelowDataFloor::test_gas_consumption_below_data_floor\\[fork_Prague-blockchain_test_from_state_test-exact_gas-type_4\\w+");
+    PARAMS.ignore(
+        "tests/cancun/eip4788_beacon_root/test_beacon_root_contract.py::test_tx_to_beacon_root_contract\\[fork_Prague-tx_type_3-blockchain_test-call_beacon_root_contract_True-auto_access_list_\\w+");
 
     // ignore for v1.0 Prague release
     PARAMS.ignore("/cancun/eip4844_blobs/");
     PARAMS.ignore("/prague/eip6110_deposits/");
-    PARAMS.ignore("/prague/eip7002_el_triggerable_withdrawals/");
     PARAMS.ignore("/prague/eip7251_consolidations/");
     PARAMS.ignore("/prague/eip7685_general_purpose_el_requests/");
-
-    // TODO: should be re-enabled for Prague v2.0
-    PARAMS.ignore("/prague/eip2537_bls_12_381_precompiles/");
-    PARAMS.ignore("/prague/eip7702_set_code_tx/");
+    // withdrawals
+    PARAMS.ignore("/prague/eip7002_el_triggerable_withdrawals/");
+    PARAMS.ignore("/prague/eip7002_el_triggerable_withdrawals_and_transfers/");
 
     // ignore tests that are failing in Besu too
     PARAMS.ignore("RevertInCreateInInitCreate2_d0g0v0_*");

--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -99,20 +99,17 @@ public class BlockchainReferenceTestTools {
     PARAMS.ignore(
         "/cancun/eip4788_beacon_root/test_beacon_root_contract.py::test_tx_to_beacon_root_contract\\[fork_Prague-tx_type_3-blockchain_test-call_beacon_root_contract_True-auto_access_list_\\w+");
     PARAMS.ignore(
-        "prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumption::test_full_gas_consumption\\[fork_Prague-blockchain_test_from_state_test-exact_gas-type_3\\w+");
+        "/prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumption::test_full_gas_consumption\\[fork_Prague-blockchain_test_from_state_test-exact_gas-type_3");
     PARAMS.ignore(
-        "prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumption::test_full_gas_consumption\\[fork_Prague-blockchain_test_from_state_test-exact_gas-type_4\\w+");
+        "/prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumption::test_full_gas_consumption\\[fork_Prague-blockchain_test_from_state_test-exact_gas-type_4");
     PARAMS.ignore(
-        "prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumption::test_full_gas_consumption\\[fork_Prague-blockchain_test_from_state_test-extra_gas-type_3\\w+");
+        "/prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumption::test_full_gas_consumption\\[fork_Prague-blockchain_test_from_state_test-extra_gas-type_3");
     PARAMS.ignore(
-        "prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumption::test_full_gas_consumption\\[fork_Prague-blockchain_test_from_state_test-extra_gas-type_4\\w+");
+        "/prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumption::test_full_gas_consumption\\[fork_Prague-blockchain_test_from_state_test-extra_gas-type_4");
     PARAMS.ignore(
-        "prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumptionBelowDataFloor::test_gas_consumption_below_data_floor\\[fork_Prague-blockchain_test_from_state_test-exact_gas-type_3\\w+");
+        "/prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumptionBelowDataFloor::test_gas_consumption_below_data_floor\\[fork_Prague-blockchain_test_from_state_test-exact_gas-type_3");
     PARAMS.ignore(
-        "prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumptionBelowDataFloor::test_gas_consumption_below_data_floor\\[fork_Prague-blockchain_test_from_state_test-exact_gas-type_4\\w+");
-    PARAMS.ignore(
-        "tests/cancun/eip4788_beacon_root/test_beacon_root_contract.py::test_tx_to_beacon_root_contract\\[fork_Prague-tx_type_3-blockchain_test-call_beacon_root_contract_True-auto_access_list_\\w+");
-
+        "/prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumptionBelowDataFloor::test_gas_consumption_below_data_floor\\[fork_Prague-blockchain_test_from_state_test-exact_gas-type_4");
     // ignore for v1.0 Prague release
     PARAMS.ignore("/cancun/eip4844_blobs/");
     PARAMS.ignore("/prague/eip6110_deposits/");
@@ -122,7 +119,9 @@ public class BlockchainReferenceTestTools {
     PARAMS.ignore("/prague/eip7002_el_triggerable_withdrawals/");
     PARAMS.ignore("/prague/eip7002_el_triggerable_withdrawals_and_transfers/");
     PARAMS.ignore(
-        "/cancun/eip4788_beacon_root/test_beacon_root_contract.py::test_multi_block_beacon_root_timestamp_calls");
+        "cancun/eip4788_beacon_root/test_beacon_root_contract.py::test_multi_block_beacon_root_timestamp_calls");
+    PARAMS.ignore("shanghai/eip4895_withdrawals/test_withdrawals.py::test_balance_within_block");
+    PARAMS.ignore("shanghai/eip4895_withdrawals/test_withdrawals.py::test_use_value_in_contract");
 
     // ignore tests that are failing in Besu too
     PARAMS.ignore("RevertInCreateInInitCreate2_d0g0v0_*");

--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -87,6 +87,14 @@ public class BlockchainReferenceTestTools {
     if (NETWORKS_TO_RUN.isEmpty()) {
       PARAMS.ignoreAll();
     }
+    // ignore type 3 and 4 transactions
+    PARAMS.ignore(
+        "prague/eip7623_increase_calldata_cost/test_transaction_validity/transaction_validity_type_3.json");
+    PARAMS.ignore(
+        "prague/eip7623_increase_calldata_cost/test_transaction_validity/transaction_validity_type_4.json");
+    PARAMS.ignore(
+        "/cancun/eip4788_beacon_root/test_beacon_root_contract/tx_to_beacon_root_contract\\[fork_Prague-tx_type_3.*");
+
     // ignore for v1.0 Prague release
     PARAMS.ignore("/cancun/eip4844_blobs/");
     PARAMS.ignore("/prague/eip6110_deposits/");

--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -88,6 +88,7 @@ public class BlockchainReferenceTestTools {
       PARAMS.ignoreAll();
     }
     // ignore for v1.0 Prague release
+    PARAMS.ignore("/cancun/eip4844_blobs/");
     PARAMS.ignore("/prague/eip6110_deposits/");
     PARAMS.ignore("/prague/eip7002_el_triggerable_withdrawals/");
     PARAMS.ignore("/prague/eip7251_consolidations/");

--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -121,6 +121,8 @@ public class BlockchainReferenceTestTools {
     // withdrawals
     PARAMS.ignore("/prague/eip7002_el_triggerable_withdrawals/");
     PARAMS.ignore("/prague/eip7002_el_triggerable_withdrawals_and_transfers/");
+    PARAMS.ignore(
+        "/cancun/eip4788_beacon_root/test_beacon_root_contract.py::test_multi_block_beacon_root_timestamp_calls");
 
     // ignore tests that are failing in Besu too
     PARAMS.ignore("RevertInCreateInInitCreate2_d0g0v0_*");

--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -535,7 +535,7 @@ public class BlockchainReferenceTestTools {
     Arrays.stream(filePath).forEach(f -> log.info("checking file: {}", f));
     return PARAMS.generate(
         Arrays.stream(filePath)
-            .map(f -> Paths.get("src/test/resources/ethereum-tests/" + f).toFile())
+            .map(f -> Paths.get("build/execution-spec-tests/" + f).toFile())
             .toList());
   }
 
@@ -546,7 +546,7 @@ public class BlockchainReferenceTestTools {
     Collection<Object[]> params =
         PARAMS.generate(
             Arrays.stream(filePath)
-                .map(f -> Paths.get("src/test/resources/ethereum-tests/" + f).toFile())
+                .map(f -> Paths.get("build/execution-spec-tests/" + f).toFile())
                 .toList());
 
     return getRecordedFailedTestsFromJson(failedModule, failedConstraint)


### PR DESCRIPTION
This cannot be merged at all - it's WIP :) 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches blockchain reference tests to Ethereum Execution Spec fixtures, updates CI and paths, and adds targeted Prague/Cancun test ignores.
> 
> - **Tests**:
>   - **Execution Spec migration**: Add `generateExecutionSpecTests` to unpack `fixtures_develop.tar.gz` into `build/execution-spec-tests` and generate `ExecutionSpecBlockchainTest_*` classes; make `referenceBlockchainTests` depend on it.
>   - **Paths**: Update `BlockchainReferenceTestTools` to read fixtures from `build/execution-spec-tests/...` instead of `src/test/resources/ethereum-tests/...`.
>   - **Ignores**: Add/adjust ignores for Prague EIPs (e.g., `eip2537`, `eip7702`), type 3/4 txs, withdrawals, Cancun blob-related cases, and other heavy/unsupported tests.
>   - **Configs**: Introduce `tarConfig` to resolve tar artifacts (commented example dependency included).
> - **CI**:
>   - Update `.github/workflows/reusable-blockchain-tests.yml` to generate execution spec tests and run `ExecutionSpecBlockchainTest_*` by default.
> - **Build**:
>   - Add Ivy repo with `exclusiveContent` for `reference-tests:execution-spec-tests` artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1115c89eafe4c75e7bfc82d39442d9c54ac5ff28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->