### PR TITLE
feat: expose fork method to external

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/Fork.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/Fork.java
@@ -109,7 +109,7 @@ public enum Fork {
    * @param hardForkId the hardfork id retrieved from Besu API
    * @return Fork
    */
-  private static Fork fromMainnetHardforkId(MainnetHardforkId hardForkId) {
+  public static Fork fromMainnetHardforkIdToTracerFork(MainnetHardforkId hardForkId) {
     return switch (hardForkId) {
       case MainnetHardforkId.LONDON -> LONDON;
       case MainnetHardforkId.PARIS -> PARIS;
@@ -117,7 +117,8 @@ public enum Fork {
       case MainnetHardforkId.CANCUN -> CANCUN;
       case MainnetHardforkId.PRAGUE -> PRAGUE;
       case MainnetHardforkId.OSAKA -> OSAKA;
-      default -> throw new IllegalArgumentException("Unknown hardfork id: " + hardForkId);
+      default -> throw new IllegalArgumentException(
+          "Fork not supported by the tracer: " + hardForkId);
     };
   }
 
@@ -152,7 +153,7 @@ public enum Fork {
                 + toBlock);
       }
     }
-    return fromMainnetHardforkId((MainnetHardforkId) forkStart);
+    return fromMainnetHardforkIdToTracerFork((MainnetHardforkId) forkStart);
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make the Besu `MainnetHardforkId`→`Fork` mapper public with a new name and updated error, and switch internal calls to use it.
> 
> - **zktracer**:
>   - Expose fork mapper: rename `fromMainnetHardforkId` (private) to public `fromMainnetHardforkIdToTracerFork` in `arithmetization/src/main/java/net/consensys/linea/zktracer/Fork.java`.
>     - Update default-case error to: `Fork not supported by the tracer: ...`.
>     - Replace internal call in `getForkFromBesuBlockchainService(long, long)` to use `fromMainnetHardforkIdToTracerFork`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9674690e4f2a780f318a4cc3383bde3c8cd7316d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->