### PR TITLE
Feat: log at trace level the exceptions collected during tracing

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -146,7 +146,7 @@ public class ZkTracer implements LineCountingTracer {
       hub.traceStartConflation(numBlocksInConflation);
       this.debugMode.ifPresent(x -> x.traceStartConflation(numBlocksInConflation));
     } catch (final Exception e) {
-      this.tracingExceptions.add(e);
+      collectException(e);
     }
   }
 
@@ -156,7 +156,7 @@ public class ZkTracer implements LineCountingTracer {
       this.hub.traceEndConflation(state);
       this.debugMode.ifPresent(DebugMode::traceEndConflation);
     } catch (final Exception e) {
-      this.tracingExceptions.add(e);
+      collectException(e);
     }
 
     if (!this.tracingExceptions.isEmpty()) {
@@ -173,7 +173,7 @@ public class ZkTracer implements LineCountingTracer {
       this.hub.traceStartBlock(world, processableBlockHeader, miningBeneficiary);
       this.debugMode.ifPresent(DebugMode::traceEndConflation);
     } catch (final Exception e) {
-      this.tracingExceptions.add(e);
+      collectException(e);
     }
   }
 
@@ -187,7 +187,7 @@ public class ZkTracer implements LineCountingTracer {
       this.hub.traceStartBlock(world, blockHeader, miningBeneficiary);
       this.debugMode.ifPresent(x -> x.traceStartBlock(blockHeader, blockBody, miningBeneficiary));
     } catch (final Exception e) {
-      this.tracingExceptions.add(e);
+      collectException(e);
     }
   }
 
@@ -197,7 +197,7 @@ public class ZkTracer implements LineCountingTracer {
       this.hub.traceEndBlock(blockHeader, blockBody);
       this.debugMode.ifPresent(DebugMode::traceEndBlock);
     } catch (final Exception e) {
-      this.tracingExceptions.add(e);
+      collectException(e);
     }
   }
 
@@ -206,7 +206,7 @@ public class ZkTracer implements LineCountingTracer {
       this.debugMode.ifPresent(x -> x.tracePrepareTx(worldView, transaction));
       this.hub.traceStartTransaction(worldView, transaction);
     } catch (final Exception e) {
-      this.tracingExceptions.add(e);
+      collectException(e);
     }
   }
 
@@ -223,7 +223,7 @@ public class ZkTracer implements LineCountingTracer {
       this.debugMode.ifPresent(x -> x.traceEndTx(worldView, tx, status, output, logs, gasUsed));
       this.hub.traceEndTransaction(worldView, tx, status, logs, selfDestructs);
     } catch (final Exception e) {
-      this.tracingExceptions.add(e);
+      collectException(e);
     }
   }
 
@@ -243,7 +243,7 @@ public class ZkTracer implements LineCountingTracer {
         this.hub.tracePreExecution(frame);
         this.debugMode.ifPresent(x -> x.tracePreOpcode(frame));
       } catch (final Exception e) {
-        this.tracingExceptions.add(e);
+        collectException(e);
       }
     }
   }
@@ -261,7 +261,7 @@ public class ZkTracer implements LineCountingTracer {
         this.hub.tracePostExecution(frame, operationResult);
         this.debugMode.ifPresent(x -> x.tracePostOpcode(frame, operationResult));
       } catch (final Exception e) {
-        this.tracingExceptions.add(e);
+        collectException(e);
       }
     }
   }
@@ -275,7 +275,7 @@ public class ZkTracer implements LineCountingTracer {
         this.hub.traceContextEnter(frame);
         this.debugMode.ifPresent(x -> x.traceContextEnter(frame));
       } catch (final Exception e) {
-        this.tracingExceptions.add(e);
+        collectException(e);
       }
     }
   }
@@ -286,7 +286,7 @@ public class ZkTracer implements LineCountingTracer {
       this.hub.traceContextReEnter(frame);
       this.debugMode.ifPresent(x -> x.traceContextReEnter(frame));
     } catch (final Exception e) {
-      this.tracingExceptions.add(e);
+      collectException(e);
     }
   }
 
@@ -296,8 +296,13 @@ public class ZkTracer implements LineCountingTracer {
       this.hub.traceContextExit(frame);
       this.debugMode.ifPresent(x -> x.traceContextExit(frame));
     } catch (final Exception e) {
-      this.tracingExceptions.add(e);
+      collectException(e);
     }
+  }
+
+  private void collectException(final Exception e) {
+    this.tracingExceptions.add(e);
+    log.trace("Collected exception during transaction processing", e);
   }
 
   private void maybeThrowTracingExceptions() {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/exceptions/TracingExceptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/exceptions/TracingExceptions.java
@@ -35,7 +35,11 @@ public class TracingExceptions extends RuntimeException {
   public String getMessage() {
     final StringBuilder msg = new StringBuilder("Exceptions triggered while tracing:\n");
     for (final Exception e : tracingExceptions) {
-      msg.append("  - ").append(e.getMessage()).append("\n");
+      msg.append("  - ").append(e.getClass());
+      if (e.getMessage() != null) {
+        msg.append(": ").append(e.getMessage());
+      }
+      msg.append("\n");
     }
     log.error("First exception that was caught while tracing:", tracingExceptions.getFirst());
     return msg.toString();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Logs collected tracing exceptions at trace level and enriches aggregated error messages with exception classes.
> 
> - **Tracing**:
>   - Add `collectException(Exception)` in `ZkTracer` to centralize exception handling and log at `trace` level when exceptions are collected; replace direct `tracingExceptions.add(e)` calls across tracing hooks with `collectException`.
>   - Improve `TracingExceptions#getMessage()` to include each exception's class and message (when present), preserving first-exception error log.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb58ab876d7ae4fea7802d69e871f2fafdfbcf45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->