### PR TITLE
test: rm duplicate tests

### DIFF
--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rom/RomTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/rom/RomTest.java
@@ -16,11 +16,9 @@
 package net.consensys.linea.zktracer.module.rom;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-import kotlin.Pair;
 import net.consensys.linea.UnitTestWatcher;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.BytecodeCompiler;
@@ -39,7 +37,7 @@ public class RomTest extends TracerTestBase {
   @Test
   void oneIncompletePushTest(TestInfo testInfo) {
     BytecodeCompiler program = BytecodeCompiler.newProgram(chainConfig);
-    program.incompletePush(12, "ff".repeat(4));
+    program.incompletePush(12, "5b".repeat(4));
     BytecodeRunner.of(program.compile()).run(chainConfig, testInfo);
   }
 
@@ -48,8 +46,8 @@ public class RomTest extends TracerTestBase {
   @MethodSource("incompletePushTestSource")
   void extensiveIncompletePushTest(int j, int k, TestInfo testInfo) {
     BytecodeCompiler program = BytecodeCompiler.newProgram(chainConfig);
-    // Bytes taken by a PUSHX do not have a specific purpose here
-    program.incompletePush(k, "ff".repeat(j));
+    // Bytes taken by a PUSHX are JUMPDEST on purpose
+    program.incompletePush(k, "5b".repeat(j));
     BytecodeRunner.of(program.compile()).run(chainConfig, testInfo);
   }
 
@@ -61,39 +59,5 @@ public class RomTest extends TracerTestBase {
       }
     }
     return trailingFFRomTestSourceList.stream();
-  }
-
-  /**
-   * The bytecode constructed in the following test is a random concatenation of incomplete pushes
-   * where every "incomplete push" is made up of some <b>PUSHX</b> opcode follwed by
-   *
-   * <pre> l := 0, 1, ..., X </pre>
-   *
-   * bytes with value "5b", i.e. the byte value of <b>JUMPDEST</b>.
-   *
-   * <p>The execution of this code is therefore a mixture of <b>PUSHX</b>'s and <b>JUMPDEST</b>'s.
-   *
-   * <p>The purpose is to test ROM module's ability to correctly perform "jump destination analysis"
-   * i.e. its ability to distinguish between valid <b>JUMPDEST</b>'s and invalid ones, i.e. "5b"'s
-   * claimed by some <b>PUSHX</b> opcode.
-   */
-  @Test
-  void jumpDestinationAnalysisTest(TestInfo testInfo) {
-    List<Pair<Integer, Integer>> permutationOfKAndJPairs = new ArrayList<>();
-    for (int k = 1; k <= 32; k++) {
-      for (int j = 0; j <= k; j++) {
-        permutationOfKAndJPairs.add(new Pair<>(k, j));
-      }
-    }
-    Collections.shuffle(permutationOfKAndJPairs);
-
-    BytecodeCompiler program = BytecodeCompiler.newProgram(chainConfig);
-    for (Pair<Integer, Integer> kAndJPair : permutationOfKAndJPairs) {
-      int k = kAndJPair.getFirst();
-      int j = kAndJPair.getSecond();
-      program.incompletePush(k, "5b".repeat(j)); // invalid JUMPDEST
-    }
-
-    BytecodeRunner.of(program.compile()).run(chainConfig, testInfo);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch incomplete-push tests to use `0x5b` (JUMPDEST) bytes and remove the `jumpDestinationAnalysisTest` along with related imports.
> 
> - **Tests (`arithmetization/src/test/java/net/consensys/linea/zktracer/module/rom/RomTest.java`)**:
>   - Use `0x5b` (JUMPDEST) bytes in `program.incompletePush(...)` for `oneIncompletePushTest` and parameterized `extensiveIncompletePushTest`.
>   - Remove `jumpDestinationAnalysisTest` and associated utilities/imports (`kotlin.Pair`, `Collections`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2b30fd17dca546e00404ab4c3c057c2ecb9a3dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->