### PR TITLE
test: add check that event detection is the same with tracer and counter

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -268,8 +268,8 @@ public abstract class Hub implements Module {
   private final RipemdBlocks ripemdBlocks = new RipemdBlocks();
 
   // related to Blake
-  private final IncrementAndDetectModule blakeEffectiveCall =
-      new IncrementAndDetectModule(PRECOMPILE_BLAKE_EFFECTIVE_CALLS);
+  private final IncrementingModule blakeEffectiveCall =
+      new IncrementingModule(PRECOMPILE_BLAKE_EFFECTIVE_CALLS);
   private final BlakeRounds blakeRounds = new BlakeRounds();
 
   // Related to Bls

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -268,8 +268,8 @@ public abstract class Hub implements Module {
   private final RipemdBlocks ripemdBlocks = new RipemdBlocks();
 
   // related to Blake
-  private final IncrementingModule blakeEffectiveCall =
-      new IncrementingModule(PRECOMPILE_BLAKE_EFFECTIVE_CALLS);
+  private final IncrementAndDetectModule blakeEffectiveCall =
+      new IncrementAndDetectModule(PRECOMPILE_BLAKE_EFFECTIVE_CALLS);
   private final BlakeRounds blakeRounds = new BlakeRounds();
 
   // Related to Bls

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/CallSection.java
@@ -206,14 +206,6 @@ public class CallSection extends TraceSection
     rawCalleeAddress = frame.getStackItem(1);
     calleeAddress = Address.extract(EWord.of(rawCalleeAddress));
 
-    // TODO: remove me when Linea supports Cancun & Prague precompiles
-    if (isKzgPrecompileCall(calleeAddress, hub.fork)) {
-      hub.pointEval().detectEvent();
-    }
-    if (isBlsPrecompileCall(calleeAddress, hub.fork)) {
-      hub.bls().detectEvent();
-    }
-
     callerFirst = canonical(hub, callerAddress);
     calleeFirst = canonical(hub, calleeAddress);
 
@@ -386,6 +378,14 @@ public class CallSection extends TraceSection
   }
 
   private void prcProcessing(Hub hub) {
+    // TODO: remove me when Linea supports Cancun & Prague precompiles
+    if (isKzgPrecompileCall(calleeAddress, hub.fork)) {
+      hub.pointEval().detectEvent();
+    }
+    if (isBlsPrecompileCall(calleeAddress, hub.fork)) {
+      hub.bls().detectEvent();
+    }
+
     precompileSubsection = ADDRESS_TO_PRECOMPILE.get(calleeFirst.address()).apply(hub, this);
     hub.defers().scheduleForContextEntry(this);
     hub.defers().scheduleForContextReEntry(this, hub.currentFrame());

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
@@ -147,6 +147,34 @@ public class ToyExecutionEnvironmentV2 {
                   .map(module -> module.moduleKey().toString())
                   .toList();
 
+          // check that event detection is the same between tracer and counter
+          checkArgument(
+              Objects.equals(
+                  lightCounterCount.get(POINT_EVAL.toString()),
+                  tracerCount.get(POINT_EVAL.toString())),
+              "PointEval event detection is different between tracer and counter");
+          checkArgument(
+              Objects.equals(
+                  lightCounterCount.get(BLS.toString()), tracerCount.get(BLS.toString())),
+              "BLS event detection is different between tracer and counter");
+          final int ripCountMaxOrZero =
+              tracerCount.get(PRECOMPILE_RIPEMD_BLOCKS.toString()) == Integer.MAX_VALUE
+                  ? Integer.MAX_VALUE
+                  : 0;
+          checkArgument(
+              Objects.equals(
+                  lightCounterCount.get(PRECOMPILE_RIPEMD_BLOCKS.toString()), ripCountMaxOrZero),
+              "RIP event detection is different between tracer and counter");
+          final int blakeCountMaxOrZero =
+              tracerCount.get(PRECOMPILE_BLAKE_EFFECTIVE_CALLS.toString()) == Integer.MAX_VALUE
+                  ? Integer.MAX_VALUE
+                  : 0;
+          checkArgument(
+              Objects.equals(
+                  lightCounterCount.get(PRECOMPILE_BLAKE_EFFECTIVE_CALLS.toString()),
+                  blakeCountMaxOrZero),
+              "BLAKE event detection is different between tracer and counter");
+
           // There is no point to check for conflation where an excluded PRC has been triggered:
           if (lightCounterCount.get(POINT_EVAL.toString()) != 0
               || lightCounterCount.get(BLS.toString()) != 0

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
@@ -157,20 +157,13 @@ public class ToyExecutionEnvironmentV2 {
               Objects.equals(
                   lightCounterCount.get(BLS.toString()), tracerCount.get(BLS.toString())),
               "BLS event detection is different between tracer and counter");
-          final int ripCountMaxOrZero =
-              tracerCount.get(PRECOMPILE_RIPEMD_BLOCKS.toString()) != 0 ? Integer.MAX_VALUE : 0;
           checkArgument(
-              Objects.equals(
-                  lightCounterCount.get(PRECOMPILE_RIPEMD_BLOCKS.toString()), ripCountMaxOrZero),
+              lightCounterCount.get(PRECOMPILE_RIPEMD_BLOCKS.toString())
+                  >= tracerCount.get(PRECOMPILE_RIPEMD_BLOCKS.toString()),
               "RIP event detection is different between tracer and counter");
-          final int blakeCountMaxOrZero =
-              tracerCount.get(PRECOMPILE_BLAKE_EFFECTIVE_CALLS.toString()) != 0
-                  ? Integer.MAX_VALUE
-                  : 0;
           checkArgument(
-              Objects.equals(
-                  lightCounterCount.get(PRECOMPILE_BLAKE_EFFECTIVE_CALLS.toString()),
-                  blakeCountMaxOrZero),
+              lightCounterCount.get(PRECOMPILE_BLAKE_EFFECTIVE_CALLS.toString())
+                  >= tracerCount.get(PRECOMPILE_BLAKE_EFFECTIVE_CALLS.toString()),
               "BLAKE event detection is different between tracer and counter");
 
           // There is no point to check for conflation where an excluded PRC has been triggered:

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
@@ -158,15 +158,13 @@ public class ToyExecutionEnvironmentV2 {
                   lightCounterCount.get(BLS.toString()), tracerCount.get(BLS.toString())),
               "BLS event detection is different between tracer and counter");
           final int ripCountMaxOrZero =
-              tracerCount.get(PRECOMPILE_RIPEMD_BLOCKS.toString()) == Integer.MAX_VALUE
-                  ? Integer.MAX_VALUE
-                  : 0;
+              tracerCount.get(PRECOMPILE_RIPEMD_BLOCKS.toString()) != 0 ? Integer.MAX_VALUE : 0;
           checkArgument(
               Objects.equals(
                   lightCounterCount.get(PRECOMPILE_RIPEMD_BLOCKS.toString()), ripCountMaxOrZero),
               "RIP event detection is different between tracer and counter");
           final int blakeCountMaxOrZero =
-              tracerCount.get(PRECOMPILE_BLAKE_EFFECTIVE_CALLS.toString()) == Integer.MAX_VALUE
+              tracerCount.get(PRECOMPILE_BLAKE_EFFECTIVE_CALLS.toString()) != 0
                   ? Integer.MAX_VALUE
                   : 0;
           checkArgument(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves KZG/BLS precompile event detection into PRC processing and adds tests ensuring tracer vs light-counter event detection parity.
> 
> - **Hub / Call processing**:
>   - Move KZG PointEval and BLS event detection from constructor to `prcProcessing()` in `CallSection`.
> - **Testing**:
>   - In `ToyExecutionEnvironmentV2`, assert event detection parity between tracer and light-counter:
>     - `POINT_EVAL` and `BLS` counts must match; `PRECOMPILE_RIPEMD_BLOCKS` and `PRECOMPILE_BLAKE_EFFECTIVE_CALLS` in counter must be ≥ tracer.
>   - Perform these checks before early exit when excluded PRCs are triggered.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 171e5fb249f5691436a8029bf486225c4fa8c3c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->