### PR TITLE
Chore: update Besu to 25.10.0-RC2-linea1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 releaseVersion=beta-v4.0-rc12
-besuVersion=25.10.0-RC1-linea2
+besuVersion=25.10.0-RC2-linea1
 shomeiVersion=2.4-develop
 besuShomeiPluginVersion=v0.7.4
 besuArtifactGroup=org.hyperledger.besu

--- a/reference-tests/src/test/java/net/consensys/linea/CorsetBlockProcessor.java
+++ b/reference-tests/src/test/java/net/consensys/linea/CorsetBlockProcessor.java
@@ -96,7 +96,7 @@ public class CorsetBlockProcessor extends MainnetBlockProcessor {
             protocolSpec,
             preExecutionProcessor.createBlockHashLookup(blockchain, blockHeader),
             OperationTracer.NO_TRACING);
-    preExecutionProcessor.process(blockProcessingContext);
+    preExecutionProcessor.process(blockProcessingContext, Optional.empty());
 
     for (final Transaction transaction : transactions) {
       if (!hasAvailableBlockBudget(blockHeader, transaction, currentGasUsed)) {
@@ -162,7 +162,7 @@ public class CorsetBlockProcessor extends MainnetBlockProcessor {
       try {
         maybeWithdrawalsProcessor
             .get()
-            .processWithdrawals(maybeWithdrawals.get(), worldState.updater());
+            .processWithdrawals(maybeWithdrawals.get(), worldState.updater(), Optional.empty());
       } catch (final Exception e) {
         log.error("failed processing withdrawals", e);
         return new BlockProcessingResult(Optional.empty(), e);

--- a/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
@@ -27,7 +27,6 @@ import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.OptionalLong;
 
 import net.consensys.linea.corset.CorsetValidator;
 import net.consensys.linea.zktracer.ChainConfig;
@@ -173,7 +172,7 @@ public class ExecutionEnvironment {
         new MainnetProtocolSpecFactory(
             Optional.of(chainId),
             true,
-            OptionalLong.empty(),
+            genesisConfigOptions,
             EvmConfiguration.DEFAULT,
             MiningConfiguration.MINING_DISABLED,
             false,
@@ -182,17 +181,17 @@ public class ExecutionEnvironment {
 
     final ProtocolSpecBuilder builder =
         switch (fork) {
-          case LONDON -> protocol.londonDefinition(genesisConfigOptions);
-          case PARIS -> protocol.parisDefinition(genesisConfigOptions);
-          case SHANGHAI -> protocol.shanghaiDefinition(genesisConfigOptions);
+          case LONDON -> protocol.londonDefinition();
+          case PARIS -> protocol.parisDefinition();
+          case SHANGHAI -> protocol.shanghaiDefinition();
           case CANCUN -> protocol
-              .cancunDefinition(genesisConfigOptions)
+              .cancunDefinition()
               .preExecutionProcessor(new CancunPreExecutionProcessor());
           case PRAGUE -> protocol
-              .pragueDefinition(genesisConfigOptions)
+              .pragueDefinition()
               .preExecutionProcessor(new PraguePreExecutionProcessor());
           case OSAKA -> protocol
-              .osakaDefinition(genesisConfigOptions)
+              .osakaDefinition()
               .preExecutionProcessor(new PraguePreExecutionProcessor());
           default -> throw new IllegalArgumentException("Unexpected fork value: " + fork);
         };

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionTools.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionTools.java
@@ -343,7 +343,7 @@ public class ToyExecutionTools {
               spec,
               preExecutionProcessor.createBlockHashLookup(blockchain, header),
               tracer);
-      preExecutionProcessor.process(context);
+      preExecutionProcessor.process(context, Optional.empty());
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update Besu to 25.10.0-RC2-linea1 and adjust pre-execution, withdrawals, and protocol spec APIs across tests/utilities.
> 
> - **Dependencies**:
>   - Bump `besuVersion` in `gradle.properties` to `25.10.0-RC2-linea1`.
> - **API updates (align with new Besu)**:
>   - `reference-tests/.../CorsetBlockProcessor.java`:
>     - Use `preExecutionProcessor.process(context, Optional.empty())`.
>     - Use `WithdrawalsProcessor.processWithdrawals(withdrawals, worldState.updater(), Optional.empty())`.
>   - `testing/.../ExecutionEnvironment.java`:
>     - Update `MainnetProtocolSpecFactory` ctor to pass `genesisConfigOptions` instead of `OptionalLong.empty()`.
>     - Switch to no-arg protocol definitions: `.londonDefinition()`, `.parisDefinition()`, `.shanghaiDefinition()`, `.cancunDefinition()`, `.pragueDefinition()`, `.osakaDefinition()`.
>   - `testing/.../ToyExecutionTools.java`:
>     - Use `preExecutionProcessor.process(context, Optional.empty())`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32b00459cd73075b903fb4560976beb7be07aa2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->