### PR TITLE
`beta-v4.0-rc11-tracer-only-columns-hotfix`

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/cancun/CancunRlpTxn.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/cancun/CancunRlpTxn.java
@@ -36,6 +36,6 @@ public class CancunRlpTxn extends RlpTxn {
   @Override
   protected void traceOperation(RlpTxnOperation op, int userTxNumber, Trace.Rlptxn trace) {
     final CancunRlpTxnOperation cancunOp = (CancunRlpTxnOperation) op;
-    cancunOp.trace(trace);
+    cancunOp.trace(trace, operations.size());
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/cancun/CancunRlpTxnOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/cancun/CancunRlpTxnOperation.java
@@ -97,7 +97,8 @@ public class CancunRlpTxnOperation extends RlpTxnOperation {
     phaseSectionList.add(new IntegerPhaseSection(rlpUtils, S, tx));
   }
 
-  protected void trace(Trace.Rlptxn trace) {
+  protected void trace(Trace.Rlptxn trace, int userTransactionNumberMax) {
+    tracedValues.userTxnNumberMax(userTransactionNumberMax);
     for (PhaseSection section : phaseSectionList) {
       section.trace(trace, tracedValues);
     }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/cancun/GenericTracedValue.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/cancun/GenericTracedValue.java
@@ -34,6 +34,7 @@ public class GenericTracedValue {
   private final boolean type4;
   private int rlpLtByteSize;
   private int rlpLxByteSize;
+  @Setter @Getter private int userTxnNumberMax;
 
   public GenericTracedValue(TransactionProcessingMetadata tx) {
     this.tx = tx;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/cancun/phaseSection/PhaseSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxn/cancun/phaseSection/PhaseSection.java
@@ -80,7 +80,8 @@ public abstract class PhaseSection {
         .replayProtection(tracedValues.tx().replayProtection())
         .yParity(tracedValues.tx().yParity())
         .requiresEvmExecution(tracedValues.tx().requiresEvmExecution())
-        .isDeployment(tracedValues.tx().isDeployment());
+        .isDeployment(tracedValues.tx().isDeployment())
+        .proverUserTxnNumberMax(tracedValues.userTxnNumberMax());
   }
 
   public void tracePostValues(Trace.Rlptxn trace, GenericTracedValue tracedValues) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnData.java
@@ -28,7 +28,6 @@ import net.consensys.linea.zktracer.module.txndata.cancun.transactions.SysfNoopT
 import net.consensys.linea.zktracer.module.txndata.cancun.transactions.SysiEip2935Transaction;
 import net.consensys.linea.zktracer.module.txndata.cancun.transactions.SysiEip4788Transaction;
 import net.consensys.linea.zktracer.module.txndata.cancun.transactions.UserTransaction;
-import net.consensys.linea.zktracer.module.txndata.london.LondonTxnDataOperation;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
 import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
 import org.hyperledger.besu.datatypes.Address;
@@ -36,8 +35,6 @@ import org.hyperledger.besu.evm.worldstate.WorldView;
 import org.hyperledger.besu.plugin.data.BlockBody;
 import org.hyperledger.besu.plugin.data.BlockHeader;
 import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
-
-import static com.google.common.base.Preconditions.checkState;
 
 public class CancunTxnData extends TxnData<CancunTxnDataOperation> {
 
@@ -57,10 +54,10 @@ public class CancunTxnData extends TxnData<CancunTxnDataOperation> {
     currentBlockHeader = processableBlockHeader;
   }
 
-    @Override
-    public void traceEndBlock(final BlockHeader blockHeader, final BlockBody blockBody) {
-        blocks.getLast().setNbOfTxsInBlock(blockBody.getTransactions().size());
-    }
+  @Override
+  public void traceEndBlock(final BlockHeader blockHeader, final BlockBody blockBody) {
+    blocks.getLast().setNbOfTxsInBlock(blockBody.getTransactions().size());
+  }
 
   @Override
   public void traceEndTx(TransactionProcessingMetadata tx) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnData.java
@@ -14,24 +14,34 @@
  */
 package net.consensys.linea.zktracer.module.txndata.cancun;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import lombok.Getter;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.module.euc.Euc;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.fragment.transaction.system.SystemTransactionType;
+import net.consensys.linea.zktracer.module.txndata.BlockSnapshot;
 import net.consensys.linea.zktracer.module.txndata.TxnData;
 import net.consensys.linea.zktracer.module.txndata.cancun.transactions.SysfNoopTransaction;
 import net.consensys.linea.zktracer.module.txndata.cancun.transactions.SysiEip2935Transaction;
 import net.consensys.linea.zktracer.module.txndata.cancun.transactions.SysiEip4788Transaction;
 import net.consensys.linea.zktracer.module.txndata.cancun.transactions.UserTransaction;
+import net.consensys.linea.zktracer.module.txndata.london.LondonTxnDataOperation;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
 import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.worldstate.WorldView;
+import org.hyperledger.besu.plugin.data.BlockBody;
+import org.hyperledger.besu.plugin.data.BlockHeader;
 import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
+
+import static com.google.common.base.Preconditions.checkState;
 
 public class CancunTxnData extends TxnData<CancunTxnDataOperation> {
 
+  @Getter private final List<BlockSnapshot> blocks = new ArrayList<>();
   @Getter private ProcessableBlockHeader currentBlockHeader;
 
   public CancunTxnData(Hub hub, Wcp wcp, Euc euc) {
@@ -43,8 +53,14 @@ public class CancunTxnData extends TxnData<CancunTxnDataOperation> {
       WorldView world,
       final ProcessableBlockHeader processableBlockHeader,
       final Address miningBeneficiary) {
+    blocks.add(new BlockSnapshot(processableBlockHeader));
     currentBlockHeader = processableBlockHeader;
   }
+
+    @Override
+    public void traceEndBlock(final BlockHeader blockHeader, final BlockBody blockBody) {
+        blocks.getLast().setNbOfTxsInBlock(blockBody.getTransactions().size());
+    }
 
   @Override
   public void traceEndTx(TransactionProcessingMetadata tx) {
@@ -53,7 +69,7 @@ public class CancunTxnData extends TxnData<CancunTxnDataOperation> {
 
   @Override
   public int numberOfUserTransactionsInCurrentBlock() {
-    return 0;
+    return blocks.getLast().getNbOfTxsInBlock();
   }
 
   public void callTxnDataForSystemTransaction(final SystemTransactionType type) {
@@ -66,10 +82,14 @@ public class CancunTxnData extends TxnData<CancunTxnDataOperation> {
     }
   }
 
+  public long totalNumberOfUserTransactions() {
+    return operations().stream().filter(op -> op instanceof UserTransaction).count();
+  }
+
   @Override
   public void commit(Trace trace) {
     for (CancunTxnDataOperation tx : operations().getAll()) {
-      tx.traceTransaction(trace.txndata());
+      tx.traceTransaction(trace.txndata(), totalNumberOfUserTransactions());
     }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnDataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnDataOperation.java
@@ -43,6 +43,7 @@ public abstract class CancunTxnDataOperation extends TxnDataOperation {
   public final short sysfTransactionNumber;
   public final List<TxnDataRow> rows = new ArrayList<>();
   public final TransactionProcessingType category;
+  public final BlockSnapshot blockSnapshot;
 
   protected abstract int ctMax();
 
@@ -66,19 +67,25 @@ public abstract class CancunTxnDataOperation extends TxnDataOperation {
     userTransactionNumber = hub.state.getUserTransactionNumber();
     sysfTransactionNumber = hub.state.sysfTransactionNumber();
     this.category = category;
+    blockSnapshot = txnData.getBlocks().getLast();
   }
 
-  public void traceTransaction(Trace.Txndata trace) {
+  public void traceTransaction(Trace.Txndata trace, long totalUserTransactionsInConflation) {
     short ct = 0;
     for (TxnDataRow row : rows) {
-      traceCommonSaveForFlags(trace, ct);
+      traceCommonSaveForFlags(trace, ct, totalUserTransactionsInConflation);
       row.traceRow(trace);
       trace.fillAndValidateRow();
       ct++;
     }
   }
 
-  private void traceCommonSaveForFlags(Trace.Txndata trace, int ct) {
+  private void traceCommonSaveForFlags(
+      Trace.Txndata trace, int ct, long totalUserTransactionsInConflation) {
+    final long relativeUserTxNumMax =
+        this instanceof UserTransaction
+            ? blockSnapshot.getNbOfTxsInBlock()
+            : 0;
     trace
         // BLK_NUMBER is (defcomputed ...)
         // TOTL_TXN_NUMBER is (defcomputed ...)
@@ -91,6 +98,8 @@ public abstract class CancunTxnDataOperation extends TxnDataOperation {
         // CMPTN, HUB, RLP flags get traced by the rows themselves
         .ct(ct)
         .ctMax(ctMax())
+        .proverRelativeUserTxnNumberMax(relativeUserTxNumMax)
+        .proverUserTxnNumberMax(totalUserTransactionsInConflation)
     // GAS_CUMULATIVE gets traced for USER transactions only
     ;
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnDataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnDataOperation.java
@@ -83,9 +83,7 @@ public abstract class CancunTxnDataOperation extends TxnDataOperation {
   private void traceCommonSaveForFlags(
       Trace.Txndata trace, int ct, long totalUserTransactionsInConflation) {
     final long relativeUserTxNumMax =
-        this instanceof UserTransaction
-            ? blockSnapshot.getNbOfTxsInBlock()
-            : 0;
+        this instanceof UserTransaction ? blockSnapshot.getNbOfTxsInBlock() : 0;
     trace
         // BLK_NUMBER is (defcomputed ...)
         // TOTL_TXN_NUMBER is (defcomputed ...)

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/SysfNoopTransaction.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/SysfNoopTransaction.java
@@ -17,6 +17,7 @@ package net.consensys.linea.zktracer.module.txndata.cancun.transactions;
 import static net.consensys.linea.zktracer.module.hub.TransactionProcessingType.SYSF;
 import static net.consensys.linea.zktracer.module.txndata.cancun.rows.hubRows.Type.NOOP;
 
+import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.module.txndata.cancun.CancunTxnData;
 import net.consensys.linea.zktracer.module.txndata.cancun.CancunTxnDataOperation;
 import net.consensys.linea.zktracer.module.txndata.cancun.rows.computationRows.NoopRow;
@@ -43,4 +44,7 @@ public class SysfNoopTransaction extends CancunTxnDataOperation {
     rows.add(new HubRowForSystemTransactions(txnData.getCurrentBlockHeader(), txnData.hub(), NOOP));
     rows.add(new NoopRow());
   }
+
+  @Override
+  public void traceTransaction(Trace.Txndata trace) {}
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/SysiEip2935Transaction.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/SysiEip2935Transaction.java
@@ -20,6 +20,7 @@ import static net.consensys.linea.zktracer.Trace.HISTORY_SERVE_WINDOW;
 import static net.consensys.linea.zktracer.module.hub.TransactionProcessingType.SYSI;
 import static net.consensys.linea.zktracer.module.txndata.cancun.rows.computationRows.WcpRow.smallCallToIszero;
 
+import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.module.txndata.cancun.CancunTxnData;
 import net.consensys.linea.zktracer.module.txndata.cancun.CancunTxnDataOperation;
 import net.consensys.linea.zktracer.module.txndata.cancun.rows.computationRows.EucRow;
@@ -87,4 +88,7 @@ public class SysiEip2935Transaction extends CancunTxnDataOperation {
   private Bytes previousBlockHash() {
     return currentBlockIsGenesisBlock() ? Bytes.EMPTY : blockHeader.getParentHash();
   }
+
+  @Override
+  public void traceTransaction(Trace.Txndata trace) {}
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/SysiEip4788Transaction.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/SysiEip4788Transaction.java
@@ -26,6 +26,7 @@ import static net.consensys.linea.zktracer.types.Conversions.longToUnsignedBigIn
 
 import java.math.BigInteger;
 
+import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.module.txndata.cancun.CancunTxnData;
 import net.consensys.linea.zktracer.module.txndata.cancun.CancunTxnDataOperation;
 import net.consensys.linea.zktracer.module.txndata.cancun.rows.computationRows.EucRow;
@@ -84,4 +85,7 @@ public class SysiEip4788Transaction extends CancunTxnDataOperation {
   protected int ctMax() {
     return NB_ROWS_TXN_DATA_SYSI_EIP4788 - 1;
   }
+
+  @Override
+  public void traceTransaction(Trace.Txndata trace) {}
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/UserTransaction.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/transactions/UserTransaction.java
@@ -44,6 +44,9 @@ public class UserTransaction extends CancunTxnDataOperation {
   public final ProcessableBlockHeader blockHeader;
   public final Fork fork;
 
+  @Override
+  public void traceTransaction(Txndata trace) {}
+
   public enum DominantCost {
     FLOOR_COST_DOMINATES,
     EXECUTION_COST_DOMINATES

--- a/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
+++ b/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
@@ -30,7 +30,7 @@ public class TracerTestBase {
   public static void init() {
     // Configure chain information and fork before any tests are run, including any methods used as
     // MethodSource.
-    TracerTestBase.chainConfig = ChainConfig.MAINNET_TESTCONFIG(getForkOrDefault(LONDON));
+    TracerTestBase.chainConfig = ChainConfig.MAINNET_TESTCONFIG(getForkOrDefault(CANCUN));
     TracerTestBase.fork = TracerTestBase.chainConfig.fork;
     TracerTestBase.opcodes = OpCodes.load(fork);
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Propagates and records per-block and total user-transaction maxima through RLP and TXNDATA tracing, adds block snapshots, and switches tests to Cancun.
> 
> - **Tracing (Cancun RLP TXN)**:
>   - Pass and record `userTxnNumberMax` via `CancunRlpTxn.traceOperation()` → `CancunRlpTxnOperation.trace(trace, userTxnNumberMax)`.
>   - Add `GenericTracedValue.userTxnNumberMax` and emit `proverUserTxnNumberMax` in `PhaseSection`.
> - **Tracing (Cancun TXN_DATA)**:
>   - Track blocks with `BlockSnapshot`; record `nbOfTxsInBlock` on `traceEndBlock`.
>   - Provide `numberOfUserTransactionsInCurrentBlock()` and `totalNumberOfUserTransactions()`.
>   - Update `commit()` to pass total user-tx count to `traceTransaction`.
>   - In `CancunTxnDataOperation`, emit `proverRelativeUserTxnNumberMax` (per-block) and `proverUserTxnNumberMax` (conflation total) during row tracing.
>   - Adjust transaction subclasses to new `traceTransaction` signature (system txns no-op overrides).
> - **Testing**:
>   - Default test fork changed to `CANCUN` in `testing/.../TracerTestBase.java`.
> - **Submodule**:
>   - Update `linea-constraints` submodule reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bd7268d61bdb823898a51b850028ba646501463. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->