### PR TITLE
feat(EIP-7825): transaction gas limit cap

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
@@ -76,8 +76,8 @@ import static net.consensys.linea.zktracer.module.stp.StpOperation.NB_ROWS_STP;
 import static net.consensys.linea.zktracer.module.txndata.cancun.transactions.SysfNoopTransaction.NB_ROWS_TXN_DATA_SYSF_NOOP;
 import static net.consensys.linea.zktracer.module.txndata.cancun.transactions.SysiEip2935Transaction.NB_ROWS_TXN_DATA_SYSI_EIP2935;
 import static net.consensys.linea.zktracer.module.txndata.cancun.transactions.SysiEip4788Transaction.NB_ROWS_TXN_DATA_SYSI_EIP4788;
-import static net.consensys.linea.zktracer.module.txndata.cancun.transactions.UserTransaction.NB_ROWS_TXN_DATA_USER_1559_SEMANTIC;
-import static net.consensys.linea.zktracer.module.txndata.cancun.transactions.UserTransaction.NB_ROWS_TXN_DATA_USER_NO_1559_SEMANTIC;
+import static net.consensys.linea.zktracer.module.txndata.osaka.OsakaUserTransaction.NB_ROWS_TXN_DATA_OSAKA_USER_1559_SEMANTIC;
+import static net.consensys.linea.zktracer.module.txndata.osaka.OsakaUserTransaction.NB_ROWS_TXN_DATA_OSAKA_USER_NO_1559_SEMANTIC;
 import static net.consensys.linea.zktracer.opcode.OpCode.*;
 import static net.consensys.linea.zktracer.runtime.stack.Stack.MAX_STACK_SIZE;
 import static net.consensys.linea.zktracer.types.TransactionProcessingMetadata.computeRequiresEvmExecution;
@@ -416,8 +416,8 @@ public class ZkCounter implements LineCountingTracer {
         }
         txnData.updateTally(
             transactionHasEip1559GasSemantics(tx)
-                ? NB_ROWS_TXN_DATA_USER_1559_SEMANTIC
-                : NB_ROWS_TXN_DATA_USER_NO_1559_SEMANTIC);
+                ? NB_ROWS_TXN_DATA_OSAKA_USER_1559_SEMANTIC
+                : NB_ROWS_TXN_DATA_OSAKA_USER_NO_1559_SEMANTIC);
         // deploymentTransaction:
         if (tx.isContractCreation()) {
           rlpAddr.updateTally(NB_ROWS_RLPADDR_CREATE);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/module/Blockdata.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockdata/module/Blockdata.java
@@ -31,7 +31,6 @@ import net.consensys.linea.zktracer.module.blockdata.moduleOperation.BlockdataOp
 import net.consensys.linea.zktracer.module.euc.Euc;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.txndata.TxnData;
-import net.consensys.linea.zktracer.module.txndata.TxnDataOperation;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.hyperledger.besu.evm.worldstate.WorldView;
@@ -148,7 +147,7 @@ public abstract class Blockdata implements Module {
     }
   }
 
-  TxnData<? extends TxnDataOperation> txnData() {
+  TxnData txnData() {
     return hub.txnData();
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/CancunHub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/CancunHub.java
@@ -43,7 +43,6 @@ import net.consensys.linea.zktracer.module.tables.PowerRt;
 import net.consensys.linea.zktracer.module.tables.instructionDecoder.CancunInstructionDecoder;
 import net.consensys.linea.zktracer.module.tables.instructionDecoder.InstructionDecoder;
 import net.consensys.linea.zktracer.module.txndata.TxnData;
-import net.consensys.linea.zktracer.module.txndata.TxnDataOperation;
 import net.consensys.linea.zktracer.module.txndata.cancun.CancunTxnData;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
 import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
@@ -82,7 +81,7 @@ public class CancunHub extends ShanghaiHub {
   }
 
   @Override
-  protected TxnData<? extends TxnDataOperation> setTxnData() {
+  protected TxnData setTxnData() {
     return new CancunTxnData(this, wcp(), euc());
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -105,7 +105,6 @@ import net.consensys.linea.zktracer.module.tables.bls.BlsRt;
 import net.consensys.linea.zktracer.module.tables.instructionDecoder.*;
 import net.consensys.linea.zktracer.module.trm.Trm;
 import net.consensys.linea.zktracer.module.txndata.TxnData;
-import net.consensys.linea.zktracer.module.txndata.TxnDataOperation;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
@@ -223,7 +222,7 @@ public abstract class Hub implements Module {
   private final Rom rom = new Rom(romLex);
   private final RlpTxn rlpTxn;
   private final Mmio mmio;
-  @Getter final TxnData<? extends TxnDataOperation> txnData = setTxnData();
+  @Getter final TxnData txnData = setTxnData();
   private final RlpTxnRcpt rlpTxnRcpt = new RlpTxnRcpt();
   private final LogInfo logInfo = new LogInfo(rlpTxnRcpt);
   private final LogData logData = new LogData(rlpTxnRcpt);
@@ -1166,7 +1165,7 @@ public abstract class Hub implements Module {
 
   protected abstract BlsRt setBlsRt();
 
-  protected abstract TxnData<? extends TxnDataOperation> setTxnData();
+  protected abstract TxnData setTxnData();
 
   protected abstract Mxp setMxp();
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/LondonHub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/LondonHub.java
@@ -41,7 +41,6 @@ import net.consensys.linea.zktracer.module.tables.bls.BlsRt;
 import net.consensys.linea.zktracer.module.tables.instructionDecoder.InstructionDecoder;
 import net.consensys.linea.zktracer.module.tables.instructionDecoder.LondonInstructionDecoder;
 import net.consensys.linea.zktracer.module.txndata.TxnData;
-import net.consensys.linea.zktracer.module.txndata.TxnDataOperation;
 import net.consensys.linea.zktracer.module.txndata.london.LondonTxnData;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
 import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
@@ -67,7 +66,7 @@ public class LondonHub extends Hub {
   }
 
   @Override
-  protected TxnData<? extends TxnDataOperation> setTxnData() {
+  protected TxnData setTxnData() {
     return new LondonTxnData(this, wcp(), euc());
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/ShanghaiHub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/ShanghaiHub.java
@@ -22,7 +22,6 @@ import net.consensys.linea.zktracer.module.euc.Euc;
 import net.consensys.linea.zktracer.module.hub.section.create.ShanghaiCreateSection;
 import net.consensys.linea.zktracer.module.hub.section.txInitializationSection.ShanghaiInitializationSection;
 import net.consensys.linea.zktracer.module.txndata.TxnData;
-import net.consensys.linea.zktracer.module.txndata.TxnDataOperation;
 import net.consensys.linea.zktracer.module.txndata.shanghai.ShanghaiTxnData;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -39,7 +38,7 @@ public class ShanghaiHub extends ParisHub {
   }
 
   @Override
-  protected TxnData<? extends TxnDataOperation> setTxnData() {
+  protected TxnData setTxnData() {
     return new ShanghaiTxnData(this, wcp(), euc());
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/TxnData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/TxnData.java
@@ -34,9 +34,10 @@ import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
 
 @RequiredArgsConstructor
 @Accessors(fluent = true)
-public abstract class TxnData<T extends TxnDataOperation> implements OperationListModule<T> {
+public abstract class TxnData implements OperationListModule<TxnDataOperation> {
   @Getter
-  private final ModuleOperationStackedList<T> operations = new ModuleOperationStackedList<>();
+  private final ModuleOperationStackedList<TxnDataOperation> operations =
+      new ModuleOperationStackedList<>();
 
   @Getter private final Hub hub;
   @Getter private final Wcp wcp;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnDataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnDataOperation.java
@@ -14,7 +14,6 @@
  */
 package net.consensys.linea.zktracer.module.txndata.cancun;
 
-import static com.google.common.base.Preconditions.checkState;
 import static net.consensys.linea.zktracer.module.hub.TransactionProcessingType.*;
 
 import java.util.ArrayList;
@@ -27,7 +26,7 @@ import net.consensys.linea.zktracer.module.hub.TransactionProcessingType;
 import net.consensys.linea.zktracer.module.txndata.BlockSnapshot;
 import net.consensys.linea.zktracer.module.txndata.TxnDataOperation;
 import net.consensys.linea.zktracer.module.txndata.cancun.rows.TxnDataRow;
-import net.consensys.linea.zktracer.module.txndata.cancun.transactions.UserTransaction;
+import net.consensys.linea.zktracer.module.txndata.cancun.transactions.CancunUserTransaction;
 import net.consensys.linea.zktracer.module.wcp.Wcp;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
@@ -48,11 +47,6 @@ public abstract class CancunTxnDataOperation extends TxnDataOperation {
 
   @Override
   public int computeLineCount() {
-    checkState(
-        rows.size() == 1 + ctMax(),
-        "Cancun TXN_DATA operation has rows size = %s != 1 + ctMax = %s",
-        rows.size(),
-        ctMax() + 1);
     return rows.size();
   }
 
@@ -94,8 +88,8 @@ public abstract class CancunTxnDataOperation extends TxnDataOperation {
     // GAS_CUMULATIVE gets traced for USER transactions only
     ;
 
-    if (this instanceof UserTransaction) {
-      UserTransaction userTransaction = (UserTransaction) this;
+    if (this instanceof CancunUserTransaction) {
+      CancunUserTransaction userTransaction = (CancunUserTransaction) this;
       trace.gasCumulative(Bytes.ofUnsignedLong(userTransaction.txn.getAccumulatedGasUsedInBlock()));
     }
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/london/LondonTxnData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/london/LondonTxnData.java
@@ -38,7 +38,7 @@ import org.hyperledger.besu.plugin.data.BlockBody;
 import org.hyperledger.besu.plugin.data.BlockHeader;
 import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 
-public class LondonTxnData extends TxnData<LondonTxnDataOperation> {
+public class LondonTxnData extends TxnData {
 
   private static final int NB_WCP_EUC_ROWS_FRONTIER_ACCESS_LIST_LONDON = 7;
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/osaka/OsakaTxnData.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/osaka/OsakaTxnData.java
@@ -13,19 +13,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package net.consensys.linea.zktracer.module.hub;
+package net.consensys.linea.zktracer.module.txndata.osaka;
 
-import net.consensys.linea.zktracer.ChainConfig;
-import net.consensys.linea.zktracer.module.txndata.TxnData;
-import net.consensys.linea.zktracer.module.txndata.osaka.OsakaTxnData;
+import net.consensys.linea.zktracer.module.euc.Euc;
+import net.consensys.linea.zktracer.module.hub.Hub;
+import net.consensys.linea.zktracer.module.txndata.cancun.CancunTxnData;
+import net.consensys.linea.zktracer.module.wcp.Wcp;
+import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
 
-public class OsakaHub extends PragueHub {
-  public OsakaHub(ChainConfig chain) {
-    super(chain);
+public class OsakaTxnData extends CancunTxnData {
+  public OsakaTxnData(Hub hub, Wcp wcp, Euc euc) {
+    super(hub, wcp, euc);
   }
 
   @Override
-  protected TxnData setTxnData() {
-    return new OsakaTxnData(this, wcp(), euc());
+  public void traceEndTx(TransactionProcessingMetadata tx) {
+    operations().add(new OsakaUserTransaction(this, tx));
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/osaka/OsakaUserTransaction.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/osaka/OsakaUserTransaction.java
@@ -37,11 +37,11 @@ public class OsakaUserTransaction extends CancunUserTransaction {
   protected void eip7825TransactionGasLimitCap() {
     final long gasLimit = txn.getGasLimit();
 
-    final WcpRow gasLimitMustCoverUpfrontGasCost =
+    final WcpRow transactionGasLimitCap =
         WcpRow.smallCallToLeq(
             wcp, Bytes.ofUnsignedLong(gasLimit), EIP_7825_TRANSACTION_GAS_LIMIT_CAP_BYTES);
 
-    rows.add(gasLimitMustCoverUpfrontGasCost);
+    rows.add(transactionGasLimitCap);
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/osaka/OsakaUserTransaction.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/osaka/OsakaUserTransaction.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright ConsenSys Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.zktracer.module.txndata.osaka;
+
+import static net.consensys.linea.zktracer.Trace.EIP_7825_TRANSACTION_GAS_LIMIT_CAP;
+
+import net.consensys.linea.zktracer.module.txndata.cancun.CancunTxnData;
+import net.consensys.linea.zktracer.module.txndata.cancun.rows.computationRows.WcpRow;
+import net.consensys.linea.zktracer.module.txndata.cancun.transactions.CancunUserTransaction;
+import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
+import org.apache.tuweni.bytes.Bytes;
+
+public class OsakaUserTransaction extends CancunUserTransaction {
+  public static final short NB_ROWS_TXN_DATA_OSAKA_USER_1559_SEMANTIC = 17;
+  public static final short NB_ROWS_TXN_DATA_OSAKA_USER_NO_1559_SEMANTIC = 15;
+  private static final Bytes EIP_7825_TRANSACTION_GAS_LIMIT_CAP_BYTES =
+      Bytes.minimalBytes(EIP_7825_TRANSACTION_GAS_LIMIT_CAP);
+
+  public OsakaUserTransaction(CancunTxnData txnData, TransactionProcessingMetadata txnMetadata) {
+    super(txnData, txnMetadata);
+  }
+
+  @Override
+  protected void eip7825TransactionGasLimitCap() {
+    final long gasLimit = txn.getGasLimit();
+
+    final WcpRow gasLimitMustCoverUpfrontGasCost =
+        WcpRow.smallCallToLeq(
+            wcp, Bytes.ofUnsignedLong(gasLimit), EIP_7825_TRANSACTION_GAS_LIMIT_CAP_BYTES);
+
+    rows.add(gasLimitMustCoverUpfrontGasCost);
+  }
+
+  @Override
+  protected int ctMax() {
+    return (txn.transactionTypeHasEip1559GasSemantics()
+            ? NB_ROWS_TXN_DATA_OSAKA_USER_1559_SEMANTIC
+            : NB_ROWS_TXN_DATA_OSAKA_USER_NO_1559_SEMANTIC)
+        - 1;
+  }
+}

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/types/TransactionProcessingMetadata.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/types/TransactionProcessingMetadata.java
@@ -20,6 +20,7 @@ import static net.consensys.linea.zktracer.module.Util.getTxTypeAsInt;
 import static net.consensys.linea.zktracer.types.AddressUtils.effectiveToAddress;
 import static net.consensys.linea.zktracer.types.Conversions.bigIntegerToBoolean;
 import static net.consensys.linea.zktracer.types.Conversions.bigIntegerToBytes;
+import static net.consensys.linea.zktracer.types.TransactionUtils.transactionHasEip1559GasSemantics;
 import static org.hyperledger.besu.datatypes.TransactionType.FRONTIER;
 
 import java.math.BigInteger;
@@ -484,5 +485,9 @@ public class TransactionProcessingMetadata {
 
   public boolean isMessageCall() {
     return !isDeployment;
+  }
+
+  public boolean transactionTypeHasEip1559GasSemantics() {
+    return transactionHasEip1559GasSemantics(getBesuTransaction());
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/forkSpecific/prague/floorprice/NontrivialExecutionTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/forkSpecific/prague/floorprice/NontrivialExecutionTests.java
@@ -26,7 +26,7 @@ import net.consensys.linea.UnitTestWatcher;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.BytecodeRunner;
-import net.consensys.linea.zktracer.module.txndata.cancun.transactions.UserTransaction;
+import net.consensys.linea.zktracer.module.txndata.cancun.transactions.CancunUserTransaction;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.AccessListEntry;
@@ -51,7 +51,7 @@ public class NontrivialExecutionTests extends TracerTestBase {
   void adjustableByteCodeTest(
       Bytes byteCode,
       boolean provideAccessList,
-      UserTransaction.DominantCost dominantCostPrediction,
+      CancunUserTransaction.DominantCost dominantCostPrediction,
       TestInfo testInfo) {
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(byteCode);
     AccessListEntry accessListEntry =
@@ -61,8 +61,8 @@ public class NontrivialExecutionTests extends TracerTestBase {
     // Test blocks contain 4 transactions: 2 system transactions, 1 user transaction (the one we
     // created) and 1 noop transaction.
     if (isPostPrague(fork)) {
-      UserTransaction userTransaction =
-          (UserTransaction) bytecodeRunner.getHub().txnData().operations().get(2);
+      CancunUserTransaction userTransaction =
+          (CancunUserTransaction) bytecodeRunner.getHub().txnData().operations().get(2);
       Preconditions.checkArgument(userTransaction.getDominantCost() == dominantCostPrediction);
     }
   }
@@ -74,16 +74,16 @@ public class NontrivialExecutionTests extends TracerTestBase {
         Arguments.of(
             buildProgram(
                 TransactionCategory.MESSAGE_CALL,
-                UserTransaction.DominantCost.FLOOR_COST_DOMINATES),
+                CancunUserTransaction.DominantCost.FLOOR_COST_DOMINATES),
             false,
-            UserTransaction.DominantCost.FLOOR_COST_DOMINATES));
+            CancunUserTransaction.DominantCost.FLOOR_COST_DOMINATES));
     arguments.add(
         Arguments.of(
             buildProgram(
                 TransactionCategory.MESSAGE_CALL,
-                UserTransaction.DominantCost.EXECUTION_COST_DOMINATES),
+                CancunUserTransaction.DominantCost.EXECUTION_COST_DOMINATES),
             false,
-            UserTransaction.DominantCost.EXECUTION_COST_DOMINATES));
+            CancunUserTransaction.DominantCost.EXECUTION_COST_DOMINATES));
 
     return arguments.stream();
   }
@@ -109,14 +109,16 @@ public class NontrivialExecutionTests extends TracerTestBase {
   @ParameterizedTest
   @MethodSource("adjustableInitCodeTestSource")
   void adjustableInitCodeTest(
-      Bytes initCode, UserTransaction.DominantCost dominantCostPrediction, TestInfo testInfo) {
+      Bytes initCode,
+      CancunUserTransaction.DominantCost dominantCostPrediction,
+      TestInfo testInfo) {
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(initCode);
     bytecodeRunner.runInitCode(chainConfig, testInfo);
     // Test blocks contain 4 transactions: 2 system transactions, 1 user transaction (the one we
     // created) and 1 noop transaction.
     if (isPostPrague(fork)) {
-      UserTransaction userTransaction =
-          (UserTransaction) bytecodeRunner.getHub().txnData().operations().get(2);
+      CancunUserTransaction userTransaction =
+          (CancunUserTransaction) bytecodeRunner.getHub().txnData().operations().get(2);
       Preconditions.checkArgument(userTransaction.getDominantCost() == dominantCostPrediction);
     }
   }
@@ -127,14 +129,15 @@ public class NontrivialExecutionTests extends TracerTestBase {
     arguments.add(
         Arguments.of(
             buildProgram(
-                TransactionCategory.DEPLOYMENT, UserTransaction.DominantCost.FLOOR_COST_DOMINATES),
-            UserTransaction.DominantCost.FLOOR_COST_DOMINATES));
+                TransactionCategory.DEPLOYMENT,
+                CancunUserTransaction.DominantCost.FLOOR_COST_DOMINATES),
+            CancunUserTransaction.DominantCost.FLOOR_COST_DOMINATES));
     arguments.add(
         Arguments.of(
             buildProgram(
                 TransactionCategory.DEPLOYMENT,
-                UserTransaction.DominantCost.EXECUTION_COST_DOMINATES),
-            UserTransaction.DominantCost.EXECUTION_COST_DOMINATES));
+                CancunUserTransaction.DominantCost.EXECUTION_COST_DOMINATES),
+            CancunUserTransaction.DominantCost.EXECUTION_COST_DOMINATES));
 
     return arguments.stream();
   }
@@ -146,7 +149,7 @@ public class NontrivialExecutionTests extends TracerTestBase {
   }
 
   private static Bytes buildProgram(
-      TransactionCategory transactionCategory, UserTransaction.DominantCost dominantCost) {
+      TransactionCategory transactionCategory, CancunUserTransaction.DominantCost dominantCost) {
     return switch (transactionCategory) {
       case MESSAGE_CALL -> {
         /**
@@ -157,7 +160,7 @@ public class NontrivialExecutionTests extends TracerTestBase {
         BytecodeCompiler program = BytecodeCompiler.newProgram(chainConfig);
         program.op(
             OpCode.JUMPDEST,
-            dominantCost == UserTransaction.DominantCost.EXECUTION_COST_DOMINATES ? 12 : 11);
+            dominantCost == CancunUserTransaction.DominantCost.EXECUTION_COST_DOMINATES ? 12 : 11);
         yield program.compile();
       }
       case DEPLOYMENT -> {
@@ -168,7 +171,9 @@ public class NontrivialExecutionTests extends TracerTestBase {
         BytecodeCompiler program = BytecodeCompiler.newProgram(chainConfig);
         program.op(
             OpCode.JUMPDEST,
-            dominantCost == UserTransaction.DominantCost.EXECUTION_COST_DOMINATES ? 1395 : 1396);
+            dominantCost == CancunUserTransaction.DominantCost.EXECUTION_COST_DOMINATES
+                ? 1395
+                : 1396);
         yield program.compile();
       }
     };

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/forkSpecific/prague/floorprice/RefundTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/forkSpecific/prague/floorprice/RefundTests.java
@@ -30,8 +30,8 @@ import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.ToyTransaction;
 import net.consensys.linea.testing.TransactionProcessingResultValidator;
-import net.consensys.linea.zktracer.module.txndata.cancun.transactions.UserTransaction;
-import net.consensys.linea.zktracer.module.txndata.cancun.transactions.UserTransaction.DominantCost;
+import net.consensys.linea.zktracer.module.txndata.cancun.transactions.CancunUserTransaction;
+import net.consensys.linea.zktracer.module.txndata.cancun.transactions.CancunUserTransaction.DominantCost;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import net.consensys.linea.zktracer.types.AddressUtils;
 import org.apache.tuweni.bytes.Bytes;
@@ -121,8 +121,8 @@ public class RefundTests extends TracerTestBase {
     // transaction and the one we
     // created) and 1 noop transaction.
     if (isPostPrague(fork)) {
-      UserTransaction userTransaction =
-          (UserTransaction) toyExecutionEnvironmentV2.getHub().txnData().operations().get(3);
+      CancunUserTransaction userTransaction =
+          (CancunUserTransaction) toyExecutionEnvironmentV2.getHub().txnData().operations().get(3);
       Preconditions.checkArgument(userTransaction.getDominantCost() == dominantCostPrediction);
     }
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/forkSpecific/prague/floorprice/TrivialExecutionTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/forkSpecific/prague/floorprice/TrivialExecutionTests.java
@@ -26,8 +26,8 @@ import net.consensys.linea.UnitTestWatcher;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.BytecodeRunner;
-import net.consensys.linea.zktracer.module.txndata.cancun.transactions.UserTransaction;
-import net.consensys.linea.zktracer.module.txndata.cancun.transactions.UserTransaction.DominantCost;
+import net.consensys.linea.zktracer.module.txndata.cancun.transactions.CancunUserTransaction;
+import net.consensys.linea.zktracer.module.txndata.cancun.transactions.CancunUserTransaction.DominantCost;
 import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.AccessListEntry;
@@ -58,8 +58,8 @@ public class TrivialExecutionTests extends TracerTestBase {
     // Test blocks contain 4 transactions: 2 system transactions, 1 user transaction (the one we
     // created) and 1 noop transaction.
     if (isPostPrague(fork)) {
-      UserTransaction userTransaction =
-          (UserTransaction) bytecodeRunner.getHub().txnData().operations().get(2);
+      CancunUserTransaction userTransaction =
+          (CancunUserTransaction) bytecodeRunner.getHub().txnData().operations().get(2);
       Preconditions.checkArgument(userTransaction.getDominantCost() == dominantCostPrediction);
     }
   }
@@ -82,8 +82,8 @@ public class TrivialExecutionTests extends TracerTestBase {
     // Test blocks contain 4 transactions: 2 system transactions, 1 user transaction (the one we
     // created) and 1 noop transaction.
     if (isPostPrague(fork)) {
-      UserTransaction userTransaction =
-          (UserTransaction) bytecodeRunner.getHub().txnData().operations().get(2);
+      CancunUserTransaction userTransaction =
+          (CancunUserTransaction) bytecodeRunner.getHub().txnData().operations().get(2);
       Preconditions.checkArgument(userTransaction.getDominantCost() == dominantCostPrediction);
     }
   }

--- a/testing/src/main/java/net/consensys/linea/testing/BytecodeRunner.java
+++ b/testing/src/main/java/net/consensys/linea/testing/BytecodeRunner.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.TestInfo;
 @Accessors(fluent = true)
 public final class BytecodeRunner {
   public static final long DEFAULT_GAS_LIMIT =
-      16777216; // = 0x1000000 max tx gas limit since EIP-7825 (OSAKA)
+      EIP_7825_TRANSACTION_GAS_LIMIT_CAP; // = 0x1000000 max tx gas limit since EIP-7825 (OSAKA)
   private final Bytes byteCode;
   ToyExecutionEnvironmentV2 toyExecutionEnvironmentV2;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce Osaka TxnData/UserTransaction with EIP-7825 gas limit cap; remove TxnData generics and update hubs/blockdata; rename Cancun UserTransaction, adjust counting and tests.
> 
> - **Txndata/Hub API**:
>   - Refactor `TxnData` to be non-generic; update `Hub`, `Blockdata`, and fork hubs (`LondonHub`, `ShanghaiHub`, `CancunHub`) to return/use `TxnData`.
> - **Osaka support (EIP-7825)**:
>   - Add `txndata/osaka`: `OsakaTxnData`, `OsakaUserTransaction` implementing transaction gas limit cap check and updated row counts (`NB_ROWS_TXN_DATA_OSAKA_*`).
>   - `OsakaHub`: override `setTxnData()` to use `OsakaTxnData`.
> - **Cancun txndata**:
>   - Rename `UserTransaction` to `CancunUserTransaction`; update references and row constants (`NB_ROWS_TXN_DATA_CANCUN_USER_*`).
>   - Move 1559 gas-semantics check into `TransactionProcessingMetadata.transactionTypeHasEip1559GasSemantics()`; simplify usages.
>   - Adjust cumulative gas tracing type checks in `CancunTxnDataOperation`.
> - **Counting/Utilities**:
>   - `ZkCounter`: use Osaka row constants when tallying user tx rows.
>   - `BytecodeRunner`: set `DEFAULT_GAS_LIMIT` to `EIP_7825_TRANSACTION_GAS_LIMIT_CAP`.
> - **Tests/Deps**:
>   - Update tests to reference `CancunUserTransaction` enums/types.
>   - Bump `linea-constraints` submodule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0d3ed6dafb70e993136e2638ab52c761f7fd100. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->