### PR TITLE
Add system address account row to `HUB` system transaction processing

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/systemTransaction/EIP2935HistoricalHash.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/systemTransaction/EIP2935HistoricalHash.java
@@ -47,12 +47,17 @@ public class EIP2935HistoricalHash extends TraceSection {
               Bytes.minimalBytes(HISTORY_STORAGE_ADDRESS_HI),
               bigIntegerToBytes16(HISTORY_STORAGE_ADDRESS_LO)));
 
+  public static final Address SYSTEM_ADDRESS =
+      Address.fromHexString("0xfffffffffffffffffffffffffffffffffffffffe");
+
   public EIP2935HistoricalHash(final Hub hub, WorldView world, ProcessableBlockHeader blockHeader) {
     super(hub, NB_ROWS_HUB_SYSI_EIP2935);
     final long blockNumber = blockHeader.getNumber();
     final boolean currentBlockIsGenesis = blockNumber == 0;
     final long previousBlockNumber = currentBlockIsGenesis ? 0 : blockNumber - 1;
     final short previousBlockNumberMod8191 = (short) (previousBlockNumber % HISTORY_SERVE_WINDOW);
+    final AccountSnapshot systemAccountSnapshot =
+              AccountSnapshot.canonical(hub, world, SYSTEM_ADDRESS, false);
     final AccountSnapshot blockhashHistoryAccount =
         AccountSnapshot.canonical(hub, world, EIP2935_HISTORY_STORAGE_ADDRESS, false);
     final boolean isNonTrivialOperation =
@@ -70,6 +75,17 @@ public class EIP2935HistoricalHash extends TraceSection {
     fragments().add(transactionFragment);
     hub.txnData().callTxnDataForSystemTransaction(transactionFragment.type());
 
+    final AccountFragment systemAccountFragment =
+        hub.factories()
+            .accountFragment()
+            .makeWithTrm(
+                systemAccountSnapshot,
+                systemAccountSnapshot,
+                SYSTEM_ADDRESS,
+                DomSubStampsSubFragment.standardDomSubStamps(hubStamp(), 1),
+                SYSI);
+    fragments().add(systemAccountFragment);
+
     final AccountFragment accountFragment =
         hub.factories()
             .accountFragment()
@@ -77,7 +93,7 @@ public class EIP2935HistoricalHash extends TraceSection {
                 blockhashHistoryAccount,
                 blockhashHistoryAccount,
                 EIP2935_HISTORY_STORAGE_ADDRESS,
-                DomSubStampsSubFragment.standardDomSubStamps(hubStamp(), 1),
+                DomSubStampsSubFragment.standardDomSubStamps(hubStamp(), 2),
                 SYSI);
     fragments().add(accountFragment);
 
@@ -93,7 +109,7 @@ public class EIP2935HistoricalHash extends TraceSection {
                       .get(EIP2935_HISTORY_STORAGE_ADDRESS)
                       .getStorageValue(UInt256.fromBytes(key))),
               EWord.of(previousBlockhashOrZero),
-              2);
+              3);
       fragments().add(storingBlockhash);
     }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/systemTransaction/EIP4788BeaconBlockRootSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/systemTransaction/EIP4788BeaconBlockRootSection.java
@@ -45,6 +45,7 @@ public class EIP4788BeaconBlockRootSection extends TraceSection {
 
   public static final short NB_ROWS_HUB_SYSI_EIP4788 = 5;
 
+  public static final Address SYSTEM_ADDRESS = Address.fromHexString("0xfffffffffffffffffffffffffffffffffffffffe");
   public static final Address EIP4788_BEACONROOT_ADDRESS =
       AddressUtils.addressFromBytes(
           Bytes.concatenate(
@@ -57,6 +58,8 @@ public class EIP4788BeaconBlockRootSection extends TraceSection {
   public EIP4788BeaconBlockRootSection(
       Hub hub, WorldView world, ProcessableBlockHeader blockHeader) {
     super(hub, NB_ROWS_HUB_SYSI_EIP4788);
+    final AccountSnapshot systemAccountSnapshot =
+            AccountSnapshot.canonical(hub, world, SYSTEM_ADDRESS, false);
     final AccountSnapshot beaconrootAccount =
         AccountSnapshot.canonical(hub, world, EIP4788_BEACONROOT_ADDRESS, false);
     final BigInteger timestamp = longToUnsignedBigInteger(blockHeader.getTimestamp());
@@ -74,16 +77,27 @@ public class EIP4788BeaconBlockRootSection extends TraceSection {
     fragments().add(transactionFragment);
     hub.txnData().callTxnDataForSystemTransaction(transactionFragment.type());
 
-    final AccountFragment accountFragment =
+    final AccountFragment systemAccountFragment =
+        hub.factories()
+            .accountFragment()
+            .makeWithTrm(
+                systemAccountSnapshot,
+                systemAccountSnapshot,
+                SYSTEM_ADDRESS,
+                DomSubStampsSubFragment.standardDomSubStamps(hubStamp(), 1),
+                SYSI);
+    fragments().add(systemAccountFragment);
+
+    final AccountFragment eip4788smcAccountFragment =
         hub.factories()
             .accountFragment()
             .makeWithTrm(
                 beaconrootAccount,
                 beaconrootAccount,
                 EIP4788_BEACONROOT_ADDRESS,
-                DomSubStampsSubFragment.standardDomSubStamps(hubStamp(), 1),
+                DomSubStampsSubFragment.standardDomSubStamps(hubStamp(), 2),
                 SYSI);
-    fragments().add(accountFragment);
+    fragments().add(eip4788smcAccountFragment);
 
     if (isNonTrivialOperation) {
       final EWord keyTimestamp = EWord.of(timestamp.mod(HISTORY_BUFFER_LENGTH_BI));
@@ -97,7 +111,7 @@ public class EIP4788BeaconBlockRootSection extends TraceSection {
                       .get(EIP4788_BEACONROOT_ADDRESS)
                       .getStorageValue(UInt256.fromBytes(keyTimestamp))),
               EWord.of(timestamp),
-              2);
+              3);
       fragments().add(storingTimestamp);
 
       final EWord keyBeaconRoot = keyTimestamp.add(HISTORY_BUFFER_LENGTH);
@@ -111,7 +125,7 @@ public class EIP4788BeaconBlockRootSection extends TraceSection {
                       .get(EIP4788_BEACONROOT_ADDRESS)
                       .getStorageValue(UInt256.fromBytes(keyBeaconRoot))),
               EWord.of(beaconRoot),
-              3);
+              4);
       fragments().add(storingBeaconroot);
     }
 


### PR DESCRIPTION
Implementation of https://github.com/Consensys/linea-constraints/pull/802

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a system address account fragment to EIP-2935 and EIP-4788 sections, updating stamp counts and storage op indices accordingly.
> 
> - **Hub system transactions**:
>   - **EIP2935HistoricalHash (`EIP2935HistoricalHash.java`)**:
>     - Introduce `SYSTEM_ADDRESS` and add system account snapshot/fragment before the history account.
>     - Update `DomSubStampsSubFragment.standardDomSubStamps` from `1` to `2` for `EIP2935_HISTORY_STORAGE_ADDRESS`.
>     - Bump storage op index from `2` to `3`.
>   - **EIP4788BeaconBlockRootSection (`EIP4788BeaconBlockRootSection.java`)**:
>     - Introduce `SYSTEM_ADDRESS` and add system account snapshot/fragment before the beacon roots account.
>     - Update `DomSubStampsSubFragment.standardDomSubStamps` from `1` to `2` for `EIP4788_BEACONROOT_ADDRESS`.
>     - Bump storage op indices `2→3` and `3→4`.
> - **Dependencies**: update `linea-constraints` submodule reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71449f013dc3c00101202b5d761f7f4ce0fd67b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->