### PR TITLE
feat: add floor gas cost for prague when running runOnlyForGasCost in…

### DIFF
--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionTools.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionTools.java
@@ -314,12 +314,15 @@ public class ToyExecutionTools {
       processor.process(messageFrameStack.peekFirst(), tracer);
     }
 
-    final long intrinsicTxCostWithNoAccessOrDelegationCost =
-        tracer.getHub().gasCalculator.transactionIntrinsicGasCost(tx, 0);
+    final long intrinsicGasCostOrFloor =
+        Math.max(
+            tracer.getHub().gasCalculator.transactionIntrinsicGasCost(tx, 0),
+            tracer
+                .getHub()
+                .gasCalculator
+                .transactionFloorCost(tx.getPayload(), tx.getPayloadZeroBytes()));
 
-    return LINEA_BLOCK_GAS_LIMIT
-        - initialMessageFrame.getRemainingGas()
-        + intrinsicTxCostWithNoAccessOrDelegationCost;
+    return LINEA_BLOCK_GAS_LIMIT - initialMessageFrame.getRemainingGas() + intrinsicGasCostOrFloor;
   }
 
   private static boolean shouldClearEmptyAccounts(final String eip) {


### PR DESCRIPTION
… tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Compute gas using the max of intrinsic gas and transaction floor cost in `executeTestOnlyForGasCost`.
> 
> - **Testing utilities**:
>   - Update `testing/src/main/java/net/consensys/linea/testing/ToyExecutionTools.java`:
>     - In `executeTestOnlyForGasCost`, compute `intrinsicGasCostOrFloor = max(gasCalculator.transactionIntrinsicGasCost(tx, 0), gasCalculator.transactionFloorCost(tx.getPayload(), tx.getPayloadZeroBytes()))` and use it in the returned gas value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5794c697db3671feecfaa580f6c30f9e9a656aac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->