### PR TITLE
chore: update besu to 25.10.0-linea1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 releaseVersion=beta-v4.0-rc12
-besuVersion=25.10.0-RC2-linea1
+besuVersion=25.10.0-linea1
 shomeiVersion=2.4-develop
 besuShomeiPluginVersion=v0.7.4
 besuArtifactGroup=org.hyperledger.besu

--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -70,8 +70,7 @@ public class BlockchainReferenceTestTools {
   // Keep the forkName and the zkevm_fork in github worklow in PascalCase
   private static final Fork fork = getForkOrDefault(LONDON);
   private static final ReferenceTestProtocolSchedules REFERENCE_TEST_PROTOCOL_SCHEDULES =
-      ReferenceTestProtocolSchedules.create();
-
+      ReferenceTestProtocolSchedules.getInstance();
   private static final List<String> NETWORKS_TO_RUN = List.of(toPascalCase(fork));
 
   public static final JsonTestParameters<?, ?> PARAMS =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps Besu to 25.10.0-linea1 and updates tests to use ReferenceTestProtocolSchedules.getInstance().
> 
> - **Dependencies**:
>   - Update `besuVersion` in `gradle.properties` from `25.10.0-RC2-linea1` to `25.10.0-linea1`.
> - **Tests**:
>   - Replace `ReferenceTestProtocolSchedules.create()` with `ReferenceTestProtocolSchedules.getInstance()` in `reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd9059b09f09cf3fae5eec912c09aae2dfcb8c57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->