### PR TITLE
fix: BlockHeaderSnapshot

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/blockcapture/snapshots/BlockHeaderSnapshot.java
+++ b/arithmetization/src/main/java/net/consensys/linea/blockcapture/snapshots/BlockHeaderSnapshot.java
@@ -90,7 +90,8 @@ public record BlockHeaderSnapshot(
             .blockHeaderFunctions(new CliqueBlockHeaderFunctions());
 
     this.baseFee.ifPresent(baseFee -> builder.baseFee(Wei.fromHexString(baseFee)));
-    this.parentBeaconBlockRoot.ifPresent(root -> builder.parentBeaconBlockRoot(Bytes32.fromHexString(root)));
+    this.parentBeaconBlockRoot.ifPresent(
+        root -> builder.parentBeaconBlockRoot(Bytes32.fromHexString(root)));
     return builder.buildBlockHeader();
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/blockcapture/snapshots/BlockHeaderSnapshot.java
+++ b/arithmetization/src/main/java/net/consensys/linea/blockcapture/snapshots/BlockHeaderSnapshot.java
@@ -46,7 +46,7 @@ public record BlockHeaderSnapshot(
     String mixHashOrPrevRandao,
     long nonce,
     Optional<String> baseFee,
-    Bytes32 parentBeaconBlockRoot) {
+    Optional<String> parentBeaconBlockRoot) {
   public static BlockHeaderSnapshot from(BlockHeader header) {
     return new BlockHeaderSnapshot(
         header.getParentHash().toHexString(),
@@ -65,7 +65,7 @@ public record BlockHeaderSnapshot(
         header.getMixHashOrPrevRandao().toHexString(),
         header.getNonce(),
         header.getBaseFee().map(Quantity::toHexString),
-        header.getParentBeaconBlockRoot().orElse(null));
+        header.getParentBeaconBlockRoot().map(Bytes::toHexString));
   }
 
   public BlockHeader toBlockHeader() {
@@ -87,11 +87,10 @@ public record BlockHeaderSnapshot(
             .mixHash(Hash.fromHexString(this.mixHashOrPrevRandao))
             .prevRandao(Bytes32.fromHexString(this.mixHashOrPrevRandao))
             .nonce(this.nonce)
-            .blockHeaderFunctions(new CliqueBlockHeaderFunctions())
-            .parentBeaconBlockRoot(parentBeaconBlockRoot);
+            .blockHeaderFunctions(new CliqueBlockHeaderFunctions());
 
     this.baseFee.ifPresent(baseFee -> builder.baseFee(Wei.fromHexString(baseFee)));
-
+    this.parentBeaconBlockRoot.ifPresent(root -> builder.parentBeaconBlockRoot(Bytes32.fromHexString(root)));
     return builder.buildBlockHeader();
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ChainConfig.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ChainConfig.java
@@ -37,6 +37,7 @@ public class ChainConfig {
    * billion). As the name suggest, this is only intended for testing purposes.
    */
   public static final ChainConfig MAINNET_LONDON_TESTCONFIG = MAINNET_TESTCONFIG(LONDON);
+
   public static final ChainConfig SEPOLIA_PRAGUE_TESTCONFIG = SEPOLIA_TESTCONFIG(PRAGUE);
 
   public static final ChainConfig MAINNET_TESTCONFIG(final Fork fork) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ChainConfig.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ChainConfig.java
@@ -15,6 +15,7 @@
 package net.consensys.linea.zktracer;
 
 import static net.consensys.linea.zktracer.Fork.LONDON;
+import static net.consensys.linea.zktracer.Fork.PRAGUE;
 import static net.consensys.linea.zktracer.Trace.ETHEREUM_GAS_LIMIT_MAXIMUM;
 import static net.consensys.linea.zktracer.Trace.ETHEREUM_GAS_LIMIT_MINIMUM;
 import static net.consensys.linea.zktracer.Trace.LINEA_CHAIN_ID;
@@ -36,11 +37,22 @@ public class ChainConfig {
    * billion). As the name suggest, this is only intended for testing purposes.
    */
   public static final ChainConfig MAINNET_LONDON_TESTCONFIG = MAINNET_TESTCONFIG(LONDON);
+  public static final ChainConfig SEPOLIA_PRAGUE_TESTCONFIG = SEPOLIA_TESTCONFIG(PRAGUE);
 
   public static final ChainConfig MAINNET_TESTCONFIG(final Fork fork) {
     return new ChainConfig(
         fork,
         LINEA_CHAIN_ID,
+        true,
+        BigInteger.valueOf(LINEA_GAS_LIMIT_MINIMUM),
+        BigInteger.valueOf(LINEA_GAS_LIMIT_MAXIMUM),
+        LineaL1L2BridgeSharedConfiguration.TEST_DEFAULT);
+  }
+
+  public static final ChainConfig SEPOLIA_TESTCONFIG(final Fork fork) {
+    return new ChainConfig(
+        fork,
+        LINEA_SEPOLIA_CHAIN_ID,
         true,
         BigInteger.valueOf(LINEA_GAS_LIMIT_MINIMUM),
         BigInteger.valueOf(LINEA_GAS_LIMIT_MAXIMUM),

--- a/testing/src/main/java/net/consensys/linea/testing/ReplayExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ReplayExecutionEnvironment.java
@@ -41,6 +41,7 @@ import net.consensys.linea.blockcapture.snapshots.TransactionSnapshot;
 import net.consensys.linea.corset.CorsetValidator;
 import net.consensys.linea.zktracer.ChainConfig;
 import net.consensys.linea.zktracer.ConflationAwareOperationTracer;
+import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.ZkTracer;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import org.apache.commons.io.FileUtils;
@@ -288,10 +289,12 @@ public class ReplayExecutionEnvironment {
           new BlockBody(
               blockSnapshot.txs().stream().map(TransactionSnapshot::toTransaction).toList(),
               new ArrayList<>());
+      // Determine mining beneficiay
       final Address miningBeneficiary =
           useCoinbaseAddressFromBlockHeader
               ? header.getCoinbase()
-              : CliqueHelpers.getProposerOfBlock(header);
+              : determineMiningBeneficiary(header, chain.fork);
+
       tracer.traceStartBlock(world.updater(), header, body, miningBeneficiary);
       runSystemInitialTransactions(protocolSpec, chain.fork, world, header, tracer);
 
@@ -319,6 +322,15 @@ public class ReplayExecutionEnvironment {
 
   public Hub getHub() {
     return zkTracer.getHub();
+  }
+
+  private static Address determineMiningBeneficiary(BlockHeader header, Fork fork) {
+    // Clique was only used on forks prior to Shanghai
+    if (Fork.isPostShanghai(fork)) {
+      return header.getCoinbase();
+    } else {
+      return CliqueHelpers.getProposerOfBlock(header);
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make `parentBeaconBlockRoot` optional hex in `BlockHeaderSnapshot`, add Sepolia Prague test config, and select mining beneficiary by fork (post-Shanghai uses coinbase).
> 
> - **Block capture / snapshots**:
>   - Convert `BlockHeaderSnapshot.parentBeaconBlockRoot` from `Bytes32` to `Optional<String>` and serialize as hex via `map(Bytes::toHexString)`.
>   - In `toBlockHeader()`, set `parentBeaconBlockRoot` only when present (`Bytes32.fromHexString(...)`); keep `CliqueBlockHeaderFunctions` setup.
> - **Testing / replay**:
>   - Determine mining beneficiary by fork: post-Shanghai uses `header.getCoinbase()`, otherwise `CliqueHelpers.getProposerOfBlock(...)`.
> - **Chain config**:
>   - Add `SEPOLIA_TESTCONFIG(fork)` and `SEPOLIA_PRAGUE_TESTCONFIG` for Prague on Sepolia.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit add5f6a59c28b42686bb0a6eef1f15adbc03d63f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->