### PR TITLE
Chore: set besuVersion=25.10.0-linea2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 releaseVersion=beta-v4.0-rc12
-besuVersion=25.10.0-linea1
+besuVersion=25.10.0-linea2
 shomeiVersion=2.4-develop
 besuShomeiPluginVersion=v0.7.4
 besuArtifactGroup=org.hyperledger.besu

--- a/testing/src/main/java/net/consensys/linea/testing/EngineAPIService.java
+++ b/testing/src/main/java/net/consensys/linea/testing/EngineAPIService.java
@@ -132,7 +132,6 @@ public class EngineAPIService {
       if (isPostCancun(fork)) {
         blobsBundle = (ObjectNode) result.get("blobsBundle");
         executionRequests = (ArrayNode) result.get("executionRequests");
-        parentBeaconBlockRoot = executionPayload.remove("parentBeaconBlockRoot").asText();
         // Transform KZG commitments to versioned hashes
         for (JsonNode kzgCommitment : blobsBundle.get("commitments")) {
           Bytes kzgBytes = Bytes.fromHexString(kzgCommitment.asText());


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps Besu to 25.10.0-linea2 and removes `parentBeaconBlockRoot` extraction from test Engine API payload handling.
> 
> - **Build/Config**:
>   - Bump `gradle.properties` `besuVersion` to `25.10.0-linea2`.
> - **Testing**:
>   - In `testing/src/main/java/net/consensys/linea/testing/EngineAPIService.java`, stop extracting/removing `parentBeaconBlockRoot` from `executionPayload` in post-Cancun `engine_getPayload` handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8c3726a6185de55cc26b21df0b739f37adbfb30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->