### PR TITLE
fix: permissions to write on manual release

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -2,7 +2,8 @@
 # a release is made manually on github.
 name: Manual Release Assets
 permissions:
-  contents: read
+  contents: write
+  packages: write
 
 on:
   release:
@@ -159,9 +160,6 @@ jobs:
     needs: [build, unit-tests-london, unit-tests-paris, unit-tests-shanghai, unit-tests-cancun, unit-tests-prague, replay-tests]
     if: github.event_name != 'pull_request'
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
-    permissions:
-      contents: write
-      packages: write
     env:
       architecture: "amd64"
       GRADLE_OPTS: "-Xmx6g -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4"


### PR DESCRIPTION
Tested here https://github.com/Consensys/linea-tracer/actions/runs/18603795269

Can be merged