### PR TITLE
feat: run units and replay in // of jar building for releases

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -157,7 +157,7 @@ jobs:
   # Publish release post tests
   # ==================================================================
   publish:
-    needs: [build, unit-tests-london, unit-tests-paris, unit-tests-shanghai, unit-tests-cancun, unit-tests-prague, replay-tests]
+    needs: [ build ]
     if: github.event_name != 'pull_request'
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
     env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update `.github/workflows/manual-release.yml` to have `publish` depend only on `build` (removing unit/replay test dependencies).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b21f16a321de4ef28188453887f167119c1d8237. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->