### PR TITLE
fix: cherry-pick commit 3edbc80

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnDataOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/txndata/cancun/CancunTxnDataOperation.java
@@ -76,8 +76,7 @@ public abstract class CancunTxnDataOperation extends TxnDataOperation {
 
   private void traceCommonSaveForFlags(
       Trace.Txndata trace, int ct, long totalUserTransactionsInConflation) {
-    final long relativeUserTxNumMax =
-        this instanceof CancunUserTransaction ? blockSnapshot.getNbOfTxsInBlock() : 0;
+    final long relativeUserTxNumMax = blockSnapshot.getNbOfTxsInBlock();
     trace
         // BLK_NUMBER is (defcomputed ...)
         // TOTL_TXN_NUMBER is (defcomputed ...)


### PR DESCRIPTION
This cherry-picks a commit made against `beta-v4.0-rc17` entitled simply `ras` which updated the calculation of `relativeUserTxNumMax`.

This also then updates `linea-constraints` accordingly to ensure all is well.