### PR TITLE
Chore: set besuVersion=25.10.0-linea3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 releaseVersion=beta-v4.0-rc12
-besuVersion=25.10.0-linea2
+besuVersion=25.10.0-linea3
 shomeiVersion=2.4-develop
 besuShomeiPluginVersion=v0.7.4
 besuArtifactGroup=org.hyperledger.besu

--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -70,7 +70,7 @@ public class BlockchainReferenceTestTools {
   // Keep the forkName and the zkevm_fork in github worklow in PascalCase
   private static final Fork fork = getForkOrDefault(LONDON);
   private static final ReferenceTestProtocolSchedules REFERENCE_TEST_PROTOCOL_SCHEDULES =
-      ReferenceTestProtocolSchedules.getInstance();
+      ReferenceTestProtocolSchedules.create();
   private static final List<String> NETWORKS_TO_RUN = List.of(toPascalCase(fork));
 
   public static final JsonTestParameters<?, ?> PARAMS =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade Besu to 25.10.0-linea3 and switch reference test schedules to use create() instead of getInstance().
> 
> - **Build**:
>   - Bump `besuVersion` in `gradle.properties` to `25.10.0-linea3`.
> - **Tests**:
>   - Initialize `REFERENCE_TEST_PROTOCOL_SCHEDULES` via `ReferenceTestProtocolSchedules.create()` in `reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48413b71e85c523a2e55e81567f10016e13276d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->