### PR TITLE
fix: stack section shouldn't call stateless module when exception

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/StackOnlySection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/StackOnlySection.java
@@ -18,6 +18,7 @@ package net.consensys.linea.zktracer.module.hub.section;
 import static net.consensys.linea.zktracer.opcode.OpCode.*;
 
 import net.consensys.linea.zktracer.module.hub.Hub;
+import net.consensys.linea.zktracer.module.hub.signals.Exceptions;
 import net.consensys.linea.zktracer.opcode.OpCodeData;
 
 public class StackOnlySection extends TraceSection {
@@ -28,20 +29,22 @@ public class StackOnlySection extends TraceSection {
 
     this.addStack(hub);
 
-    switch (opcode.instructionFamily()) {
-      case ADD -> hub.add().callAdd(hub.messageFrame(), opcode.mnemonic());
-      case BIN -> hub.bin().callBin(hub.messageFrame(), opcode.mnemonic());
-      case MOD -> hub.mod().callMod(hub.messageFrame(), opcode.mnemonic());
-      case SHF -> hub.shf().callShf(hub.messageFrame(), opcode.mnemonic());
-      case WCP -> hub.wcp().callWcp(hub.messageFrame(), opcode.mnemonic());
-      case EXT -> hub.ext().callExt(hub.messageFrame(), opcode.mnemonic());
-      case MUL -> hub.mul().callMul(hub.messageFrame(), opcode.mnemonic());
-      case BATCH -> {
-        if (opcode.mnemonic() == BLOCKHASH) {
-          hub.blockhash().callBlockhash(hub.messageFrame());
+    if (Exceptions.none(hub.pch().exceptions())) {
+      switch (opcode.instructionFamily()) {
+        case ADD -> hub.add().callAdd(hub.messageFrame(), opcode.mnemonic());
+        case BIN -> hub.bin().callBin(hub.messageFrame(), opcode.mnemonic());
+        case MOD -> hub.mod().callMod(hub.messageFrame(), opcode.mnemonic());
+        case SHF -> hub.shf().callShf(hub.messageFrame(), opcode.mnemonic());
+        case WCP -> hub.wcp().callWcp(hub.messageFrame(), opcode.mnemonic());
+        case EXT -> hub.ext().callExt(hub.messageFrame(), opcode.mnemonic());
+        case MUL -> hub.mul().callMul(hub.messageFrame(), opcode.mnemonic());
+        case BATCH -> {
+          if (opcode.mnemonic() == BLOCKHASH) {
+            hub.blockhash().callBlockhash(hub.messageFrame());
+          }
         }
+        default -> {}
       }
-      default -> {}
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Only dispatch stack-only operations in `StackOnlySection` when `Exceptions.none(hub.pch().exceptions())` is true.
> 
> - **Hub / StackOnlySection**
>   - Gate stateless calls (`add`, `bin`, `mod`, `shf`, `wcp`, `ext`, `mul`, `blockhash`) behind `Exceptions.none(hub.pch().exceptions())`.
>   - Adds `Exceptions` import and wraps opcode family switch in the exception check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39a7f8a9f696bf9f271e1f84917e98ff1c930c92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->