### PR TITLE
EIP-4788 storage key fix

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/blockcapture/reapers/Reaper.java
+++ b/arithmetization/src/main/java/net/consensys/linea/blockcapture/reapers/Reaper.java
@@ -88,9 +88,10 @@ public class Reaper {
     try {
       conflationAddresses.touch(EIP4788_BEACONROOT_ADDRESS);
       final UInt256 timestamp = UInt256.valueOf(header.getTimestamp());
-      final UInt256 keyTimestamp = timestamp.mod(HISTORY_BUFFER_LENGTH);
-      conflationStorage.touch(EIP4788_BEACONROOT_ADDRESS, timestamp);
-      conflationStorage.touch(EIP4788_BEACONROOT_ADDRESS, keyTimestamp);
+      final UInt256 timestampIdx = timestamp.mod(HISTORY_BUFFER_LENGTH);
+      final UInt256 rootIdx = timestampIdx.add(HISTORY_BUFFER_LENGTH);
+      conflationStorage.touch(EIP4788_BEACONROOT_ADDRESS, timestampIdx);
+      conflationStorage.touch(EIP4788_BEACONROOT_ADDRESS, rootIdx);
     } catch (Exception e) {
       log.warn(
           "Failed to retrieve EIP4788 infos for block {}, exception caught is: {}",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjust EIP-4788 storage keys to use computed history buffer indices (`timestampIdx`, `rootIdx`) instead of raw timestamp.
> 
> - **EIP-4788 storage key calculation**:
>   - In `Reaper.touchedBySystemTransactions`, replace touches using raw `timestamp` with ring-buffer indices: `timestampIdx = timestamp % HISTORY_BUFFER_LENGTH` and `rootIdx = timestampIdx + HISTORY_BUFFER_LENGTH`.
>   - Touch `conflationStorage` at `timestampIdx` and `rootIdx` for `EIP4788_BEACONROOT_ADDRESS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ada993b67794bd95fc79999f85aa370a20517eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->