### PR TITLE
fix: gas calculation for TX skip

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/skip/TxSkipSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/skip/TxSkipSection.java
@@ -126,7 +126,8 @@ public abstract class TxSkipSection extends TraceSection implements EndTransacti
     final Wei value = (Wei) txMetadata.getBesuTransaction().getValue();
 
     if (txMetadata.senderAddressCollision()) {
-      final BigInteger gasUsed = BigInteger.valueOf(txMetadata.getGasUsed());
+      final BigInteger gasUsed =
+          BigInteger.valueOf(txMetadata.getGasLimit() - txMetadata.getGasRefunded());
       final BigInteger gasPrice = BigInteger.valueOf(txMetadata.getEffectiveGasPrice());
       final BigInteger gasCost = gasUsed.multiply(gasPrice);
       senderNew =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Compute gas cost in `TxSkipSection` sender-collision path using `gasLimit - gasRefunded` instead of `getGasUsed`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d646cfb3505fba41e984fd5abbe5d324b59d0e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->