### PR TITLE
Chore: set besuVersion=25.11.0-RC1-linea2

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaL1L2BridgeSharedCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaL1L2BridgeSharedCliOptions.java
@@ -19,7 +19,7 @@ import com.google.common.base.MoreObjects;
 import net.consensys.linea.plugins.LineaCliOptions;
 import net.consensys.linea.plugins.config.converters.AddressConverter;
 import net.consensys.linea.plugins.config.converters.BytesConverter;
-import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Address;
 import picocli.CommandLine;
 
@@ -42,7 +42,7 @@ public class LineaL1L2BridgeSharedCliOptions implements LineaCliOptions {
       paramLabel = "<HEX_STRING>",
       converter = BytesConverter.class,
       description = "The log topic of the L1 L2 bridge (default: ${DEFAULT-VALUE})")
-  private Bytes l1l2BridgeTopic = Bytes.EMPTY;
+  private Bytes32 l1l2BridgeTopic = Bytes32.ZERO;
 
   private LineaL1L2BridgeSharedCliOptions() {}
 

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaL1L2BridgeSharedConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaL1L2BridgeSharedConfiguration.java
@@ -17,17 +17,17 @@ package net.consensys.linea.plugins.config;
 
 import lombok.Builder;
 import net.consensys.linea.plugins.LineaOptionsConfiguration;
-import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Address;
 
 /** The Linea L1 L2 bridge configuration. */
 @Builder(toBuilder = true)
-public record LineaL1L2BridgeSharedConfiguration(Address contract, Bytes topic)
+public record LineaL1L2BridgeSharedConfiguration(Address contract, Bytes32 topic)
     implements LineaOptionsConfiguration {
 
   // = Hash(MessageSent(address,address,uint256,uint256,uint256,bytes,bytes32))
-  private static Bytes LINEA_L2L1TOPIC =
-      Bytes.fromHexString("0xe856c2b8bd4eb0027ce32eeaf595c21b0b6b4644b326e5b7bd80a1cf8db72e6c");
+  private static Bytes32 LINEA_L2L1TOPIC =
+      Bytes32.fromHexString("0xe856c2b8bd4eb0027ce32eeaf595c21b0b6b4644b326e5b7bd80a1cf8db72e6c");
 
   private static final Address SEPOLIA_L2L1LOGS_SMC =
       Address.fromHexString("0x971e727e956690b9957be6d51Ec16E73AcAC83A7");
@@ -41,6 +41,6 @@ public record LineaL1L2BridgeSharedConfiguration(Address contract, Bytes topic)
   public static final LineaL1L2BridgeSharedConfiguration EMPTY =
       LineaL1L2BridgeSharedConfiguration.builder()
           .contract(Address.ZERO)
-          .topic(Bytes.EMPTY)
+          .topic(Bytes32.ZERO)
           .build();
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -117,6 +117,7 @@ import net.consensys.linea.zktracer.types.Bytecode;
 import net.consensys.linea.zktracer.types.MemoryRange;
 import net.consensys.linea.zktracer.types.TransactionProcessingMetadata;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Transaction;
@@ -434,7 +435,7 @@ public abstract class Hub implements Module {
     gasProjector = new GasProjector(fork, gasCalculator);
     checkState(chain.id.signum() >= 0, "Hub constructor: chain id must be non-negative");
     final Address l2l1ContractAddress = chain.bridgeConfiguration.contract();
-    final Bytes l2l1Topic = chain.bridgeConfiguration.topic();
+    final Bytes32 l2l1Topic = chain.bridgeConfiguration.topic();
     if (l2l1ContractAddress.equals(TEST_DEFAULT.contract())) {
       log.info("WARN: Using default testing L2L1 contract address");
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 releaseVersion=beta-v4.0-rc12
-besuVersion=25.10.0-linea3
+besuVersion=25.11.0-RC1-linea2
 shomeiVersion=2.4-develop
 besuShomeiPluginVersion=v0.7.4
 besuArtifactGroup=org.hyperledger.besu

--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -918,8 +918,10 @@ public class BlockchainReferenceTestTools {
 
   public static void executeTest(final BlockchainReferenceTestCaseSpec spec) {
     final BlockHeader genesisBlockHeader = spec.getGenesisBlockHeader();
+    final ProtocolContext context = spec.buildProtocolContext();
     final MutableWorldState worldState =
-        spec.getWorldStateArchive()
+        context
+            .getWorldStateArchive()
             .getWorldState(
                 WorldStateQueryParams.withStateRootAndBlockHashAndUpdateNodeHead(
                     genesisBlockHeader.getStateRoot(), genesisBlockHeader.getHash()))
@@ -933,7 +935,6 @@ public class BlockchainReferenceTestTools {
         REFERENCE_TEST_PROTOCOL_SCHEDULES.getByName(spec.getNetwork());
     final ChainConfig chain = ChainConfig.ETHEREUM_CHAIN(fork);
     final MutableBlockchain blockchain = spec.getBlockchain();
-    final ProtocolContext context = spec.getProtocolContext();
 
     // Add system accounts if the fork requires it.
     addSystemAccountsIfRequired(worldState.updater(), chain.fork);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches L1/L2 bridge topic to `Bytes32` across config and hub, refactors tests to build protocol context, and bumps Besu version.
> 
> - **Core/Config**:
>   - Change L1/L2 bridge topic type from `Bytes` to `Bytes32` in `LineaL1L2BridgeSharedConfiguration` and `LineaL1L2BridgeSharedCliOptions` (defaults updated to `Bytes32.ZERO`; constant `LINEA_L2L1TOPIC` now `Bytes32`).
> - **Hub**:
>   - Update `l2l1Topic` to `Bytes32` and pass to `LogTopic.of(...)` in `net/consensys/linea/zktracer/module/hub/Hub.java`.
> - **Tests**:
>   - Use `spec.buildProtocolContext()` to obtain `ProtocolContext` and world state in `BlockchainReferenceTestTools`; remove use of `spec.getProtocolContext()`.
> - **Dependencies**:
>   - Bump `besuVersion` to `25.11.0-RC1-linea2` in `gradle.properties`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4883655e13fc6adc8bf9c4795ca5789428baee76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->