### PR TITLE
Initialize AccountSnapshot with the hash of the byteCode

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java
@@ -89,8 +89,10 @@ public class AccountSnapshot {
     final Account account = worldView.get(address);
     final Bytecode bytecode =
         deploymentInfo.getDeploymentStatus(address)
-            ? new Bytecode(deploymentInfo.getInitializationCode(address))
-            : (account == null) ? new Bytecode(Bytes.EMPTY) : new Bytecode(account.getCode());
+            ? new Bytecode(deploymentInfo.getInitializationCode(address), true)
+            : (account == null)
+                ? new Bytecode(Bytes.EMPTY, true)
+                : new Bytecode(account.getCode(), true);
     if (account != null) {
       return new AccountSnapshot(
           account.getAddress(),
@@ -140,7 +142,7 @@ public class AccountSnapshot {
                     a.getNonce(),
                     a.getBalance().copy(),
                     isWarm,
-                    new Bytecode(a.getCode().copy()),
+                    new Bytecode(a.getCode().copy(), true),
                     deploymentNumber,
                     deploymentStatus))
         .orElseGet(() -> AccountSnapshot.empty(isWarm, deploymentNumber, deploymentStatus));

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/types/Bytecode.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/types/Bytecode.java
@@ -51,6 +51,19 @@ public final class Bytecode {
   }
 
   /**
+   * Create an instance from {@link Bytes}.
+   *
+   * @param bytes the bytecode
+   */
+  public Bytecode(Bytes bytes, boolean calculateByteCodeHash) {
+    this.bytecode = Objects.requireNonNullElse(bytes, Bytes.EMPTY);
+    if (calculateByteCodeHash) {
+      if (bytes.isEmpty()) this.hash = Hash.EMPTY;
+      else this.hash = Hash.hash(bytes);
+    }
+  }
+
+  /**
    * Create an instance from Besu {@link Code}.
    *
    * @param code the bytecode

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/types/Bytecode.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/types/Bytecode.java
@@ -54,6 +54,7 @@ public final class Bytecode {
    * Create an instance from {@link Bytes}.
    *
    * @param bytes the bytecode
+   * @param calculateByteCodeHash indicates if we need to compute the hash of the bytecode or not
    */
   public Bytecode(Bytes bytes, boolean calculateByteCodeHash) {
     this.bytecode = Objects.requireNonNullElse(bytes, Bytes.EMPTY);


### PR DESCRIPTION
During load testing with ERC20 transaction, we noticed a performance regression related to calculating the hash of the bytecode of each AccountSnapshot.

<img width="1249" height="763" alt="image" src="https://github.com/user-attachments/assets/f2a142c3-8f86-43ee-97ef-2b04b2059dcc" />


From my investigation, this is related to having the initial AccountSnapshot referencing an instance of Bytecode that doesn't have the hash computed. In this case, `deepCopy()` will create an instance of AccountSnapshot that is also referencing an instance of Bytecode that is missing its hash. 

This PR introduces a new constructor that initializes the hash of the bytecode alongside the bytecode.
 
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Precompute and store bytecode hash for AccountSnapshot by introducing a Bytecode constructor that can eagerly calculate the code hash.
> 
> - **Hub**:
>   - Initialize `AccountSnapshot` code using `new Bytecode(..., true)` to precompute code hash in `fromArguments` and `fromAccount`.
> - **Types**:
>   - Add `Bytecode(Bytes bytes, boolean calculateByteCodeHash)` constructor to optionally precompute and memoize code hash.
>   - Keep existing constructors and hash memoization behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b452e0af13753597172953a1983a46b37bd96836. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->