### PR TITLE
Compute `tracedHasCode` via byte code size for performance reasons

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java
@@ -281,6 +281,6 @@ public class AccountSnapshot {
   }
 
   public boolean tracedHasCode() {
-    return !this.tracedCodeHash().equals(EWord.of(Hash.EMPTY));
+    return !this.deploymentStatus() && !this.code().isEmpty();
   }
 }


### PR DESCRIPTION
This may help fix @ameziane's performance issue by preventing excessive code hash computations.

Note: this deviates from the spec which identifies empty code (`HAS_CODE` IIRC) using a comparison of the code hash to
```
KECCAK(())
```
It _should_ be functionally equivalent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `tracedHasCode` hash comparison with a check on deployment status and bytecode emptiness to avoid code-hash computation.
> 
> - **Hub module**
>   - **`arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/AccountSnapshot.java`**:
>     - Update `tracedHasCode()` to return `!deploymentStatus && !code.isEmpty()` instead of comparing `tracedCodeHash()` to empty hash.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ab6d85e9de5423f1c1da83e40632784a92dff98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->