### PR TITLE
feat: make jar release condition to unit and replay passing by default'

### DIFF
--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -71,42 +71,6 @@ jobs:
   replay-tests:
     if: github.event.pull_request.draft == false && github.base_ref != 'main'
     needs: [ build ]
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          submodules: false
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          enable-ssh: ${{ inputs.tests-with-ssh }}
-
-      - name: Run replay tests
-        run: GOMEMLIMIT=26GiB ./gradlew :arithmetization:fastReplayTests
-        env:
-          JAVA_OPTS: -Dorg.gradle.daemon=false
-          JUNIT_TESTS_PARALLELISM: 4
-          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
-
-      - name: Upload test report
-        if: ${{ always() }}
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-        with:
-          name: replay-tests-report
-          path: arithmetization/build/reports/tests/**/*
-
-      - name: Upload jacoco fast replay tests coverage report
-        if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-        with:
-          name: jacoco-fast-replay-tests-coverage-report
-          path: arithmetization/build/reports/jacoco/jacocoFastReplayTestsReport/**/*
-
-      - name: Upload jacoco fast replay tests exec file
-        if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-        with:
-          name: jacoco-fast-replay-tests-exec-file
-          path: arithmetization/build/jacoco/fastReplayTests.exec
+    uses: ./.github/workflows/reusable-fast-replay-tests.yml
+    with:
+      tests-with-ssh: ${{ inputs.tests-with-ssh || false}}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -145,23 +145,23 @@ jobs:
           CLOUDSMITH_USER: ${{ secrets.CLOUDSMITH_USER }}
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
 
-    publish-as-soon-as-ready:
-      needs: [ build ]
-      if: ${{ github.event_name != 'pull_request' && inputs.wait-for-tests-bef-publish == 'false'}}
-      runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
-      env:
-        architecture: "amd64"
-        GRADLE_OPTS: "-Xmx6g -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4"
+  publish-as-soon-as-ready:
+    needs: [ build ]
+    if: ${{ github.event_name != 'pull_request' && inputs.wait-for-tests-bef-publish == 'false'}}
+    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    env:
+      architecture: "amd64"
+      GRADLE_OPTS: "-Xmx6g -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4"
 
-      steps:
-        - name: Checkout
-          uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-        - name: Setup Environment
-          uses: ./.github/actions/setup-environment
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
 
-        - name: Publish Java artifacts
-          run: ./gradlew publish
-          env:
-            CLOUDSMITH_USER: ${{ secrets.CLOUDSMITH_USER }}
-            CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+      - name: Publish Java artifacts
+        run: ./gradlew publish
+        env:
+          CLOUDSMITH_USER: ${{ secrets.CLOUDSMITH_USER }}
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: 'true'
+      tests-with-ssh:
+        description: Run tests with ability to ssh into environment
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   # ==================================================================
@@ -77,27 +82,6 @@ jobs:
   # ==================================================================
   # Unit Tests
   # ==================================================================
-  unit-tests-london:
-    needs: [ build ]
-    uses: ./.github/workflows/reusable-unit-tests.yml
-    with:
-      zkevm_fork: LONDON
-      tests-with-ssh: false
-
-  unit-tests-paris:
-    needs: [ build ]
-    uses: ./.github/workflows/reusable-unit-tests.yml
-    with:
-      zkevm_fork: PARIS
-      tests-with-ssh: false
-
-  unit-tests-shanghai:
-    needs: [ build ]
-    uses: ./.github/workflows/reusable-unit-tests.yml
-    with:
-      zkevm_fork: SHANGHAI
-      tests-with-ssh: false
-
   unit-tests-cancun:
     needs: [ build ]
     uses: ./.github/workflows/reusable-unit-tests.yml
@@ -124,7 +108,7 @@ jobs:
   # ==================================================================
   # Publish release post tests
   # ==================================================================
-  publish-conditional-to-units-and-replay-tests:
+  publish-default:
     needs: [ build, unit-tests-prague, replay-tests ]
     if: ${{ github.event_name != 'pull_request' && ( github.event_name == 'release' || inputs.wait-for-tests-bef-publish == 'true') }}
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -14,6 +14,11 @@ on:
         required: true
         type: string
         default: "v1.2.3"
+      wait-for-tests-bef-publish:
+        description: 'If "false", the release jar will be published when ready without waiting for the unit and replay tests to pass.'
+        required: false
+        type: string
+        default: 'true'
 
 jobs:
   # ==================================================================
@@ -112,53 +117,16 @@ jobs:
   # ==================================================================
   replay-tests:
     needs: [ build ]
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          submodules: false
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          enable-ssh: false
-
-      - name: Run replay tests
-        run: GOMEMLIMIT=26GiB ./gradlew :arithmetization:fastReplayTests
-        env:
-          JAVA_OPTS: -Dorg.gradle.daemon=false
-          JUNIT_TESTS_PARALLELISM: 4
-          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
-          ZKEVM_FORK: LONDON
-
-      - name: Upload test report
-        if: ${{ always() }}
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-        with:
-          name: replay-tests-report
-          path: arithmetization/build/reports/tests/**/*
-
-      - name: Upload jacoco fast replay tests coverage report
-        if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-        with:
-          name: jacoco-fast-replay-tests-coverage-report
-          path: arithmetization/build/reports/jacoco/jacocoFastReplayTestsReport/**/*
-
-      - name: Upload jacoco fast replay tests exec file
-        if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-        with:
-          name: jacoco-fast-replay-tests-exec-file
-          path: arithmetization/build/jacoco/fastReplayTests.exec
+    uses: ./.github/workflows/reusable-fast-replay-tests.yml
+    with:
+      tests-with-ssh: ${{ inputs.tests-with-ssh || false}}
 
   # ==================================================================
   # Publish release post tests
   # ==================================================================
-  publish:
-    needs: [ build ]
-    if: github.event_name != 'pull_request'
+  publish-conditional-to-units-and-replay-tests:
+    needs: [ build, unit-tests-prague, replay-tests ]
+    if: ${{ github.event_name != 'pull_request' && inputs.wait-for-tests-bef-publish == 'true'}}
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
     env:
       architecture: "amd64"
@@ -176,3 +144,24 @@ jobs:
         env:
           CLOUDSMITH_USER: ${{ secrets.CLOUDSMITH_USER }}
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+
+    publish-as-soon-as-ready:
+      needs: [ build ]
+      if: ${{ github.event_name != 'pull_request' && inputs.wait-for-tests-bef-publish == 'false'}}
+      runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+      env:
+        architecture: "amd64"
+        GRADLE_OPTS: "-Xmx6g -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4"
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+        - name: Setup Environment
+          uses: ./.github/actions/setup-environment
+
+        - name: Publish Java artifacts
+          run: ./gradlew publish
+          env:
+            CLOUDSMITH_USER: ${{ secrets.CLOUDSMITH_USER }}
+            CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -126,7 +126,7 @@ jobs:
   # ==================================================================
   publish-conditional-to-units-and-replay-tests:
     needs: [ build, unit-tests-prague, replay-tests ]
-    if: ${{ github.event_name != 'pull_request' && inputs.wait-for-tests-bef-publish == 'true'}}
+    if: ${{ github.event_name != 'pull_request' && ( github.event_name == 'release' || inputs.wait-for-tests-bef-publish == 'true') }}
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
     env:
       architecture: "amd64"

--- a/.github/workflows/reusable-fast-replay-tests.yml
+++ b/.github/workflows/reusable-fast-replay-tests.yml
@@ -1,0 +1,53 @@
+name: "Reusable fast replay tests workflow"
+
+on:
+  workflow_call:
+    inputs:
+      tests-with-ssh:
+        required: true
+        type: boolean
+
+jobs:
+  # ==================================================================
+  # Fast replay Tests
+  # ==================================================================
+  fast-replay-tests:
+    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          submodules: false
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+        with:
+          enable-ssh: ${{ inputs.tests-with-ssh }}
+
+      - name: Run replay tests
+        run: GOMEMLIMIT=26GiB ./gradlew :arithmetization:fastReplayTests
+        env:
+          JAVA_OPTS: -Dorg.gradle.daemon=false
+          JUNIT_TESTS_PARALLELISM: 4
+          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
+
+      - name: Upload test report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: replay-tests-report
+          path: arithmetization/build/reports/tests/**/*
+
+      - name: Upload jacoco fast replay tests coverage report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: jacoco-fast-replay-tests-coverage-report
+          path: arithmetization/build/reports/jacoco/jacocoFastReplayTestsReport/**/*
+
+      - name: Upload jacoco fast replay tests exec file
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: jacoco-fast-replay-tests-exec-file
+          path: arithmetization/build/jacoco/fastReplayTests.exec

--- a/.github/workflows/reusable-fast-replay-tests.yml
+++ b/.github/workflows/reusable-fast-replay-tests.yml
@@ -1,4 +1,6 @@
 name: "Reusable fast replay tests workflow"
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make releases publish only after unit and fast replay tests by default, add a reusable fast replay workflow, and refactor CI to consume it.
> 
> - **CI Workflows**:
>   - **Reusable fast replay tests**: Add `./.github/workflows/reusable-fast-replay-tests.yml` to run `:arithmetization:fastReplayTests` and upload reports/artifacts.
>   - **Gradle tests** (`.github/workflows/gradle-tests.yml`):
>     - Replace inline `replay-tests` job with call to `reusable-fast-replay-tests.yml`.
>     - Pass through `tests-with-ssh` to unit and replay tests.
>   - **Manual release** (`.github/workflows/manual-release.yml`):
>     - Add inputs `wait-for-tests-bef-publish` and `tests-with-ssh`.
>     - Run unit tests (CANCUN, PRAGUE) and fast replay via reusable workflow.
>     - Split publishing into:
>       - `publish-default`: waits for tests (default) before `./gradlew publish` with Cloudsmith creds.
>       - `publish-as-soon-as-ready`: publishes immediately when `wait-for-tests-bef-publish` is `false`.
>     - Remove duplicated inline replay test steps and migrate to reusable workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03b6fea39e8a9e4d54f7507dc56fa27c47f7bd29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->