### PR TITLE
fix: tidy up after replay tests PR

### DIFF
--- a/arithmetization/src/test/java/net/consensys/linea/pragueReplayTests/BlockHashTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/pragueReplayTests/BlockHashTests.java
@@ -26,15 +26,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("replay")
 @ExtendWith(UnitTestWatcher.class)
-public class SepoliaTests extends TracerTestBase {
+public class BlockHashTests extends TracerTestBase {
 
   @Test
-  void block_19562398(TestInfo testInfo) {
+  void someHistoricalHashesAreChecked(TestInfo testInfo) {
     replay(SEPOLIA_PRAGUE_TESTCONFIG, "prague/19562398.sepolia.prague.json.gz", testInfo);
   }
 
+  /**
+   * The purpose of this second replay tests is to provide two consecutive conflation to the prover,
+   * with BLOCKHASH checking the "historical hashes" in both conflations.
+   */
   @Test
-  void block_19562399_19562417(TestInfo testInfo) {
+  void conflationFollowingThePreviousOneWithAgainHistoricalBlockhashesChecked(TestInfo testInfo) {
     replay(SEPOLIA_PRAGUE_TESTCONFIG, "prague/19562399-19562417.sepolia.prague.json.gz", testInfo);
   }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/blockhash/BlockhashTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/blockhash/BlockhashTest.java
@@ -15,8 +15,6 @@
 
 package net.consensys.linea.zktracer.module.blockhash;
 
-import static net.consensys.linea.ReplayTestTools.replay;
-import static net.consensys.linea.zktracer.ChainConfig.SEPOLIA_PRAGUE_TESTCONFIG;
 import static net.consensys.linea.zktracer.Trace.BLOCKHASH_MAX_HISTORY;
 
 import java.util.List;
@@ -32,7 +30,6 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -98,17 +95,6 @@ public class BlockhashTest extends TracerTestBase {
                 .op(OpCode.STOP)
                 .compile())
         .run(chainConfig, testInfo);
-  }
-
-  /**
-   * The purpose of this second replay tests is to provide two consecutive conflation to the prover,
-   * with BLOCKHASH checking the "historical hashes" in both conflations.
-   */
-  @Tag("replay")
-  @Disabled("Disabled, see comment")
-  @Test
-  void conflationFollowingThePreviousOneWithAgainHistoricalBlockhashesChecked(TestInfo testInfo) {
-    replay(SEPOLIA_PRAGUE_TESTCONFIG, "19562399-19562417.mainnet.json.gz", testInfo);
   }
 
   /**

--- a/reference-tests/build.gradle
+++ b/reference-tests/build.gradle
@@ -78,7 +78,7 @@ tasks.register('referenceExecutionSpecBlockchainTests', Test) {
     systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
     systemProperty("junit.jupiter.execution.parallel.config.strategy", "fixed")
     systemProperty("junit.jupiter.execution.parallel.config.fixed.parallelism",
-            System.getenv().getOrDefault("REFERENCE_TESTS_PARALLELISM", "1").toInteger())
+            System.getenv().getOrDefault("JUNIT_TESTS_PARALLELISM", "1").toInteger())
   }
 
   useJUnitPlatform {


### PR DESCRIPTION
This tidies two things up after the replay tests PR.  Firstly, the `build.gradle` file for the reference-tests is updated to use `JUNIT_TESTS_PARALLELISM` to match the github workflow; secondly, the disable replay test in BlockhashTest is removed, since it was a duplicate.  Specifically, the replay tests for BlockHash are now in `pragueReplayTests/BlockHashTests`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves BlockHash replay tests into `pragueReplayTests/BlockHashTests`, removes duplicate disabled replay test, and switches `reference-tests` parallelism env var to `JUNIT_TESTS_PARALLELISM`.
> 
> - **Tests**:
>   - **Replay tests**: Rename and consolidate into `pragueReplayTests/BlockHashTests` with clearer method names.
>   - **Cleanup**: Remove duplicate disabled replay test from `zktracer/module/blockhash/BlockhashTest` and related unused imports/tags.
> - **Build**:
>   - **JUnit parallelism**: Change env var in `reference-tests/build.gradle` from `REFERENCE_TESTS_PARALLELISM` to `JUNIT_TESTS_PARALLELISM`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 333d837aa135e151774f9843ff591165d4f68d11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->