### PR TITLE
@karim's fix for CANCUN blockchain reference tests

### DIFF
--- a/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -974,10 +974,8 @@ public class BlockchainReferenceTestTools {
         context
             .getWorldStateArchive()
             .getWorldState(
-                WorldStateQueryParams.withStateRootAndBlockHashAndUpdateNodeHead(
-                    genesisBlockHeader.getStateRoot(), genesisBlockHeader.getHash()))
+                WorldStateQueryParams.withBlockHeaderAndNoUpdateNodeHead(genesisBlockHeader))
             .orElseThrow();
-
     log.info(
         "checking roothash {} is {}", worldState.rootHash(), genesisBlockHeader.getStateRoot());
     assertThat(worldState.rootHash()).isEqualTo(genesisBlockHeader.getStateRoot());


### PR DESCRIPTION
This addresses an issue that seems to only occur for CANCUN blockchain reference tests starting with
```
    besuVersion = 25.11.0-RC1-linea2
```
where tests `627, 626, 625, 623, 612, 608, 605, 601, 578, 576, 575, 574 ...` among others would produce besu errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch world state retrieval to `withBlockHeaderAndNoUpdateNodeHead(genesisBlockHeader)` instead of using state root + hash.
> 
> - **Reference tests**:
>   - Change world state lookup in `BlockchainReferenceTestTools.executeTest` to use `WorldStateQueryParams.withBlockHeaderAndNoUpdateNodeHead(genesisBlockHeader)` instead of `withStateRootAndBlockHashAndUpdateNodeHead(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8cf3fad1474b8ab3b371a77071289dfe1d580f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->