### PR TITLE
clean: tx skip w address collision follow up of PR 2454

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/skip/TxSkipSection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/skip/TxSkipSection.java
@@ -126,8 +126,7 @@ public abstract class TxSkipSection extends TraceSection implements EndTransacti
     final Wei value = (Wei) txMetadata.getBesuTransaction().getValue();
 
     if (txMetadata.senderAddressCollision()) {
-      final BigInteger gasUsed =
-          BigInteger.valueOf(txMetadata.getGasLimit() - txMetadata.getGasRefunded());
+      final BigInteger gasUsed = BigInteger.valueOf(txMetadata.getTotalGasUsed());
       final BigInteger gasPrice = BigInteger.valueOf(txMetadata.getEffectiveGasPrice());
       final BigInteger gasCost = gasUsed.multiply(gasPrice);
       senderNew =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Recomputes gas cost during TX_SKIP sender address collision using totalGasUsed instead of gasLimit - gasRefunded.
> 
> - **Hub/Skip Section (`TxSkipSection`)**:
>   - Use `txMetadata.getTotalGasUsed()` to compute `gasUsed` in the sender address-collision branch, replacing `gasLimit - gasRefunded`.
>   - Affects `senderNew` balance deduction for gas cost during TX_SKIP resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0925f8681dd4e8db805ca5a2a893393b20567410. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->