### PR TITLE
chore: update go-corset to v1.1.27

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -12,4 +12,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@93c23f239542f79c1db60eb5b8250ab20e30f046 # v1.1.23
+      run: go install github.com/consensys/go-corset/cmd/go-corset@0d25749dc5e7ef6e0a75d551618248d4bad65ac6 # v1.1.27


### PR DESCRIPTION
This updates go-corset to v1.1.27 and the constraints accordingly.  This is necessary because v1.1.27 is much stricter about having duplicate constraint names.  Specifically, it won't allow them in the same module at all.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates go-corset in `.github/actions/setup-go-corset/action.yml` from v1.1.23 to v1.1.27.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10d64da92bd1225c3e59a1398b958df56ab9d126. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->