### PR TITLE
eip 7642: rm bloom from tx receipt

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
@@ -16,7 +16,6 @@
 package net.consensys.linea.zktracer;
 
 import static net.consensys.linea.zktracer.Fork.*;
-import static net.consensys.linea.zktracer.Trace.*;
 import static net.consensys.linea.zktracer.Trace.BLOCKHASH_MAX_HISTORY;
 import static net.consensys.linea.zktracer.Trace.Ecdata.TOTAL_SIZE_ECPAIRING_DATA_MIN;
 import static net.consensys.linea.zktracer.TraceCancun.Oob.CT_MAX_CALL;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
@@ -440,7 +440,7 @@ public class ZkCounter implements LineCountingTracer {
       Set<Address> selfDestructs,
       long timeNs) {
     l1BlockSize.traceEndTx(tx, logs);
-    rlpTxnRcpt.updateTally(lineCountForRlpTxnRcpt(logs));
+    rlpTxnRcpt.updateTally(lineCountForRlpTxnRcpt(logs, FORK_TO_USE_FOR_ZK_COUNTER));
     logData.updateTally(lineCountForLogData(logs));
     logInfo.updateTally(lineCountForLogInfo(logs));
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -224,9 +224,9 @@ public abstract class Hub implements Module {
   private final RlpTxn rlpTxn;
   private final Mmio mmio;
   @Getter final TxnData txnData = setTxnData();
-  private final RlpTxnRcpt rlpTxnRcpt = new RlpTxnRcpt();
-  private final LogInfo logInfo = new LogInfo(rlpTxnRcpt);
-  private final LogData logData = new LogData(rlpTxnRcpt);
+  private final RlpTxnRcpt rlpTxnRcpt;
+  private final LogInfo logInfo;
+  private final LogData logData;
   private final RlpAddr rlpAddr;
 
   // modules triggered by sub-fragments of the MISCELLANEOUS / IMC perspective
@@ -446,6 +446,9 @@ public abstract class Hub implements Module {
             blockTransactions, keccak, l2L1Logs, l2l1ContractAddress, LogTopic.of(l2l1Topic));
     shakiraData = new ShakiraData(wcp, sha256Blocks, keccak, ripemdBlocks);
     trm = new Trm(fork);
+    rlpTxnRcpt = new RlpTxnRcpt(fork);
+    logInfo = new LogInfo(rlpTxnRcpt);
+    logData = new LogData(rlpTxnRcpt);
     rlpTxn = setRlpTxn(this);
     rlpAddr = new RlpAddr(this, trm, keccak);
     blockdata = setBlockData(this, wcp, euc, chain);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxrcpt/RlpTxnRcpt.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxrcpt/RlpTxnRcpt.java
@@ -15,6 +15,8 @@
 
 package net.consensys.linea.zktracer.module.rlptxrcpt;
 
+import static net.consensys.linea.zktracer.Fork.forkPredatesOsaka;
+import static net.consensys.linea.zktracer.Fork.isPostOsaka;
 import static net.consensys.linea.zktracer.Trace.LINEA_MAX_NUMBER_OF_TRANSACTIONS_IN_BATCH;
 import static net.consensys.linea.zktracer.Trace.LLARGE;
 import static net.consensys.linea.zktracer.Trace.RLP_PREFIX_INT_LONG;
@@ -31,11 +33,11 @@ import static net.consensys.linea.zktracer.types.Utils.rightPadTo;
 
 import java.math.BigInteger;
 import java.util.List;
-import java.util.function.Function;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
+import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.module.OperationListModule;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedList;
@@ -52,6 +54,7 @@ import org.hyperledger.besu.evm.log.LogsBloomFilter;
 @Accessors(fluent = true)
 @RequiredArgsConstructor
 public class RlpTxnRcpt implements OperationListModule<RlpTxrcptOperation> {
+  private final Fork fork;
   private static final Bytes BYTES_RLP_INT_SHORT = Bytes.minimalBytes(RLP_PREFIX_INT_SHORT);
   private static final Bytes BYTES_RLP_LIST_SHORT = Bytes.minimalBytes(RLP_PREFIX_LIST_SHORT);
 
@@ -70,6 +73,7 @@ public class RlpTxnRcpt implements OperationListModule<RlpTxrcptOperation> {
   public void traceEndTx(TransactionProcessingMetadata txMetaData) {
     final RlpTxrcptOperation operation =
         new RlpTxrcptOperation(
+            fork,
             txMetaData.getBesuTransaction().getType(),
             txMetaData.statusCode(),
             txMetaData.getAccumulatedGasUsedInBlock(),
@@ -80,7 +84,7 @@ public class RlpTxnRcpt implements OperationListModule<RlpTxrcptOperation> {
   public void traceOperation(
       final RlpTxrcptOperation chunk, int absTxNum, int absLogNumMax, Trace.Rlptxrcpt trace) {
     RlpTxrcptColumns traceValue = new RlpTxrcptColumns();
-    traceValue.txrcptSize = txRcptSize(chunk);
+    traceValue.txrcptSize = txRcptSize(chunk, fork);
     traceValue.absTxNum = absTxNum;
     traceValue.absLogNumMax = absLogNumMax;
 
@@ -94,7 +98,9 @@ public class RlpTxnRcpt implements OperationListModule<RlpTxrcptOperation> {
     phase3(traceValue, chunk.gasUsed(), trace);
 
     // PHASE 4: Bloom Filter Rb.
-    phase4(traceValue, chunk.logs(), trace);
+    if (forkPredatesOsaka(fork)) {
+      phase4(traceValue, chunk.logs(), trace);
+    }
 
     // Phase 5: log series Rl.
     phase5(traceValue, chunk.logs(), trace);
@@ -685,11 +691,14 @@ public class RlpTxnRcpt implements OperationListModule<RlpTxrcptOperation> {
         .nStep(traceValue.nStep)
         .phaseId(traceValue.getPhaseId());
 
-    List<Function<Boolean, Trace.Rlptxrcpt>> phaseColumns =
-        List.of(trace::phase1, trace::phase2, trace::phase3, trace::phase4, trace::phase5);
-
-    for (int i = 0; i < phaseColumns.size(); i++) {
-      phaseColumns.get(i).apply(i + 1 == traceValue.phase);
+    final int tracePhase = traceValue.phase;
+    switch (tracePhase) {
+      case 1 -> trace.phase1(true);
+      case 2 -> trace.phase2(true);
+      case 3 -> trace.phase3(true);
+      case 4 -> trace.phase4(true); // Not in Osaka
+      case 5 -> trace.phase5(true);
+      default -> throw new IllegalArgumentException("Invalid phase: " + tracePhase);
     }
 
     trace
@@ -698,7 +707,7 @@ public class RlpTxnRcpt implements OperationListModule<RlpTxrcptOperation> {
         .power(bigIntegerToBytes(traceValue.power))
         .txrcptSize(traceValue.txrcptSize);
 
-    trace.validateRow();
+    trace.fillAndValidateRow();
 
     // Increments Index.
     if (traceValue.limbConstructed) {
@@ -713,16 +722,16 @@ public class RlpTxnRcpt implements OperationListModule<RlpTxrcptOperation> {
    *     transaction execution
    * @return the size of the RLP of a transaction receipt WITHOUT its RLP prefix
    */
-  private int txRcptSize(RlpTxrcptOperation chunk) {
+  private int txRcptSize(RlpTxrcptOperation chunk, Fork fork) {
 
     // The encoded status code is always of size 1.
     int size = 1;
 
-    // As the cumulative gas is Gtransaction=21000, its size is >1.
+    // As the cumulative gas is at least >= G transaction = 21000, its byte size is >1.
     size += outerRlpSize(Bytes.minimalBytes(chunk.gasUsed()).size());
 
-    // RLP(Rb) is always 259 (256+3) long.
-    size += 259;
+    // RLP(Rb) is always 259 (256+3) long, but disappear in Osaka
+    size += isPostOsaka(fork) ? 0 : 259;
 
     // Add the size of the RLP(Log).
     int nbLog = chunk.logs().size();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxrcpt/RlpTxrcptOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlptxrcpt/RlpTxrcptOperation.java
@@ -15,6 +15,7 @@
 
 package net.consensys.linea.zktracer.module.rlptxrcpt;
 
+import static net.consensys.linea.zktracer.Fork.isPostOsaka;
 import static net.consensys.linea.zktracer.types.Utils.fromDataSizeToLimbNbRows;
 
 import java.util.List;
@@ -22,6 +23,7 @@ import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
+import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.container.ModuleOperation;
 import org.hyperledger.besu.datatypes.TransactionType;
 import org.hyperledger.besu.evm.log.Log;
@@ -30,6 +32,7 @@ import org.hyperledger.besu.evm.log.Log;
 @Accessors(fluent = true)
 @Getter
 public final class RlpTxrcptOperation extends ModuleOperation {
+  private final Fork fork;
   private final TransactionType txType;
   private final Boolean status;
   private final long gasUsed;
@@ -37,14 +40,15 @@ public final class RlpTxrcptOperation extends ModuleOperation {
 
   @Override
   protected int computeLineCount() {
-    return lineCountForRlpTxnRcpt(this.logs);
+    return lineCountForRlpTxnRcpt(logs, fork);
   }
 
-  public static int lineCountForRlpTxnRcpt(List<Log> logs) {
-    // Phase 0 is always 1+8=9 row long, Phase 1, 1 row long, Phase 2 8 row long,
-    // Phase 3 65 = 1 +
-    // 64 row long
-    int rowSize = 83;
+  public static int lineCountForRlpTxnRcpt(List<Log> logs, Fork fork) {
+    // Phase 1 is always 1+8=9 row long,
+    // Phase 2, 1 row long,
+    // Phase 3 8 row long,
+    // Phase 4 65 = 1 + 64 row long, but disappear in Osaka fork
+    int rowSize = 18 + (isPostOsaka(fork) ? 0 : 65);
 
     // add the number of rows for Phase 4 : Log entry
     if (logs.isEmpty()) {

--- a/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
+++ b/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
@@ -30,7 +30,7 @@ public class TracerTestBase {
   public static void init() {
     // Configure chain information and fork before any tests are run, including any methods used as
     // MethodSource.
-    TracerTestBase.chainConfig = ChainConfig.MAINNET_TESTCONFIG(getForkOrDefault(PRAGUE));
+    TracerTestBase.chainConfig = ChainConfig.MAINNET_TESTCONFIG(getForkOrDefault(OSAKA));
     TracerTestBase.fork = TracerTestBase.chainConfig.fork;
     TracerTestBase.opcodes = OpCodes.load(fork);
   }

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
@@ -18,10 +18,8 @@ package net.consensys.linea.testing;
 import static com.google.common.base.Preconditions.checkArgument;
 import static net.consensys.linea.reporting.TracerTestBase.chainConfig;
 import static net.consensys.linea.zktracer.ChainConfig.MAINNET_TESTCONFIG;
-import static net.consensys.linea.zktracer.Fork.LONDON;
-import static net.consensys.linea.zktracer.Fork.isPostCancun;
+import static net.consensys.linea.zktracer.Fork.*;
 import static net.consensys.linea.zktracer.Trace.LINEA_BASE_FEE;
-import static net.consensys.linea.zktracer.module.ModuleName.*;
 
 import java.util.*;
 import java.util.function.Consumer;
@@ -122,7 +120,7 @@ public class ToyExecutionEnvironmentV2 {
           zkTracerValidator,
           testInfo);
 
-      if (isPostCancun(tracer.getHub().fork)) {
+      if (isPostOsaka(tracer.getHub().fork)) {
         // This is to check that the light counter is really counting more than the full tracer
         final ZkTracer tracer = this.tracer;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Makes transaction receipt bloom omitted post-Osaka and updates receipt tracing/line counting and tests to be Osaka-aware.
> 
> - **RLP Tx Receipt (rlptxrcpt)**:
>   - Make receipt encoding fork-aware by threading `Fork` through `RlpTxnRcpt` and `RlpTxrcptOperation`.
>   - Omit Bloom filter phase/size post-`OSAKA` (`phase4` conditional; size calc now `+0` for Bloom).
>   - Update per-phase row counts (`lineCountForRlpTxnRcpt`) to exclude Bloom rows post-`OSAKA`.
>   - Switch row finalization to `fillAndValidateRow()`.
> - **Hub/Counter wiring**:
>   - Initialize `RlpTxnRcpt` with active `fork`; construct `LogInfo`/`LogData` with that instance.
>   - `ZkCounter` uses `FORK_TO_USE_FOR_ZK_COUNTER = OSAKA` and passes fork to `lineCountForRlpTxnRcpt`.
> - **Tests/Env**:
>   - Default test fork switched to `OSAKA` (`TracerTestBase`).
>   - Post-`OSAKA` check in `ToyExecutionEnvironmentV2` for light vs full tracer counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23a592c31e0f2116361506de4e0f7edbc5d57cb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->