### PR TITLE
clean: some cleaning in GAS, EUC, EXP

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
@@ -153,7 +153,7 @@ public class ZkCounter implements LineCountingTracer {
       new CountingOnlyModule(BLOCK_HASH, trace.blockhash().spillage());
   final BlsData blsdata;
   final EcData ecdata;
-  final Euc euc;
+  final Euc euc = new Euc();
   final Exp exp = new Exp();
   final Ext ext = new Ext();
   final CountingOnlyModule gas = new CountingOnlyModule(GAS, trace.gas().spillage());
@@ -327,7 +327,6 @@ public class ZkCounter implements LineCountingTracer {
   }
 
   public ZkCounter(LineaL1L2BridgeSharedConfiguration bridgeConfiguration) {
-    euc = new Euc(wcp);
     keccak = new Keccak(ecRecoverEffectiveCall, blockTransactions);
     ecdata =
         new EcData(

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Euc.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Euc.java
@@ -102,7 +102,9 @@ public class Euc implements OperationSetModule<EucOperation> {
     final Bytes quotient = bigIntegerToBytes(dividendBI.divide(divisorBI));
     final Bytes remainder = bigIntegerToBytes(dividendBI.remainder(divisorBI));
 
-    final EucOperation operation = new EucOperation(dividend, divisor, quotient, remainder);
+    final EucOperation operation =
+        new EucOperation(
+            dividend.trimLeadingZeros(), divisor.trimLeadingZeros(), quotient, remainder);
 
     final boolean isNew = operations.add(operation);
     if (isNew) {

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Euc.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Euc.java
@@ -29,7 +29,6 @@ import net.consensys.linea.zktracer.container.module.OperationSetModule;
 import net.consensys.linea.zktracer.container.stacked.CountOnlyOperation;
 import net.consensys.linea.zktracer.container.stacked.ModuleOperationStackedSet;
 import net.consensys.linea.zktracer.module.ModuleName;
-import net.consensys.linea.zktracer.module.wcp.Wcp;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.worldstate.WorldView;
@@ -38,7 +37,6 @@ import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 @RequiredArgsConstructor
 @Accessors(fluent = true)
 public class Euc implements OperationSetModule<EucOperation> {
-  private final Wcp wcp;
 
   @Getter
   private final ModuleOperationStackedSet<EucOperation> operations =
@@ -102,15 +100,6 @@ public class Euc implements OperationSetModule<EucOperation> {
     final Bytes quotient = bigIntegerToBytes(dividendBI.divide(divisorBI));
     final Bytes remainder = bigIntegerToBytes(dividendBI.remainder(divisorBI));
 
-    final EucOperation operation =
-        new EucOperation(
-            dividend.trimLeadingZeros(), divisor.trimLeadingZeros(), quotient, remainder);
-
-    final boolean isNew = operations.add(operation);
-    if (isNew) {
-      wcp.callLT(operation.remainder(), operation.divisor());
-    }
-
-    return operation;
+    return new EucOperation(dividend, divisor, quotient, remainder);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Euc.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/Euc.java
@@ -100,6 +100,8 @@ public class Euc implements OperationSetModule<EucOperation> {
     final Bytes quotient = bigIntegerToBytes(dividendBI.divide(divisorBI));
     final Bytes remainder = bigIntegerToBytes(dividendBI.remainder(divisorBI));
 
-    return new EucOperation(dividend, divisor, quotient, remainder);
+    final EucOperation op = new EucOperation(dividend, divisor, quotient, remainder);
+    operations.add(op);
+    return op;
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/EucOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/EucOperation.java
@@ -38,8 +38,8 @@ public class EucOperation extends ModuleOperation {
     final Bytes divisorTrim = divisor.trimLeadingZeros();
     final Bytes quotientTrim = quotient.trimLeadingZeros();
 
-    this.dividend = dividend;
-    this.divisor = divisorTrim;
+    this.dividend = dividend.trimLeadingZeros();
+    this.divisor = divisorTrim.trimLeadingZeros();
     this.quotient = quotientTrim;
     this.remainder = remainder;
   }
@@ -54,10 +54,10 @@ public class EucOperation extends ModuleOperation {
     final Bytes ceil = this.ceiling();
 
     trace
-        .dividend(this.dividend)
-        .divisor(this.divisor)
-        .quotient(this.quotient)
-        .remainder(this.remainder)
+        .dividend(dividend)
+        .divisor(divisor)
+        .quotient(quotient)
+        .remainder(remainder)
         .ceil(ceil)
         .validateRow();
   }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/exp/ExpOperation.java
@@ -18,8 +18,7 @@ package net.consensys.linea.zktracer.module.exp;
 import static com.google.common.base.Preconditions.*;
 import static com.google.common.math.BigIntegerMath.log2;
 import static java.lang.Math.min;
-import static net.consensys.linea.zktracer.Trace.EXP_INST_EXPLOG;
-import static net.consensys.linea.zktracer.Trace.EXP_INST_MODEXPLOG;
+import static net.consensys.linea.zktracer.Trace.*;
 import static net.consensys.linea.zktracer.module.hub.precompiles.ModexpMetadata.BASE_MIN_OFFSET;
 import static net.consensys.linea.zktracer.types.Conversions.bigIntegerToBytes;
 
@@ -62,8 +61,8 @@ public class ExpOperation extends ModuleOperation {
             "MODEXP call data unexpectedly short");
         final EWord rawLead = modexpMetadata.rawLeadingWord();
         final int cdsCutoff =
-            Math.min(modexpMetadata.callData().size() - BASE_MIN_OFFSET - bbsInt, 32);
-        final int ebsCutoff = Math.min(ebsInt, 32);
+            Math.min(modexpMetadata.callData().size() - BASE_MIN_OFFSET - bbsInt, WORD_SIZE);
+        final int ebsCutoff = Math.min(ebsInt, WORD_SIZE);
         final BigInteger leadLog =
             BigInteger.valueOf(LeadLogTrimLead.fromArgs(rawLead, cdsCutoff, ebsCutoff).leadLog());
         // Fill expCall

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/gas/Gas.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/gas/Gas.java
@@ -51,9 +51,9 @@ public class Gas implements OperationSetModule<GasOperation>, PostOpcodeDefer {
     return GAS;
   }
 
-  public void call(GasParameters gasParameters, Hub hub, CommonFragmentValues commonValues) {
+  public void call(Hub hub, CommonFragmentValues commonValues) {
     this.commonValues = commonValues;
-    this.gasParameters = gasParameters;
+    gasParameters = new GasParameters();
     hub.defers().scheduleForPostExecution(this);
   }
 

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/Hub.java
@@ -204,11 +204,10 @@ public abstract class Hub implements Module {
 
   // stateless modules
   private final Wcp wcp = new Wcp();
-
   private final Add add = new Add();
   private final Bin bin = new Bin();
   private final Blockhash blockhash;
-  private final Euc euc = new Euc(wcp);
+  private final Euc euc = new Euc();
   private final Ext ext = new Ext();
   private final Gas gas = new Gas();
   private final Mul mul = new Mul();

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
@@ -30,7 +30,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Accessors;
-import net.consensys.linea.zktracer.module.gas.GasParameters;
 import net.consensys.linea.zktracer.module.hub.Hub;
 import net.consensys.linea.zktracer.module.hub.HubProcessingPhase;
 import net.consensys.linea.zktracer.module.hub.TransactionProcessingType;

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/fragment/common/CommonFragmentValues.java
@@ -124,7 +124,7 @@ public class CommonFragmentValues {
 
     if (contextMayChange) {
       // Trigger the gas module in case contextMayChange is true
-      hub.gas().call(new GasParameters(), hub, this);
+      hub.gas().call(hub, this);
     }
 
     if (none(exceptions)) {

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/exp/ExpTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/exp/ExpTest.java
@@ -71,9 +71,16 @@ public class ExpTest extends TracerTestBase {
   @Test
   void testExpLogDuplicate(TestInfo testInfo) {
     BytecodeRunner bytecodeRunner =
-            BytecodeRunner.of(BytecodeCompiler.newProgram(chainConfig)
-                    .push(256).push(256).op(OpCode.EXP).op(OpCode.POP)
-                    .push(256).push(256).op(OpCode.EXP).op(OpCode.POP));
+        BytecodeRunner.of(
+            BytecodeCompiler.newProgram(chainConfig)
+                .push(256)
+                .push(256)
+                .op(OpCode.EXP)
+                .op(OpCode.POP)
+                .push(256)
+                .push(256)
+                .op(OpCode.EXP)
+                .op(OpCode.POP));
     bytecodeRunner.run(chainConfig, testInfo);
   }
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/module/exp/ExpTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/module/exp/ExpTest.java
@@ -69,6 +69,15 @@ public class ExpTest extends TracerTestBase {
   }
 
   @Test
+  void testExpLogDuplicate(TestInfo testInfo) {
+    BytecodeRunner bytecodeRunner =
+            BytecodeRunner.of(BytecodeCompiler.newProgram(chainConfig)
+                    .push(256).push(256).op(OpCode.EXP).op(OpCode.POP)
+                    .push(256).push(256).op(OpCode.EXP).op(OpCode.POP));
+    bytecodeRunner.run(chainConfig, testInfo);
+  }
+
+  @Test
   void testModexpLogSingleCase(TestInfo testInfo) {
     BytecodeCompiler program =
         BytecodeCompiler.newProgram(chainConfig)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-releaseVersion=beta-v4.0-rc12
+releaseVersion=beta-v5.0-integration-test-wo-modexp-secp256r1
 besuVersion=25.11.0-RC1-linea2
 shomeiVersion=2.4-develop
 besuShomeiPluginVersion=v0.7.4


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Decouples `EUC` from `Wcp`, simplifies `Gas` invocation, refines `EXP` constants, refactors `StpCall`, adds an EXP duplicate test, and bumps the release version.
> 
> - **Core modules**:
>   - **`EUC`**: Remove `Wcp` dependency; instantiate via `new Euc()` in `ZkCounter`/`Hub`; drop `wcp.callLT` and simplify `callEUC`; trim `dividend`/`divisor` in `EucOperation`.
>   - **`Gas`**: Simplify API to `call(Hub, CommonFragmentValues)`; internally create `GasParameters`; update trigger in `CommonFragmentValues`.
> - **EXP**:
>   - Use `WORD_SIZE` for cutoffs in `ExpOperation` (replacing hardcoded `32`).
> - **Hub/IMC**:
>   - `StpCall`: refactor to use `opCodeData.mnemonic()` and pass `frame/opCode` to helpers; minor cleanups.
> - **Counters/Init**:
>   - `ZkCounter`: construct `Euc` without `Wcp`.
> - **Tests**:
>   - Add `ExpTest.testExpLogDuplicate`.
> - **Build**:
>   - Bump `releaseVersion` in `gradle.properties`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 564f95d04fef11d29b52ae04ed92e6938917e2fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->