### PR TITLE
feat: support assembly implementation of euc

### DIFF
--- a/.github/workflows/reusable-blockchain-tests.yml
+++ b/.github/workflows/reusable-blockchain-tests.yml
@@ -67,7 +67,7 @@ jobs:
         run: GOMAXPROCS=10 GOMEMLIMIT=20GiB ./gradlew referenceExecutionSpecBlockchainTests -x spotlessCheck --tests "${{ inputs.test_filter || 'BlockchainReferenceTest_*' }}"
         timeout-minutes: 360
         env:
-          JUNIT_TESTS_PARALLELISM: 3
+          JUNIT_TESTS_PARALLELISM: 2
           JAVA_OPTS: -Dorg.gradle.daemon=false
           GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
           FAILED_TEST_JSON_DIRECTORY: ${{ github.workspace }}/tmp/${{ steps.extract_branch.outputs.branch }}/

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/EucOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/EucOperation.java
@@ -15,14 +15,11 @@
 
 package net.consensys.linea.zktracer.module.euc;
 
-import static net.consensys.linea.zktracer.types.Utils.leftPadTo;
-
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import net.consensys.linea.zktracer.Trace;
 import net.consensys.linea.zktracer.container.ModuleOperation;
-import net.consensys.linea.zktracer.types.UnsignedByte;
 import org.apache.tuweni.bytes.Bytes;
 
 @Accessors(fluent = true)
@@ -32,7 +29,6 @@ public class EucOperation extends ModuleOperation {
   @Getter @EqualsAndHashCode.Include private final Bytes divisor;
   @Getter private final Bytes remainder;
   @Getter private final Bytes quotient;
-  private int ctMax;
 
   public EucOperation(
       final Bytes dividend, final Bytes divisor, final Bytes quotient, final Bytes remainder) {
@@ -55,36 +51,19 @@ public class EucOperation extends ModuleOperation {
   }
 
   void trace(Trace.Euc trace) {
-    final Bytes divisor = leftPadTo(this.divisor, this.ctMax + 1);
-    final Bytes quotient = leftPadTo(this.quotient, this.ctMax + 1);
-    final Bytes remainder = leftPadTo(this.remainder, this.ctMax + 1);
     final Bytes ceil = this.ceiling();
 
-    for (int ct = 0; ct <= ctMax; ct++) {
-      trace
-          .iomf(true)
-          .ct((short) ct)
-          .ctMax((short) ctMax)
-          .done(ct == ctMax)
-          .dividend(dividend)
-          .divisor(divisor.slice(0, ct + 1))
-          .quotient(quotient.slice(0, ct + 1))
-          .remainder(remainder.slice(0, ct + 1))
-          .ceil(ceil)
-          .divisorByte(UnsignedByte.of(divisor.get(ct)))
-          .quotientByte(UnsignedByte.of(quotient.get(ct)))
-          .remainderByte(UnsignedByte.of(remainder.get(ct)))
-          .validateRow();
-    }
+    trace
+        .dividend(this.dividend)
+        .divisor(this.divisor)
+        .quotient(this.quotient)
+        .remainder(this.remainder)
+        .ceil(ceil)
+        .validateRow();
   }
 
   @Override
   protected int computeLineCount() {
-    ctMax = computeCtMax();
-    return ctMax + 1;
-  }
-
-  private int computeCtMax() {
-    return Math.max(quotient.size(), divisor.size()) - 1;
+    return 1;
   }
 }


### PR DESCRIPTION
This puts in place the necessary support for the assembly implementation of the EUC module.  Mostly, this comes down to remove the need to compute certain intermediate columns which no longer exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies EUC tracing to a single-row without per-byte intermediates and reduces CI JUnit parallelism from 3 to 2.
> 
> - **EUC module**:
>   - Simplifies `EucOperation.trace` from per-byte iterative rows to a single-row trace using full `Bytes` (`dividend`, `divisor`, `quotient`, `remainder`, `ceil`).
>   - Removes `ctMax`, padding/slicing, and byte-level fields; `computeLineCount()` now returns `1`.
> - **CI**:
>   - Lowers `JUNIT_TESTS_PARALLELISM` from `3` to `2` in `.github/workflows/reusable-blockchain-tests.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49dfc4828c419c95d31f9ca125f4ecc366b58a60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->