### PR TITLE
fix: unnecessary trm duplicate in EUC

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/EucOperation.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/euc/EucOperation.java
@@ -35,12 +35,10 @@ public class EucOperation extends ModuleOperation {
     if (divisor.isZero()) {
       throw new IllegalArgumentException("EUC module doesn't accept 0 for divisor");
     }
-    final Bytes divisorTrim = divisor.trimLeadingZeros();
-    final Bytes quotientTrim = quotient.trimLeadingZeros();
 
     this.dividend = dividend.trimLeadingZeros();
-    this.divisor = divisorTrim.trimLeadingZeros();
-    this.quotient = quotientTrim;
+    this.divisor = divisor.trimLeadingZeros();
+    this.quotient = quotient.trimLeadingZeros();
     this.remainder = remainder;
   }
 

--- a/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
+++ b/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
@@ -30,7 +30,7 @@ public class TracerTestBase {
   public static void init() {
     // Configure chain information and fork before any tests are run, including any methods used as
     // MethodSource.
-    TracerTestBase.chainConfig = ChainConfig.MAINNET_TESTCONFIG(getForkOrDefault(PRAGUE));
+    TracerTestBase.chainConfig = ChainConfig.MAINNET_TESTCONFIG(getForkOrDefault(OSAKA));
     TracerTestBase.fork = TracerTestBase.chainConfig.fork;
     TracerTestBase.opcodes = OpCodes.load(fork);
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes redundant trimming in EUC operation and updates tests to default to the OSAKA fork.
> 
> - **EUC Module**:
>   - Simplifies `EucOperation` by trimming `dividend`, `divisor`, and `quotient` directly; removes redundant intermediate trims.
> - **Testing**:
>   - Changes default fork in `testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java` from `PRAGUE` to `OSAKA`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30c5ecc70a983374cb8c4d35cd86a522de2ebe8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->