### PR TITLE
fix: trivial osaka test fixes

### DIFF
--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/ForkTracingAndSwitchingBesuTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/ForkTracingAndSwitchingBesuTest.java
@@ -67,7 +67,7 @@ public class ForkTracingAndSwitchingBesuTest extends TracerTestBase {
           .push(32) // offset to trigger mem expansion
           .push(0) // dest offset
           .op(OpCode.MCOPY);
-      case OSAKA -> compiler.push("0x07acaa").op(OpCode.CLZ);
+      case OSAKA -> compiler.push(Bytes.fromHexString("0x07acaa")).op(OpCode.CLZ);
       default -> throw new IllegalArgumentException("Unsupported fork: " + fork);
     }
 

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/forkSpecific/prague/floorprice/RefundTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/forkSpecific/prague/floorprice/RefundTests.java
@@ -15,7 +15,7 @@
 
 package net.consensys.linea.zktracer.forkSpecific.prague.floorprice;
 
-import static net.consensys.linea.testing.BytecodeRunner.DEFAULT_GAS_LIMIT;
+import static net.consensys.linea.testing.BytecodeRunner.MAX_GAS_LIMIT;
 import static net.consensys.linea.zktracer.Fork.isPostPrague;
 
 import java.util.ArrayList;
@@ -85,7 +85,7 @@ public class RefundTests extends TracerTestBase {
     final Transaction deploymentTransaction =
         ToyTransaction.builder()
             .payload(initCode)
-            .gasLimit(DEFAULT_GAS_LIMIT)
+            .gasLimit(MAX_GAS_LIMIT)
             .sender(senderAccount)
             .value(Wei.of(272)) // 256 + 16, easier for debugging
             .keyPair(keyPair)
@@ -99,7 +99,7 @@ public class RefundTests extends TracerTestBase {
     final Transaction callTransaction =
         ToyTransaction.builder()
             .payload(callData)
-            .gasLimit(DEFAULT_GAS_LIMIT)
+            .gasLimit(MAX_GAS_LIMIT)
             .sender(senderAccount)
             .toAddress(deploymentAddress)
             .value(Wei.ZERO)

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/ContractModifyingStorageTest.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/ContractModifyingStorageTest.java
@@ -15,22 +15,18 @@
 package net.consensys.linea.zktracer.instructionprocessing;
 
 import static com.google.common.base.Preconditions.*;
+import static net.consensys.linea.testing.BytecodeRunner.MAX_GAS_LIMIT;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 import net.consensys.linea.UnitTestWatcher;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.ToyAccount;
 import net.consensys.linea.testing.ToyExecutionEnvironmentV2;
 import net.consensys.linea.testing.ToyTransaction;
-import net.consensys.linea.zktracer.module.rlpcommon.RlpRandEdgeCase;
-import net.consensys.linea.zktracer.types.AddressUtils;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.crypto.KeyPair;
 import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECPPublicKey;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.TransactionType;
@@ -69,31 +65,27 @@ public class ContractModifyingStorageTest extends TracerTestBase {
     // arithmetization/src/test/resources/contracts/contractModifyingStorage/ContractModifyingStorageInConstructor.sol
 
     // User address
-    KeyPair keyPair = new SECP256K1().generateKeyPair();
-    Address userAddress = Address.extract(Hash.hash(keyPair.getPublicKey().getEncodedBytes()));
-    ToyAccount userAccount =
+    final KeyPair keyPair = new SECP256K1().generateKeyPair();
+    final Address userAddress =
+        Address.extract(Hash.hash(keyPair.getPublicKey().getEncodedBytes()));
+    final ToyAccount userAccount =
         ToyAccount.builder().balance(Wei.fromEth(1000)).nonce(1).address(userAddress).build();
 
-    System.out.println("User address: " + userAddress);
-
     // Deployment transaction
-    Transaction tx =
+    final Transaction tx =
         ToyTransaction.builder()
             .sender(userAccount)
             .keyPair(keyPair)
             .transactionType(TransactionType.FRONTIER)
-            .gasLimit(0xffffffL) // 0xffffffffL
+            .gasLimit(MAX_GAS_LIMIT)
             .payload(
                 Bytes.fromHexString(
                     "0x608060405234801561001057600080fd5b5060008081905550600180819055506002808190555060038081905550600a60005461003c91906100d9565b600081905550600b60015461005191906100d9565b600181905550600c60025461006691906100d9565b600281905550600d60035461007b91906100d9565b6003819055506000805461008f919061012f565b60008190555060146001546100a4919061012f565b60018190555060156002546100b9919061012f565b60028190555060156003546100ce919061012f565b6003819055506101c2565b60006100e482610189565b91506100ef83610189565b9250827fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0382111561012457610123610193565b5b828201905092915050565b600061013a82610189565b915061014583610189565b9250817fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff048311821515161561017e5761017d610193565b5b828202905092915050565b6000819050919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b610131806101d16000396000f3fe6080604052348015600f57600080fd5b506004361060465760003560e01c8063501e821214604b5780636cc014de146065578063a314150f14607f578063a5d666a9146099575b600080fd5b605160b3565b604051605c919060d8565b60405180910390f35b606b60b9565b6040516076919060d8565b60405180910390f35b608560bf565b6040516090919060d8565b60405180910390f35b609f60c5565b60405160aa919060d8565b60405180910390f35b60005481565b60015481565b60025481565b60035481565b60d28160f1565b82525050565b600060208201905060eb600083018460cb565b92915050565b600081905091905056fea2646970667358221220cebaf0c22dd1be33c20b916dce0c167bffc36711ff2f805c6d8667fe803601f464736f6c63430008000033"))
             .build();
 
-    Address deployedAddress = AddressUtils.effectiveToAddress(tx);
-    System.out.println("Deployed address: " + deployedAddress);
-
     checkArgument(tx.isContractCreation());
 
-    ToyExecutionEnvironmentV2 toyExecutionEnvironment =
+    final ToyExecutionEnvironmentV2 toyExecutionEnvironment =
         ToyExecutionEnvironmentV2.builder(chainConfig, testInfo)
             .accounts(List.of(userAccount))
             .transaction(tx)
@@ -122,12 +114,12 @@ public class ContractModifyingStorageTest extends TracerTestBase {
                 Bytes.fromHexString(
                     "0x608060405234801561001057600080fd5b50610304806100206000396000f3fe608060405234801561001057600080fd5b50600436106100575760003560e01c8063501e82121461005c5780636cc014de1461007a578063a314150f14610098578063a5d666a9146100b6578063e8af2fa5146100d4575b600080fd5b6100646100de565b60405161007191906101ca565b60405180910390f35b6100826100e4565b60405161008f91906101ca565b60405180910390f35b6100a06100ea565b6040516100ad91906101ca565b60405180910390f35b6100be6100f0565b6040516100cb91906101ca565b60405180910390f35b6100dc6100f6565b005b60005481565b60015481565b60025481565b60035481565b60008081905550600180819055506002808190555060038081905550600a60005461012191906101e5565b600081905550600b60015461013691906101e5565b600181905550600c60025461014b91906101e5565b600281905550600d60035461016091906101e5565b60038190555060008054610174919061023b565b6000819055506014600154610189919061023b565b600181905550601560025461019e919061023b565b60028190555060156003546101b3919061023b565b600381905550565b6101c481610295565b82525050565b60006020820190506101df60008301846101bb565b92915050565b60006101f082610295565b91506101fb83610295565b9250827fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff038211156102305761022f61029f565b5b828201905092915050565b600061024682610295565b915061025183610295565b9250817fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff048311821515161561028a5761028961029f565b5b828202905092915050565b6000819050919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fdfea26469706673582212200d443753b26ea215c94e8fd1b03e4d389ebc740d96823003d127316393455da664736f6c63430008000033"))
             .transactionType(TransactionType.FRONTIER)
-            .gasLimit(0x38444C0L)
+            .gasLimit(MAX_GAS_LIMIT)
             .value(Wei.ZERO)
             .keyPair(keyPair)
             .build();
 
-    ToyExecutionEnvironmentV2 toyExecutionEnvironment =
+    final ToyExecutionEnvironmentV2 toyExecutionEnvironment =
         ToyExecutionEnvironmentV2.builder(chainConfig, testInfo)
             .accounts(List.of(userAccount))
             .transaction(tx)
@@ -136,85 +128,5 @@ public class ContractModifyingStorageTest extends TracerTestBase {
     // TODO: add transaction to invoke function
 
     toyExecutionEnvironment.run();
-  }
-
-  private final Random rnd = new Random(666);
-
-  @Test
-  void temporaryTest(TestInfo testInfo) {
-    List<Transaction> txList = new ArrayList<>();
-
-    KeyPair keyPair1 = new SECP256K1().generateKeyPair();
-    SECPPublicKey pk1 = keyPair1.getPublicKey();
-    Address address1 = Address.extract(Hash.hash(pk1.getEncodedBytes()));
-    ToyAccount account1 = buildAnAccount(address1, 7);
-
-    KeyPair keyPair2 = new SECP256K1().generateKeyPair();
-    SECPPublicKey pk2 = keyPair2.getPublicKey();
-    ToyAccount account2 = buildAnAccount(Address.extract(Hash.hash(pk2.getEncodedBytes())), 7);
-
-    KeyPair keyPair3 = new SECP256K1().generateKeyPair();
-    SECPPublicKey pk3 = keyPair3.getPublicKey();
-    ToyAccount account3 = buildAnAccount(Address.extract(Hash.hash(pk3.getEncodedBytes())), 7);
-
-    KeyPair keyPair4 = new SECP256K1().generateKeyPair();
-    SECPPublicKey pk4 = keyPair4.getPublicKey();
-    ToyAccount account4 =
-        ToyAccount.builder()
-            .balance(Wei.fromEth(10))
-            .nonce(7)
-            .address(Address.extract(Hash.hash(pk4.getEncodedBytes())))
-            .code(Bytes.fromHexString("0x3050"))
-            .build();
-
-    KeyPair keyPair5 = new SECP256K1().generateKeyPair();
-    SECPPublicKey pk5 = keyPair5.getPublicKey();
-    ToyAccount account5 = buildAnAccount(Address.extract(Hash.hash(pk5.getEncodedBytes())), 7);
-
-    Bytes initCode = new RlpRandEdgeCase().randData(true);
-
-    // TODO: deployment transaction fails in our ToyWorld
-    /*
-    txList.add(
-        ToyTransaction.builder()
-            .sender(account1)
-            .keyPair(keyPair1)
-            .transactionType(TransactionType.FRONTIER)
-            .gasLimit(rnd.nextLong(21000, 0xffffL))
-            .payload(initCode)
-            .value(Wei.fromEth(1))
-            .build());
-    */
-
-    txList.add(
-        ToyTransaction.builder()
-            .sender(account2)
-            .to(account4)
-            .keyPair(keyPair2)
-            .transactionType(TransactionType.FRONTIER)
-            .gasLimit(rnd.nextLong(21000, 0xffffL))
-            .value(Wei.fromEth(2))
-            .build());
-
-    txList.add(
-        ToyTransaction.builder()
-            .sender(account3)
-            .to(account4)
-            .keyPair(keyPair3)
-            .transactionType(TransactionType.FRONTIER)
-            .gasLimit(rnd.nextLong(21000, 0xffffL))
-            .value(Wei.fromEth(3))
-            .build());
-
-    ToyExecutionEnvironmentV2.builder(chainConfig, testInfo)
-        .accounts(List.of(account1, account2, account3, account4, account5))
-        .transactions(txList)
-        .build()
-        .run();
-  }
-
-  // Temporary support function
-  final ToyAccount buildAnAccount(Address address, long nonce) {
-    return ToyAccount.builder().balance(Wei.fromEth(10)).nonce(nonce).address(address).build();
   }
 }

--- a/testing/src/main/java/net/consensys/linea/testing/BytecodeRunner.java
+++ b/testing/src/main/java/net/consensys/linea/testing/BytecodeRunner.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.TestInfo;
  */
 @Accessors(fluent = true)
 public final class BytecodeRunner {
-  public static final long DEFAULT_GAS_LIMIT =
+  public static final long MAX_GAS_LIMIT =
       EIP_7825_TRANSACTION_GAS_LIMIT_CAP; // = 0x1000000 max tx gas limit since EIP-7825 (OSAKA)
   private final Bytes byteCode;
   @Getter ToyExecutionEnvironmentV2 toyExecutionEnvironmentV2;
@@ -71,19 +71,13 @@ public final class BytecodeRunner {
   // Default run method
   public void run(ChainConfig chainConfig, TestInfo testInfo) {
     this.run(
-        Wei.fromEth(1),
-        DEFAULT_GAS_LIMIT,
-        List.of(),
-        Bytes.EMPTY,
-        List.of(),
-        chainConfig,
-        testInfo);
+        Wei.fromEth(1), MAX_GAS_LIMIT, List.of(), Bytes.EMPTY, List.of(), chainConfig, testInfo);
   }
 
   // Ad-hoc senderBalance
   public void run(Wei senderBalance, ChainConfig chainConfig, TestInfo testInfo) {
     this.run(
-        senderBalance, DEFAULT_GAS_LIMIT, List.of(), Bytes.EMPTY, List.of(), chainConfig, testInfo);
+        senderBalance, MAX_GAS_LIMIT, List.of(), Bytes.EMPTY, List.of(), chainConfig, testInfo);
   }
 
   // Ad-hoc gasLimit
@@ -100,7 +94,7 @@ public final class BytecodeRunner {
   public void run(List<ToyAccount> additionalAccounts, ChainConfig chainConfig, TestInfo testInfo) {
     this.run(
         Wei.fromEth(1),
-        DEFAULT_GAS_LIMIT,
+        MAX_GAS_LIMIT,
         additionalAccounts,
         Bytes.EMPTY,
         List.of(),
@@ -137,14 +131,13 @@ public final class BytecodeRunner {
 
   public void run(
       Bytes payload, List<AccessListEntry> accessList, ChainConfig chainConfig, TestInfo testInfo) {
-    this.run(
-        Wei.fromEth(1), DEFAULT_GAS_LIMIT, List.of(), payload, accessList, chainConfig, testInfo);
+    this.run(Wei.fromEth(1), MAX_GAS_LIMIT, List.of(), payload, accessList, chainConfig, testInfo);
   }
 
   public void runWithImposedSenderRecipientAddressCollision(
       Bytes payload, List<AccessListEntry> accessList, ChainConfig chainConfig, TestInfo testInfo) {
     this.runWithImposedSenderRecipientAddressCollision(
-        Wei.fromEth(1), DEFAULT_GAS_LIMIT, List.of(), payload, accessList, chainConfig, testInfo);
+        Wei.fromEth(1), MAX_GAS_LIMIT, List.of(), payload, accessList, chainConfig, testInfo);
   }
 
   public void run(
@@ -219,7 +212,7 @@ public final class BytecodeRunner {
     final ToyAccount senderAccount =
         ToyAccount.builder().balance(senderBalance).nonce(5).address(senderAddress).build();
 
-    final Long selectedGasLimit = Optional.of(gasLimit).orElse(DEFAULT_GAS_LIMIT);
+    final Long selectedGasLimit = Optional.of(gasLimit).orElse(MAX_GAS_LIMIT);
 
     final ToyAccount receiverAccount =
         imposeSenderRecipientCollision
@@ -282,7 +275,7 @@ public final class BytecodeRunner {
     final Transaction tx =
         ToyTransaction.builder()
             .payload(byteCode)
-            .gasLimit(DEFAULT_GAS_LIMIT)
+            .gasLimit(MAX_GAS_LIMIT)
             .sender(senderAccount)
             .value(Wei.of(272)) // 256 + 16, easier for debugging
             .keyPair(keyPair)

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
@@ -18,8 +18,7 @@ package net.consensys.linea.testing;
 import static com.google.common.base.Preconditions.checkArgument;
 import static net.consensys.linea.reporting.TracerTestBase.chainConfig;
 import static net.consensys.linea.zktracer.ChainConfig.MAINNET_TESTCONFIG;
-import static net.consensys.linea.zktracer.Fork.LONDON;
-import static net.consensys.linea.zktracer.Fork.isPostCancun;
+import static net.consensys.linea.zktracer.Fork.*;
 import static net.consensys.linea.zktracer.Trace.LINEA_BASE_FEE;
 import static net.consensys.linea.zktracer.module.ModuleName.*;
 
@@ -54,16 +53,14 @@ public class ToyExecutionEnvironmentV2 {
   public static final Address DEFAULT_COINBASE_ADDRESS =
       Address.fromHexString("0xc019ba5e00000000c019ba5e00000000c019ba5e");
   public static final long DEFAULT_BLOCK_NUMBER = 6678980;
-
   public static final long DEFAULT_TIME_STAMP = 1347310;
   public static final Hash DEFAULT_HASH =
       Hash.fromHexStringLenient("0xdeadbeef123123666dead666dead666");
-
   public static final Bytes32 DEFAULT_BEACON_ROOT = Bytes32.fromHexStringLenient("cc".repeat(32));
+  public static final Wei DEFAULT_BASE_FEE = Wei.of(LINEA_BASE_FEE);
 
   @Builder.Default private final List<ToyAccount> accounts = Collections.emptyList();
   @Builder.Default private final Address coinbase = DEFAULT_COINBASE_ADDRESS;
-  @Builder.Default public static final Wei DEFAULT_BASE_FEE = Wei.of(LINEA_BASE_FEE);
   @Builder.Default private final Boolean runWithBesuNode = false;
   @Builder.Default private String customBesuNodeGenesis = null;
   @Builder.Default private Boolean oneTxPerBlockOnBesuNode = false;
@@ -122,7 +119,7 @@ public class ToyExecutionEnvironmentV2 {
           zkTracerValidator,
           testInfo);
 
-      if (isPostCancun(tracer.getHub().fork)) {
+      if (isPostOsaka(tracer.getHub().fork)) {
         // This is to check that the light counter is really counting more than the full tracer
         final ZkTracer tracer = this.tracer;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces DEFAULT_GAS_LIMIT with MAX_GAS_LIMIT across tests/utilities, fixes Osaka CLZ byte push, and updates light-counter validation to run post-Osaka.
> 
> - **Testing utilities**:
>   - Rename and adopt `MAX_GAS_LIMIT` in `BytecodeRunner`; update default run paths and transaction builders to use it.
>   - In `ToyExecutionEnvironmentV2`, switch fork gate from `isPostCancun` to `isPostOsaka` for light-counter validation; minor constant/order cleanup.
> - **Tests**:
>   - Use `MAX_GAS_LIMIT` in `forkSpecific/prague/floorprice/RefundTests` and `instructionprocessing/ContractModifyingStorageTest`; add `final`s and remove temporary/debug code.
>   - Fix Osaka path in `ForkTracingAndSwitchingBesuTest` to push `Bytes.fromHexString("0x07acaa")` before `OpCode.CLZ`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ef0219139f6cdb177a5f225c2688de784c2d988. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->