### PR TITLE
feat: update reference tests build.gradle

### DIFF
--- a/reference-tests/build.gradle
+++ b/reference-tests/build.gradle
@@ -33,20 +33,23 @@ configurations.configureEach {
   exclude module: 'log4j-slf4j2-impl'
 }
 
-tasks.register("downloadExecutionSpecFixtures", Download)
-        {
+tasks.register("downloadExecutionSpecFixtures", Download) {
   src "https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_develop.tar.gz"
   dest "./build/fixtures_develop.tar.gz"
   overwrite false
 }
 
-
-tasks.register("generateExecutionSpecBlockchainTests", RefTestGenerationTask) {
-  dependsOn "downloadExecutionSpecFixtures"
-  copy {
+tasks.register("copyExecutionSpecFixtures", Copy) {
+    dependsOn "downloadExecutionSpecFixtures"
+    //
     from tarTree("./build/fixtures_develop.tar.gz")
     into "./build/execution-spec-tests"
-  }
+}
+
+
+tasks.register("generateExecutionSpecBlockchainTests", RefTestGenerationTask) {
+    dependsOn "copyExecutionSpecFixtures"
+  // Configure task
   refTestTemplateFilePath = "src/test/resources/templates/BlockchainReferenceTest.java.template"
   refTests = "./build/execution-spec-tests/fixtures/blockchain_tests"
   refTestsSrcPath = "./build/execution-spec-tests/"


### PR DESCRIPTION
This updates the build.gradle to ensure that the
downloadExecutionSpecFixtures task is triggered when running the tests, when previously it was not.  There is still an oddity though, whereby the first time you do it, it will download the fixtures but then not run any actual tests.  However, if you rerun then it does indeed run the tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a `Copy` task and rewire task dependencies so execution-spec fixtures are downloaded and unpacked before generating blockchain tests.
> 
> - **Build/Gradle (`reference-tests/build.gradle`)**:
>   - Add `copyExecutionSpecFixtures` (`Copy`) task to extract `fixtures_develop.tar.gz` into `./build/execution-spec-tests`, depending on `downloadExecutionSpecFixtures`.
>   - Update `generateExecutionSpecBlockchainTests` to depend on `copyExecutionSpecFixtures` (instead of directly on download), ensuring fixtures are unpacked before test generation.
>   - Minor cleanup of task registration blocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 649ae9e5033be20abbe87cf5f1c51eeab8086c65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->