### PR TITLE
Feat/update engine api osaka

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 releaseVersion=beta-v5.0-integration-test-wo-modexp-secp256r1
 besuVersion=25.11.0-RC1-linea2
 shomeiVersion=2.4-develop
-besuShomeiPluginVersion=v0.7.4
+besuShomeiPluginVersion=v0.8.2
 besuArtifactGroup=org.hyperledger.besu
 distributionIdentifier=linea-tracer
 distributionBaseUrl=https://github.com/Consensys/linea-besu-upstream/releases/download/

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -83,7 +83,7 @@ tasks.withType(Test).configureEach {
   // Configure BESU-related paths
   delete("${project.getLayout().getBuildDirectory().get()}/besu/traces")
   mkdir("${project.getLayout().getBuildDirectory().get()}/besu/traces")
-  mkdir("${project.getLayout().getBuildDirectory().get()}/besu/traces/prague")    
+  mkdir("${project.getLayout().getBuildDirectory().get()}/besu/traces/prague")
   mkdir("${project.getLayout().getBuildDirectory().get()}/besu/plugins")
   System.setProperty("besu.plugins.dir",
           System.getenv().getOrDefault("besu.plugins.dir",
@@ -97,7 +97,7 @@ tasks.withType(Test).configureEach {
   )
   systemProperty("besu.traces.dir", System.getProperty("besu.traces.dir"))
   systemProperty("besu.plugins.dir", System.getProperty("besu.plugins.dir"))
-  // 
+  //
   testlogger {
     // pick a theme - mocha, standard, plain, mocha-parallel, standard-parallel or plain-parallel
     theme 'plain-parallel'
@@ -154,7 +154,7 @@ tasks.withType(Test).configureEach {
 
 tasks.test.configure {
   // Following required as some unit tests run BESU checks
-  dependsOn("copyTracerPlugin", "downloadShoemiBesuPlugin")
+  dependsOn("copyTracerPlugin", "downloadShomeiBesuPlugin")
   //
   useJUnitPlatform {
     excludeTags("nightly | replay | weekly")
@@ -212,7 +212,7 @@ tasks.register("prcCallTests", Test) {
 // =============================================================================
 
 tasks.register("besuNodeTests", Test) {
-  dependsOn("copyTracerPlugin", "downloadShoemiBesuPlugin")
+  dependsOn("copyTracerPlugin", "downloadShomeiBesuPlugin")
   //
   forkEvery = 1
   maxParallelForks = 3
@@ -228,7 +228,7 @@ tasks.register("besuNodeTests", Test) {
 }
 
 tasks.register("besuNodeFastReplayTests", Test) {
-  dependsOn("copyTracerPlugin", "downloadShoemiBesuPlugin")
+  dependsOn("copyTracerPlugin", "downloadShomeiBesuPlugin")
   //
   forkEvery = 1
   maxParallelForks = 3
@@ -310,7 +310,7 @@ tasks.register("copyTracerPlugin", Copy) {
   into "${System.getProperty("besu.plugins.dir")}"
 }
 
-tasks.register("downloadShoemiBesuPlugin", Download) {
+tasks.register("downloadShomeiBesuPlugin", Download) {
   src "${besuShomeiPluginBaseUrl}${besuShomeiPluginVersion}/besu-shomei-plugin-${besuShomeiPluginVersion}.jar"
   dest "${System.getProperty("besu.plugins.dir")}"
   overwrite false

--- a/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
+++ b/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
@@ -30,7 +30,7 @@ public class TracerTestBase {
   public static void init() {
     // Configure chain information and fork before any tests are run, including any methods used as
     // MethodSource.
-    TracerTestBase.chainConfig = ChainConfig.MAINNET_TESTCONFIG(getForkOrDefault(OSAKA));
+    TracerTestBase.chainConfig = ChainConfig.MAINNET_TESTCONFIG(getForkOrDefault(PRAGUE));
     TracerTestBase.fork = TracerTestBase.chainConfig.fork;
     TracerTestBase.opcodes = OpCodes.load(fork);
   }

--- a/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
+++ b/testing/src/main/java/net/consensys/linea/reporting/TracerTestBase.java
@@ -30,7 +30,7 @@ public class TracerTestBase {
   public static void init() {
     // Configure chain information and fork before any tests are run, including any methods used as
     // MethodSource.
-    TracerTestBase.chainConfig = ChainConfig.MAINNET_TESTCONFIG(getForkOrDefault(PRAGUE));
+    TracerTestBase.chainConfig = ChainConfig.MAINNET_TESTCONFIG(getForkOrDefault(OSAKA));
     TracerTestBase.fork = TracerTestBase.chainConfig.fork;
     TracerTestBase.opcodes = OpCodes.load(fork);
   }

--- a/testing/src/main/java/net/consensys/linea/testing/EngineAPIService.java
+++ b/testing/src/main/java/net/consensys/linea/testing/EngineAPIService.java
@@ -218,7 +218,8 @@ public class EngineAPIService {
       case PARIS -> createEngineCall("engine_getPayloadV1", params);
       case SHANGHAI -> createEngineCall("engine_getPayloadV2", params);
       case CANCUN -> createEngineCall("engine_getPayloadV3", params);
-      case PRAGUE, OSAKA -> createEngineCall("engine_getPayloadV4", params);
+      case PRAGUE -> createEngineCall("engine_getPayloadV4", params);
+      case OSAKA -> createEngineCall("engine_getPayloadV5", params);
       default -> throw new IllegalArgumentException(
           "Unsupported fork for createGetPayloadRequest: " + fork);
     };
@@ -244,7 +245,6 @@ public class EngineAPIService {
       case SHANGHAI -> createEngineCall("engine_newPayloadV2", params);
       case CANCUN -> createEngineCall("engine_newPayloadV3", params);
       case PRAGUE -> createEngineCall("engine_newPayloadV4", params);
-      case OSAKA -> createEngineCall("engine_newPayloadV5", params);
       default -> throw new IllegalArgumentException(
           "Unsupported fork for createNewPayloadRequest: " + fork);
     };

--- a/testing/src/main/java/net/consensys/linea/testing/EngineAPIService.java
+++ b/testing/src/main/java/net/consensys/linea/testing/EngineAPIService.java
@@ -244,7 +244,7 @@ public class EngineAPIService {
       case PARIS -> createEngineCall("engine_newPayloadV1", params);
       case SHANGHAI -> createEngineCall("engine_newPayloadV2", params);
       case CANCUN -> createEngineCall("engine_newPayloadV3", params);
-      case PRAGUE -> createEngineCall("engine_newPayloadV4", params);
+      case PRAGUE, OSAKA -> createEngineCall("engine_newPayloadV4", params);
       default -> throw new IllegalArgumentException(
           "Unsupported fork for createNewPayloadRequest: " + fork);
     };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates EngineAPIService for Osaka (getPayloadV5, newPayloadV4), fixes Gradle task name, and bumps besu-shomei plugin to v0.8.2.
> 
> - **Engine API (testing)**:
>   - `EngineAPIService`: use `engine_getPayloadV5` for `OSAKA`; keep `engine_newPayloadV4` for `PRAGUE` and `OSAKA`.
> - **Build/Test**:
>   - Rename Gradle task to `downloadShomeiBesuPlugin` and update dependent tasks.
>   - Bump `besuShomeiPluginVersion` to `v0.8.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23ac20dff215e1a64b1d25055bc92f6ef7de2d42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->