### PR TITLE
feat: support in memory trace compression

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -12,4 +12,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@fb1aebd7f532e8940bc18feeedf3600d4bb5006f # v1.1.28
+      run: go install github.com/consensys/go-corset/cmd/go-corset@791590029fa54d0ef4047dafe3560867f5021a22 # v1.1.29

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
@@ -70,6 +70,11 @@ public class GenerateConflatedTracesV2 {
             endpointConfiguration.traceCompression());
     this.l1L2BridgeSharedConfiguration = lineaL1L2BridgeSharedConfiguration;
     this.traceFileCaching = endpointConfiguration.caching();
+    // log configuration
+    log.info("trace file caching {}", this.traceFileCaching ? "enabled." : "disabled.");
+    log.info(
+        "trace file compression {}",
+        endpointConfiguration.traceCompression() ? "enabled." : "disabled.");
   }
 
   public String getNamespace() {

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
@@ -64,7 +64,9 @@ public class GenerateConflatedTracesV2 {
       final LineaL1L2BridgeSharedConfiguration lineaL1L2BridgeSharedConfiguration) {
     this.besuContext = besuContext;
     this.requestLimiter = requestLimiter;
-    this.traceWriter = new TraceWriter(Paths.get(endpointConfiguration.tracesOutputPath()));
+    this.traceWriter = new TraceWriter(
+      Paths.get(endpointConfiguration.tracesOutputPath()),
+      endpointConfiguration.traceCompression());
     this.l1L2BridgeSharedConfiguration = lineaL1L2BridgeSharedConfiguration;
     this.traceFileCaching = endpointConfiguration.caching();
   }

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
@@ -64,9 +64,10 @@ public class GenerateConflatedTracesV2 {
       final LineaL1L2BridgeSharedConfiguration lineaL1L2BridgeSharedConfiguration) {
     this.besuContext = besuContext;
     this.requestLimiter = requestLimiter;
-    this.traceWriter = new TraceWriter(
-      Paths.get(endpointConfiguration.tracesOutputPath()),
-      endpointConfiguration.traceCompression());
+    this.traceWriter =
+        new TraceWriter(
+            Paths.get(endpointConfiguration.tracesOutputPath()),
+            endpointConfiguration.traceCompression());
     this.l1L2BridgeSharedConfiguration = lineaL1L2BridgeSharedConfiguration;
     this.traceFileCaching = endpointConfiguration.caching();
   }

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointCliOptions.java
@@ -28,6 +28,9 @@ public class TracesEndpointCliOptions implements LineaCliOptions {
 
   static final String CACHING = "--plugin-linea-rpc-caching";
 
+  static final String CONFLATED_TRACE_GENERATION_TRACE_COMPRESSION =
+    "--plugin-linea-conflated-trace-generation-trace-compression";
+
   @CommandLine.Option(
       required = true,
       names = {CONFLATED_TRACE_GENERATION_TRACES_OUTPUT_PATH},
@@ -42,6 +45,13 @@ public class TracesEndpointCliOptions implements LineaCliOptions {
       paramLabel = "<CACHING>",
       description = "Reuse existing trace files when available")
   private boolean caching = true;
+
+  @CommandLine.Option(
+      names = {CONFLATED_TRACE_GENERATION_TRACE_COMPRESSION},
+      hidden = true,
+      paramLabel = "<BOOL>",
+      description = "Specify whether or not to employ trace compression")
+  private boolean traceCompression = true;
 
   private TracesEndpointCliOptions() {}
 
@@ -63,6 +73,7 @@ public class TracesEndpointCliOptions implements LineaCliOptions {
   static TracesEndpointCliOptions fromConfig(final TracesEndpointConfiguration config) {
     final TracesEndpointCliOptions options = create();
     options.tracesOutputPath = config.tracesOutputPath();
+    options.traceCompression = config.traceCompression();
     options.caching = config.caching();
     return options;
   }
@@ -76,6 +87,7 @@ public class TracesEndpointCliOptions implements LineaCliOptions {
   public TracesEndpointConfiguration toDomainObject() {
     return TracesEndpointConfiguration.builder()
         .tracesOutputPath(tracesOutputPath)
+        .traceCompression(traceCompression)
         .caching(caching)
         .build();
   }
@@ -84,6 +96,7 @@ public class TracesEndpointCliOptions implements LineaCliOptions {
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add(CONFLATED_TRACE_GENERATION_TRACES_OUTPUT_PATH, tracesOutputPath)
+        .add(CONFLATED_TRACE_GENERATION_TRACE_COMPRESSION, traceCompression)
         .add(CACHING, caching)
         .toString();
   }

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointCliOptions.java
@@ -29,7 +29,7 @@ public class TracesEndpointCliOptions implements LineaCliOptions {
   static final String CACHING = "--plugin-linea-rpc-caching";
 
   static final String CONFLATED_TRACE_GENERATION_TRACE_COMPRESSION =
-    "--plugin-linea-conflated-trace-generation-trace-compression";
+      "--plugin-linea-conflated-trace-generation-trace-compression";
 
   @CommandLine.Option(
       required = true,

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointConfiguration.java
@@ -20,5 +20,6 @@ import net.consensys.linea.plugins.LineaOptionsConfiguration;
 
 /** The Linea tracer configuration private to this repo. */
 @Builder(toBuilder = true)
-public record TracesEndpointConfiguration(String tracesOutputPath, boolean caching, boolean traceCompression)
+public record TracesEndpointConfiguration(
+    String tracesOutputPath, boolean caching, boolean traceCompression)
     implements LineaOptionsConfiguration {}

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/TracesEndpointConfiguration.java
@@ -20,5 +20,5 @@ import net.consensys.linea.plugins.LineaOptionsConfiguration;
 
 /** The Linea tracer configuration private to this repo. */
 @Builder(toBuilder = true)
-public record TracesEndpointConfiguration(String tracesOutputPath, boolean caching)
+public record TracesEndpointConfiguration(String tracesOutputPath, boolean caching, boolean traceCompression)
     implements LineaOptionsConfiguration {}

--- a/arithmetization/src/main/java/net/consensys/linea/tracewriter/TraceWriter.java
+++ b/arithmetization/src/main/java/net/consensys/linea/tracewriter/TraceWriter.java
@@ -38,9 +38,10 @@ public class TraceWriter {
 
   public TraceWriter(Path tracesOutputDirPath, boolean traceCompression) {
     this.tracesOutputDirPath = tracesOutputDirPath;
-    // Configure trace file extensions.  These provide indication during trace generation as to whether compression
+    // Configure trace file extensions.  These provide indication during trace generation as to
+    // whether compression
     // should be used, or not.
-    if(traceCompression) {
+    if (traceCompression) {
       traceFileExtension = ".lt.gz";
       tempTraceFileExtension = ".lt.tmp.gz";
     } else {
@@ -91,7 +92,7 @@ public class TraceWriter {
         writeToTmpFile(
             tracer,
             origTraceFileName + ".",
-          tempTraceFileExtension,
+            tempTraceFileExtension,
             startBlockNumber,
             endBlockNumber);
     // After trace writing is complete, rename the file by removing the .tmp prefix, indicating

--- a/arithmetization/src/main/java/net/consensys/linea/tracewriter/TraceWriter.java
+++ b/arithmetization/src/main/java/net/consensys/linea/tracewriter/TraceWriter.java
@@ -25,18 +25,29 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
 
-import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.zktracer.ZkTracer;
 
 @Slf4j
-@RequiredArgsConstructor
 public class TraceWriter {
-  private static final String TRACE_FILE_EXTENSION = ".lt";
-  private static final String TRACE_TEMP_FILE_EXTENSION = ".lt.tmp";
+  private final String traceFileExtension;
+  private final String tempTraceFileExtension;
 
   final Path tracesOutputDirPath;
+
+  public TraceWriter(Path tracesOutputDirPath, boolean traceCompression) {
+    this.tracesOutputDirPath = tracesOutputDirPath;
+    // Configure trace file extensions.  These provide indication during trace generation as to whether compression
+    // should be used, or not.
+    if(traceCompression) {
+      traceFileExtension = ".lt.gz";
+      tempTraceFileExtension = ".lt.tmp.gz";
+    } else {
+      traceFileExtension = ".lt";
+      tempTraceFileExtension = ".lt.tmp";
+    }
+  }
 
   /**
    * Check whether the corresponding trace file already exists, or not.
@@ -57,7 +68,7 @@ public class TraceWriter {
         generateOutputFileName(
             startBlockNumber, endBlockNumber, expectedTracesEngineVersion, besuVersion);
     // Generate and resolve the original and final trace file path.
-    return generateOutputFilePath(tracesOutputDirPath, origTraceFileName + TRACE_FILE_EXTENSION);
+    return generateOutputFilePath(tracesOutputDirPath, origTraceFileName + traceFileExtension);
   }
 
   @SneakyThrows(IOException.class)
@@ -73,14 +84,14 @@ public class TraceWriter {
             startBlockNumber, endBlockNumber, expectedTracesEngineVersion, besuVersion);
     // Generate and resolve the original and final trace file path.
     final Path origTraceFilePath =
-        generateOutputFilePath(tracesOutputDirPath, origTraceFileName + TRACE_FILE_EXTENSION);
+        generateOutputFilePath(tracesOutputDirPath, origTraceFileName + traceFileExtension);
     // Write the trace at the original and final trace file path, but with the suffix .tmp at the
     // end of the file.
     final Path tmpTraceFilePath =
         writeToTmpFile(
             tracer,
             origTraceFileName + ".",
-            TRACE_TEMP_FILE_EXTENSION,
+          tempTraceFileExtension,
             startBlockNumber,
             endBlockNumber);
     // After trace writing is complete, rename the file by removing the .tmp prefix, indicating

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/LtTraceFile.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/LtTraceFile.java
@@ -15,141 +15,298 @@
 
 package net.consensys.linea.zktracer;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.file.Path;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import net.consensys.linea.zktracer.container.module.Module;
+import org.jetbrains.annotations.TestOnly;
 
-/** Provides a basic API for reading the metadata from an LT trace file. */
-public class LtTraceFile implements AutoCloseable {
+/** Provides a basic API for writing an LT trace file. */
+public class LtTraceFile {
 
-  /** Represents the header component of an LtTraceFile. */
-  public static class Header {
-    /** Identifier should be "zktracer". */
-    byte[] identifier;
+  public static class Column implements Trace.Column {
+    private final String name;
+    private final int bitWidth;
+    private final int byteWidth;
+    private final long longMax;
+    private final ByteBuffer buffer;
 
-    /** Major version for LT tracefile format. */
-    short majorVersion;
-
-    /** Minor version for LT tracefile format. */
-    short minorVersion;
-
-    /** Metadata bytes for LT tracefile (encoded as JSON by default). */
-    byte[] metadata;
-
-    public Header(byte[] identifier, short majorVersion, short minorVersion, byte[] metadata) {
-      this.identifier = identifier;
-      this.majorVersion = majorVersion;
-      this.minorVersion = minorVersion;
-      this.metadata = metadata;
+    public Column(String name, int bitwidth, int length) {
+      this.name = name;
+      this.bitWidth = bitwidth;
+      this.byteWidth = byteWidth(bitwidth);
+      this.longMax = 1L << bitwidth;
+      this.buffer = ByteBuffer.allocate(length * byteWidth);
     }
 
-    /**
-     * Parse the metadata bytes into a map.
-     *
-     * @return Map representing the metadata
-     */
-    public Map<String, Object> getMetaData() throws IOException {
-      JsonNode node = objectMapper.readTree(this.metadata);
-      return parseJsonNode(node);
+    @Override
+    public void write(boolean value) {
+      this.buffer.put((byte) (value ? 1 : 0));
     }
 
-    private static Map<String, Object> parseJsonNode(JsonNode node) {
-      HashMap<String, Object> metadata = new HashMap<>();
-
-      for (java.util.Map.Entry<String, JsonNode> entry : node.properties()) {
-        JsonNode val = entry.getValue();
-        Object obj;
-        //
-        if (val.isObject()) {
-          obj = parseJsonNode(val);
-        } else if (val.isTextual()) {
-          obj = val.asText();
-        } else if (val.isBoolean()) {
-          obj = val.asBoolean();
-        } else if (val.isInt()) {
-          obj = val.asInt();
-        } else if (val.isLong()) {
-          obj = val.asLong();
-        } else {
-          // Fall back, including for null.
-          obj = val.textValue();
-        }
-        //
-        metadata.put(entry.getKey(), obj);
+    @Override
+    public void write(long value) {
+      // Sanity check
+      if(longMax <= value) {
+        throw new IllegalArgumentException(name + " has invalid value (" + value + ")");
       }
       //
-      return metadata;
+      switch(byteWidth) {
+        case 8:
+          this.buffer.put((byte) (value >> 56));
+        case 7:
+          this.buffer.put((byte) (value >> 48));
+        case 6:
+          this.buffer.put((byte) (value >> 40));
+        case 5:
+          this.buffer.put((byte) (value >> 32));
+        case 4:
+          this.buffer.put((byte) (value >> 24));
+        case 3:
+          this.buffer.put((byte) (value >> 16));
+        case 2:
+          this.buffer.put((byte) (value >> 8));
+        case 1:
+          this.buffer.put((byte) value);
+          break;
+        default:
+          throw new IllegalArgumentException(name + " has invalid width (" + byteWidth + "bytes)");
+      }
+    }
+
+    @Override
+    public void write(byte[] bytes) {
+      final int n = bitLengthOf(bytes);
+      // Sanity check
+      if(n > bitWidth) {
+        throw new IllegalArgumentException(name + " has invalid width (" + n + " bits)");
+      }
+      // Write padding (if necessary)
+      for(int i=bytes.length;i < byteWidth; i++) {
+        buffer.put((byte) 0);
+      }
+      // Write data
+      for(int i=0;i!=bytes.length;i++) {
+        buffer.put(bytes[i]);
+      }
     }
   }
 
-  private final FileChannel ch;
+  /** Object writer is used for generating JSON byte strings. */
+  private static final ObjectWriter objectWriter = new ObjectMapper().writer();
 
-  public LtTraceFile(Path path) throws IOException {
-    this.ch = FileChannel.open(path);
-  }
-
-  public Header getHeader() throws IOException {
-    return parseHeader(ch);
-  }
-
-  @Override
-  public void close() throws IOException {
-    this.ch.close();
-  }
-
-  private static Header parseHeader(FileChannel ch) throws IOException {
-    ByteBuffer header = ByteBuffer.allocate(16);
-    byte[] identifier = new byte[8];
-    // Reset channel position to beginning of file.
-    ch.position(0);
-    // Reader header bytes
-    int nBytes = ch.read(header);
-    //
-    if (nBytes != 16) {
-      return null;
+  /**
+   * Construct the binary representation of a trace.
+   *
+   * @param metadata
+   * @param trace
+   * @param modules
+   * @return
+   */
+  public static byte[] toBytes(Map<String, Object> metadata, Trace trace, List<Module> modules)
+      throws IOException {
+    final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    // Determine set of all columns headers
+    final List<Trace.ColumnHeader> rawHeaders =
+        modules.stream().flatMap(m -> m.columnHeaders(trace).stream()).toList();
+    // Align column headers
+    final Trace.ColumnHeader[] headers = alignHeaders(rawHeaders);
+    // Initialise all trace columns
+    final Column[] columns = initialiseTraceColumns(trace, headers);
+    // Open trace for writing
+    trace.open(columns);
+    // Commit each module
+    for (Module m : modules) {
+      m.commit(trace);
     }
-    // Reset buffer position
-    header.position(0);
-    // Read identifier bytes
-    header.get(identifier);
-    // Read major version
-    short majorVersion = header.getShort();
-    // Read minor version
-    short minorVersion = header.getShort();
-    // Read metadata length
-    int metadataLength = header.getInt();
-    // read metadata bytes
-    byte[] metadata = parseMetaDataBytes(ch, metadataLength);
-    // Sanity check
-    if (metadata == null) {
-      return null;
+    // Write header for LTv1 file
+    bout.writeBytes(getHeaderBytes(getMetadataBytes(metadata)));
+    bout.writeBytes(getColumnHeaderBytes(headers));
+    // Write column data
+    for(int i = 0;i!=columns.length; i++) {
+      if(columns[i] != null) {
+        bout.writeBytes(columns[i].buffer.array());
+      }
     }
-    //
-    return new Header(identifier, majorVersion, minorVersion, metadata);
-  }
-
-  private static byte[] parseMetaDataBytes(FileChannel ch, int metadataLength) throws IOException {
-    // read metadata bytes
-    ByteBuffer metadata = ByteBuffer.allocate(metadataLength);
-    byte[] metadataBytes = new byte[metadataLength];
-    int nBytes = ch.read(metadata);
-    metadata.position(0);
-    // Sanity check
-    if (nBytes != metadataLength) {
-      return null;
-    }
-    // Looks ok.
-    metadata.get(metadataBytes);
     // Done
-    return metadataBytes;
+    return bout.toByteArray();
   }
 
-  /** Object mapper is used for parsing JSON byte strings. */
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  /**
+   * Align headers ensures that the order in which columns are seen matches the order found in the
+   * trace schema.
+   *
+   * @param headers The headers to be aligned.
+   * @return The aligned headers.
+   */
+  private static Trace.ColumnHeader[] alignHeaders(List<Trace.ColumnHeader> headers) {
+    int maxRegister = 0;
+    // Determine largest register
+    //
+    for (Trace.ColumnHeader header : headers) {
+      maxRegister = Math.max(header.register(), maxRegister);
+    }
+    //
+    Trace.ColumnHeader[] alignedHeaders = new Trace.ColumnHeader[maxRegister + 1];
+    //
+    for (Trace.ColumnHeader header : headers) {
+      alignedHeaders[header.register()] = header;
+    }
+    //
+    return alignedHeaders;
+  }
+
+  /**
+   * Initialise the column buffers where all data will be written.
+   *
+   * @param trace
+   * @param headers
+   * @return
+   */
+  private static Column[] initialiseTraceColumns(Trace trace, Trace.ColumnHeader[] headers) {
+    final Column[] columns = new Column[headers.length];
+
+    for (int i = 0; i < headers.length;i++) {
+      Trace.ColumnHeader header = headers[i];
+      if (header != null) {
+        columns[i] = new Column(header.name(), header.bitwidth(), header.length());
+      }
+    }
+
+    return columns;
+  }
+
+  public static byte[] getMetadataBytes(Map<String, Object> metadata) throws IOException {
+    return objectWriter.writeValueAsBytes(metadata);
+  }
+
+  /**
+   * Construct trace file header containing the given metadata bytes.
+   *
+   * @param metadata Metadata bytes to be embedded in the trace file.
+   * @return bytes making up the header.
+   */
+  private static byte[] getHeaderBytes(byte[] metadata) {
+    ByteBuffer buffer = ByteBuffer.allocate(16 + metadata.length);
+    // File identifier
+    buffer.put(new byte[] {'z', 'k', 't', 'r', 'a', 'c', 'e', 'r'});
+    // Major version
+    buffer.putShort((short) 1);
+    // Minor version
+    buffer.putShort((short) 0);
+    // Metadata length
+    buffer.putInt(metadata.length);
+    // Metadata
+    buffer.put(metadata);
+    // Done
+    return buffer.array();
+  }
+
+  /**
+   * Write header information for the trace file.
+   *
+   * @param headers Column headers.*
+   */
+  private static byte[] getColumnHeaderBytes(Trace.ColumnHeader[] headers) throws IOException {
+    ByteBuffer buffer = ByteBuffer.allocate(getColumnHeadersSize(headers));
+    // Write column count as uint32
+    buffer.putInt(countHeaders(headers));
+    // Write column headers one-by-one
+    for (Trace.ColumnHeader h : headers) {
+      if (h != null) {
+        buffer.putShort((short) h.name().length());
+        buffer.put(h.name().getBytes());
+        buffer.put((byte) byteWidth(h.bitwidth()));
+        buffer.putInt(h.length());
+      }
+    }
+    //
+    return buffer.array();
+  }
+
+  /**
+   * Precompute the size of the trace file in order to memory map the buffers.
+   *
+   * @param headers Set of headers for the columns being written.
+   * @return Number of bytes requires for the trace file header.
+   */
+  private static int getColumnHeadersSize(Trace.ColumnHeader[] headers) {
+    int nBytes = 4; // column count
+
+    for (Trace.ColumnHeader header : headers) {
+      if (header != null) {
+        nBytes += 2; // name length
+        nBytes += header.name().length();
+        nBytes += 1; // byte per element
+        nBytes += 4; // element count
+      }
+    }
+
+    return nBytes;
+  }
+
+  /**
+   * Counter number of active (i.e. non-null) headers. A header can be null if it represents a
+   * column in a module which is not activated for this trace.
+   */
+  private static int countHeaders(Trace.ColumnHeader[] headers) {
+    int count = 0;
+    for (Trace.ColumnHeader h : headers) {
+      if (h != null) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Convert a given bitwidth into a bytewidth.  For example, a bitwidth of 1 becomes a bytewidth of 1 whilst a
+   * bitwidth of 9 becomes a bytewidth of 2, etc.
+   *
+   * @param bitwidth
+   * @return
+   */
+  private static int byteWidth(int bitwidth) {
+    int byteWidth = bitwidth / 8;
+    //
+    if((bitwidth % 8) != 0) {
+      byteWidth++;
+    }
+    //
+    return byteWidth;
+  }
+
+  public static int bitLengthOf(byte[] bytes) {
+    int n = 0;
+    // Skip forward
+    while(n < bytes.length && bytes[n] == 0) {
+      n++;
+    }
+    // Determine width
+    if(n == bytes.length) {
+      return 0;
+    } else {
+      // n > 0
+      int m = bytes.length - n - 1;
+      return bitLengthOf(bytes[n]) + (m * 8);
+    }
+  }
+
+  private static int bitLengthOf(byte b) {
+    // Convert into unsigned representation
+    int val = b & 0xff;
+    // NOTE: we could further improve performance by turning this into one big lookup table.
+    if(val >= 16) {
+      return bits[val>>4] + 4;
+    } else {
+      return bits[val];
+    }
+  }
+
+  private static final int[] bits = { 0,1,2,2,3,3,3,3,4,4,4,4,4,4,4,4 };
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/LtTraceFile.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/LtTraceFile.java
@@ -78,11 +78,16 @@ public class LtTraceFile {
       }
     }
 
+    /**
+     * Write element bytes
+     *
+     * @param bytes stored in big-endian form and already trimmed.
+     */
     @Override
     public void write(byte[] bytes) {
       final int n = bitLengthOf(bytes);
       // Sanity check
-      if (n > bitWidth) {
+      if (n > bitWidth || bytes.length > byteWidth) {
         throw new IllegalArgumentException(name + " has invalid width (" + n + " bits)");
       }
       // Write padding (if necessary)

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/LtTraceFile.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/LtTraceFile.java
@@ -15,8 +15,8 @@
 
 package net.consensys.linea.zktracer;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +27,15 @@ import net.consensys.linea.zktracer.container.module.Module;
 
 /** Provides a basic API for writing an LT trace file. */
 public class LtTraceFile {
+  private final Map<String, Object> metadata;
+  private final Trace.ColumnHeader[] headers;
+  private final Column[] columns;
+
+  public LtTraceFile(Map<String, Object> metadata, Trace.ColumnHeader[] headers, Column[] columns) {
+    this.metadata = metadata;
+    this.headers = headers;
+    this.columns = columns;
+  }
 
   public static class Column implements Trace.Column {
     private final String name;
@@ -105,16 +114,14 @@ public class LtTraceFile {
   private static final ObjectWriter objectWriter = new ObjectMapper().writer();
 
   /**
-   * Construct the binary representation of a trace.
+   * Construct a full in-memory trace of all columns across all modules.
    *
    * @param metadata
    * @param trace
    * @param modules
    * @return
    */
-  public static byte[] toBytes(Map<String, Object> metadata, Trace trace, List<Module> modules)
-      throws IOException {
-    final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+  public static LtTraceFile of(Map<String, Object> metadata, Trace trace, List<Module> modules) {
     // Determine set of all columns headers
     final List<Trace.ColumnHeader> rawHeaders =
         modules.stream().flatMap(m -> m.columnHeaders(trace).stream()).toList();
@@ -128,17 +135,28 @@ public class LtTraceFile {
     for (Module m : modules) {
       m.commit(trace);
     }
+    //
+    return new LtTraceFile(metadata, headers, columns);
+  }
+
+  /**
+   * Write a binary representation of the trace to a given output stream.
+   *
+   * @param out
+   * @return
+   */
+  public void write(OutputStream out) throws IOException {
     // Write header for LTv1 file
-    bout.writeBytes(getHeaderBytes(getMetadataBytes(metadata)));
-    bout.writeBytes(getColumnHeaderBytes(headers));
+    out.write(getHeaderBytes(getMetadataBytes(metadata)));
+    out.write(getColumnHeaderBytes(headers));
     // Write column data
     for (int i = 0; i != columns.length; i++) {
       if (columns[i] != null) {
-        bout.writeBytes(columns[i].buffer.array());
+        out.write(columns[i].buffer.array());
       }
     }
     // Done
-    return bout.toByteArray();
+    out.flush();
   }
 
   /**

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/LtTraceFile.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/LtTraceFile.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import net.consensys.linea.zktracer.container.module.Module;
-import org.jetbrains.annotations.TestOnly;
 
 /** Provides a basic API for writing an LT trace file. */
 public class LtTraceFile {
@@ -52,11 +51,11 @@ public class LtTraceFile {
     @Override
     public void write(long value) {
       // Sanity check
-      if(longMax <= value) {
+      if (longMax <= value) {
         throw new IllegalArgumentException(name + " has invalid value (" + value + ")");
       }
       //
-      switch(byteWidth) {
+      switch (byteWidth) {
         case 8:
           this.buffer.put((byte) (value >> 56));
         case 7:
@@ -83,15 +82,15 @@ public class LtTraceFile {
     public void write(byte[] bytes) {
       final int n = bitLengthOf(bytes);
       // Sanity check
-      if(n > bitWidth) {
+      if (n > bitWidth) {
         throw new IllegalArgumentException(name + " has invalid width (" + n + " bits)");
       }
       // Write padding (if necessary)
-      for(int i=bytes.length;i < byteWidth; i++) {
+      for (int i = bytes.length; i < byteWidth; i++) {
         buffer.put((byte) 0);
       }
       // Write data
-      for(int i=0;i!=bytes.length;i++) {
+      for (int i = 0; i != bytes.length; i++) {
         buffer.put(bytes[i]);
       }
     }
@@ -128,8 +127,8 @@ public class LtTraceFile {
     bout.writeBytes(getHeaderBytes(getMetadataBytes(metadata)));
     bout.writeBytes(getColumnHeaderBytes(headers));
     // Write column data
-    for(int i = 0;i!=columns.length; i++) {
-      if(columns[i] != null) {
+    for (int i = 0; i != columns.length; i++) {
+      if (columns[i] != null) {
         bout.writeBytes(columns[i].buffer.array());
       }
     }
@@ -171,7 +170,7 @@ public class LtTraceFile {
   private static Column[] initialiseTraceColumns(Trace trace, Trace.ColumnHeader[] headers) {
     final Column[] columns = new Column[headers.length];
 
-    for (int i = 0; i < headers.length;i++) {
+    for (int i = 0; i < headers.length; i++) {
       Trace.ColumnHeader header = headers[i];
       if (header != null) {
         columns[i] = new Column(header.name(), header.bitwidth(), header.length());
@@ -265,8 +264,8 @@ public class LtTraceFile {
   }
 
   /**
-   * Convert a given bitwidth into a bytewidth.  For example, a bitwidth of 1 becomes a bytewidth of 1 whilst a
-   * bitwidth of 9 becomes a bytewidth of 2, etc.
+   * Convert a given bitwidth into a bytewidth. For example, a bitwidth of 1 becomes a bytewidth of
+   * 1 whilst a bitwidth of 9 becomes a bytewidth of 2, etc.
    *
    * @param bitwidth
    * @return
@@ -274,7 +273,7 @@ public class LtTraceFile {
   private static int byteWidth(int bitwidth) {
     int byteWidth = bitwidth / 8;
     //
-    if((bitwidth % 8) != 0) {
+    if ((bitwidth % 8) != 0) {
       byteWidth++;
     }
     //
@@ -284,11 +283,11 @@ public class LtTraceFile {
   public static int bitLengthOf(byte[] bytes) {
     int n = 0;
     // Skip forward
-    while(n < bytes.length && bytes[n] == 0) {
+    while (n < bytes.length && bytes[n] == 0) {
       n++;
     }
     // Determine width
-    if(n == bytes.length) {
+    if (n == bytes.length) {
       return 0;
     } else {
       // n > 0
@@ -301,12 +300,12 @@ public class LtTraceFile {
     // Convert into unsigned representation
     int val = b & 0xff;
     // NOTE: we could further improve performance by turning this into one big lookup table.
-    if(val >= 16) {
-      return bits[val>>4] + 4;
+    if (val >= 16) {
+      return bits[val >> 4] + 4;
     } else {
       return bits[val];
     }
   }
 
-  private static final int[] bits = { 0,1,2,2,3,3,3,3,4,4,4,4,4,4,4,4 };
+  private static final int[] bits = {0, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4};
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -17,7 +17,10 @@ package net.consensys.linea.zktracer;
 import static net.consensys.linea.zktracer.ChainConfig.FORK_LINEA_CHAIN;
 import static net.consensys.linea.zktracer.Fork.getTraceFromFork;
 
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.zip.GZIPOutputStream;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +40,7 @@ import net.consensys.linea.zktracer.module.DebugMode;
 import net.consensys.linea.zktracer.module.hub.*;
 import net.consensys.linea.zktracer.runtime.callstack.CallFrame;
 import net.consensys.linea.zktracer.types.FiniteList;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Address;
@@ -137,12 +142,32 @@ public class ZkTracer implements LineCountingTracer {
     try {
       // Construct (in memory) trace file
       byte[] bytes = LtTraceFile.toBytes(metadata, trace, modulesToTrace);
+      // Compress file (if requested)
+      if(FilenameUtils.getExtension(filename.toString()).equals("gz")) {
+        bytes = compressGzip(bytes);
+      }
       // Write contents to disk
       Files.write(filename, bytes);
     } catch (IOException e) {
       log.error("Error while writing file {}", filename);
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Compress a given byte array using GZip compression.
+   *
+   * @param bytes
+   * @return
+   * @throws IOException
+   */
+  private byte[] compressGzip(byte[] bytes) throws IOException {
+    ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+    try(GZIPOutputStream gzOut = new GZIPOutputStream(bOut)) {
+      gzOut.write(bytes);
+      gzOut.flush();
+    }
+    return bOut.toByteArray();
   }
 
   /**

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -18,8 +18,8 @@ import static net.consensys.linea.zktracer.ChainConfig.FORK_LINEA_CHAIN;
 import static net.consensys.linea.zktracer.Fork.getTraceFromFork;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.math.BigInteger;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
@@ -131,39 +131,47 @@ public class ZkTracer implements LineCountingTracer {
   public void writeToFile(final Path filename, long startBlock, long endBlock) {
     maybeThrowTracingExceptions();
     final List<Module> modulesToTrace = hub.getModulesToTrace();
-    final List<Trace.ColumnHeader> headers =
-        modulesToTrace.stream().flatMap(m -> m.columnHeaders(trace).stream()).toList();
     // Configure metadata
-    trace.addMetadata("releaseVersion", ZkTracer.class.getPackage().getSpecificationVersion());
-    trace.addMetadata("chainId", this.chain.id.toString());
-    trace.addMetadata("fork", this.chain.fork.toString());
-    trace.addMetadata("l2L1LogSmcAddress", this.chain.bridgeConfiguration.contract().toString());
-    trace.addMetadata("l2L1LogTopic", this.chain.bridgeConfiguration.topic().toString());
+    final Map<String, Object> metadata = buildMetaData(startBlock, endBlock);
+    //
+    try {
+      // Construct (in memory) trace file
+      byte[] bytes = LtTraceFile.toBytes(metadata, trace, modulesToTrace);
+      // Write contents to disk
+      Files.write(filename, bytes);
+    } catch (IOException e) {
+      log.error("Error while writing file {}", filename);
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Construct the metadata to be embedded in the generated trace file.
+   *
+   * @param startBlock
+   * @param endBlock
+   * @return
+   */
+  private Map<String, Object> buildMetaData(long startBlock, long endBlock) {
+    HashMap<String, Object> metadata = new HashMap<>(trace.getMetaData());
+    metadata.put("releaseVersion", ZkTracer.class.getPackage().getSpecificationVersion());
+    metadata.put("chainId", this.chain.id.toString());
+    metadata.put("fork", this.chain.fork.toString());
+    metadata.put("l2L1LogSmcAddress", this.chain.bridgeConfiguration.contract().toString());
+    metadata.put("l2L1LogTopic", this.chain.bridgeConfiguration.topic().toString());
     // include block range
     final Map<String, String> range = new HashMap<>();
     range.put("start", Long.toString(startBlock));
     range.put("end", Long.toString(endBlock));
-    trace.addMetadata("conflation", range);
+    metadata.put("conflation", range);
     // include line counts
     final Map<String, String> lineCounts = new HashMap<>();
     for (Module m : hub.getTracelessModules()) {
       lineCounts.put(m.moduleKey().toString(), Integer.toString(m.lineCount()));
     }
-    trace.addMetadata("lineCounts", lineCounts);
+    metadata.put("lineCounts", lineCounts);
     //
-    try (RandomAccessFile file = new RandomAccessFile(filename.toString(), "rw")) {
-      // Open trace for writing
-      trace.open(file, headers);
-      // Commit each module
-      for (Module m : modulesToTrace) {
-        m.commit(trace);
-      }
-      // Close the file
-      file.getChannel().force(false);
-    } catch (IOException e) {
-      log.error("Error while writing to the file {}", filename);
-      throw new RuntimeException(e);
-    }
+    return metadata;
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -18,9 +18,7 @@ import static net.consensys.linea.zktracer.ChainConfig.FORK_LINEA_CHAIN;
 import static net.consensys.linea.zktracer.Fork.getTraceFromFork;
 
 import java.io.ByteArrayOutputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -143,7 +141,7 @@ public class ZkTracer implements LineCountingTracer {
       // Construct (in memory) trace file
       byte[] bytes = LtTraceFile.toBytes(metadata, trace, modulesToTrace);
       // Compress file (if requested)
-      if(FilenameUtils.getExtension(filename.toString()).equals("gz")) {
+      if (FilenameUtils.getExtension(filename.toString()).equals("gz")) {
         bytes = compressGzip(bytes);
       }
       // Write contents to disk
@@ -163,7 +161,7 @@ public class ZkTracer implements LineCountingTracer {
    */
   private byte[] compressGzip(byte[] bytes) throws IOException {
     ByteArrayOutputStream bOut = new ByteArrayOutputStream();
-    try(GZIPOutputStream gzOut = new GZIPOutputStream(bOut)) {
+    try (GZIPOutputStream gzOut = new GZIPOutputStream(bOut)) {
       gzOut.write(bytes);
       gzOut.flush();
     }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkTracer.java
@@ -17,10 +17,10 @@ package net.consensys.linea.zktracer;
 import static net.consensys.linea.zktracer.ChainConfig.FORK_LINEA_CHAIN;
 import static net.consensys.linea.zktracer.Fork.getTraceFromFork;
 
-import java.io.ByteArrayOutputStream;
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
@@ -136,36 +136,29 @@ public class ZkTracer implements LineCountingTracer {
     final List<Module> modulesToTrace = hub.getModulesToTrace();
     // Configure metadata
     final Map<String, Object> metadata = buildMetaData(startBlock, endBlock);
+    // Construct (in memory) trace file
+    LtTraceFile ltf = LtTraceFile.of(metadata, trace, modulesToTrace);
     //
-    try {
-      // Construct (in memory) trace file
-      byte[] bytes = LtTraceFile.toBytes(metadata, trace, modulesToTrace);
+    try (FileOutputStream fout = new FileOutputStream(filename.toString())) {
       // Compress file (if requested)
       if (FilenameUtils.getExtension(filename.toString()).equals("gz")) {
-        bytes = compressGzip(bytes);
+        // GZIPOutputStream has an internal buffer, so no need for separate buffered output stream.
+        try (GZIPOutputStream gzOut = new GZIPOutputStream(fout, 65536)) {
+          ltf.write(gzOut);
+          gzOut.flush();
+        }
+      } else {
+        try (BufferedOutputStream bout = new BufferedOutputStream(fout, 65536)) {
+          ltf.write(bout);
+          bout.flush();
+        }
       }
-      // Write contents to disk
-      Files.write(filename, bytes);
+      // Flush to disk
+      fout.flush();
     } catch (IOException e) {
       log.error("Error while writing file {}", filename);
       throw new RuntimeException(e);
     }
-  }
-
-  /**
-   * Compress a given byte array using GZip compression.
-   *
-   * @param bytes
-   * @return
-   * @throws IOException
-   */
-  private byte[] compressGzip(byte[] bytes) throws IOException {
-    ByteArrayOutputStream bOut = new ByteArrayOutputStream();
-    try (GZIPOutputStream gzOut = new GZIPOutputStream(bOut)) {
-      gzOut.write(bytes);
-      gzOut.flush();
-    }
-    return bOut.toByteArray();
   }
 
   /**

--- a/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
@@ -117,7 +117,7 @@ public class ExecutionEnvironment {
       TestInfo testInfo) {
     try {
       String prefix = constructTestPrefix(zkTracer.getChain(), testInfo);
-      Path traceFilePath = Files.createTempFile(prefix, ".lt");
+      Path traceFilePath = Files.createTempFile(prefix, ".lt.gz");
       zkTracer.writeToFile(traceFilePath, startBlock, endBlock);
       final Path finalTraceFilePath = traceFilePath;
       logger.ifPresent(log -> log.debug("trace written to {}", finalTraceFilePath));

--- a/testing/src/main/java/net/consensys/linea/testing/ReplayExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ReplayExecutionEnvironment.java
@@ -106,7 +106,7 @@ public class ReplayExecutionEnvironment {
   public void checkTracer(String inputFilePath, long startBlock, long endBlock) {
     // Generate the output file path based on the input file path
     Path inputPath = Paths.get(inputFilePath);
-    String outputFileName = inputPath.getFileName().toString().replace(".json.gz", ".lt");
+    String outputFileName = inputPath.getFileName().toString().replace(".json.gz", ".lt.gz");
     Path outputPath = inputPath.getParent().resolve(outputFileName);
     this.zkTracer.writeToFile(outputPath, startBlock, endBlock);
     log.info("trace written to `{}`", outputPath);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces an in-memory LT trace writer with optional gzip compression (configurable via CLI/config), updates file extensions/paths and tests, and bumps go-corset.
> 
> - **Tracing/Serialization**:
>   - Implement in-memory LT trace writer `LtTraceFile` that builds columns/headers and streams to `OutputStream`.
>   - `ZkTracer.writeToFile()` now writes via `LtTraceFile` and uses `GZIPOutputStream` when filename ends with `.gz`; metadata construction refactored to `buildMetaData`.
>   - `TraceWriter` accepts `traceCompression` flag and chooses `.lt.gz`/`.lt` (and temp) extensions; updates path generation and temp write workflow.
> - **RPC/Config**:
>   - Extend `TracesEndpointConfiguration` and `TracesEndpointCliOptions` with `traceCompression` (default true) and plumb into `GenerateConflatedTracesV2`.
>   - Add logs indicating caching and compression settings.
> - **Tests**:
>   - Update test utilities to generate/expect compressed traces (`.lt.gz`).
> - **CI**:
>   - Bump go-corset to `v1.1.29` in GitHub Action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1270157558c9fc9045e47c357738384f4191ca4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->