### PR TITLE
Osaka reference tests debugging --- 2

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/precompiles/modexpMetadata/LondonModexpMetadata.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/precompiles/modexpMetadata/LondonModexpMetadata.java
@@ -50,4 +50,9 @@ public class LondonModexpMetadata extends ModexpMetadata {
   public boolean loadRawLeadingWord() {
     return callData().size() > BASE_MIN_OFFSET + bbsInt() && !ebs().isZero();
   }
+
+  @Override
+  public boolean allXbsesAreInBounds() {
+    return true;
+  }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/precompiles/modexpMetadata/ModexpMetadata.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/precompiles/modexpMetadata/ModexpMetadata.java
@@ -238,5 +238,7 @@ public abstract class ModexpMetadata {
     return false;
   }
 
+  public abstract boolean allXbsesAreInBounds();
+
   public abstract int getLeadLogByteMultiplier();
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/precompiles/modexpMetadata/OsakaModexpMetadata.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/precompiles/modexpMetadata/OsakaModexpMetadata.java
@@ -15,6 +15,7 @@
 package net.consensys.linea.zktracer.module.hub.precompiles.modexpMetadata;
 
 import static net.consensys.linea.zktracer.TraceOsaka.EIP_7823_MODEXP_UPPER_BYTE_SIZE_BOUND;
+import static net.consensys.linea.zktracer.module.hub.fragment.imc.oob.precompiles.modexp.ModexpXbsCase.*;
 
 import net.consensys.linea.zktracer.module.hub.fragment.imc.oob.precompiles.modexp.ModexpXbsCase;
 import net.consensys.linea.zktracer.types.MemoryRange;
@@ -60,5 +61,12 @@ public class OsakaModexpMetadata extends LondonModexpMetadata {
   @Override
   public boolean loadRawLeadingWord() {
     return callData().size() > BASE_MIN_OFFSET + normalizedBbsInt() && normalizedEbsInt() != 0;
+  }
+
+  @Override
+  public boolean allXbsesAreInBounds() {
+    return tracedIsWithinBounds(MODEXP_XBS_CASE_BBS)
+        && tracedIsWithinBounds(MODEXP_XBS_CASE_EBS)
+        && tracedIsWithinBounds(MODEXP_XBS_CASE_MBS);
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/LondonModexpSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/LondonModexpSubsection.java
@@ -107,10 +107,22 @@ public class LondonModexpSubsection extends PrecompileSubsection {
     }
     fourthImcFragment.callOob(getForkAppropriateModexpXbsOobCall(MODEXP_XBS_CASE_MBS));
 
-    /// leading exponent word extraction, analysis and exponent log computation
-    ///////////////////////////////////////////////////////////////////////////
+    /// we add the last two IMC fragments of the common core of MODEXP
+    //////////////////////////////////////////////////////////////////
     final ImcFragment fifthImcFragment = ImcFragment.empty(hub);
     fragments().add(fifthImcFragment);
+    final ImcFragment sixthImcFragment = ImcFragment.empty(hub);
+    fragments().add(sixthImcFragment);
+
+    /// the last two IMC fragments of the common core
+    /// can remain empty in Osaka if some xbs are out of bounds:
+    ////////////////////////////////////////////////////////////
+    if (!allXbsesAreInBounds()) return;
+
+    /// leading exponent word extraction,
+    /// analysis and exponent log computation
+    /////////////////////////////////////////
+
     fifthImcFragment.callOob(new ModexpLeadOobCall(modexpMetadata));
     if (modexpMetadata.loadRawLeadingWord()) {
       final MmuCall mmuCall = forModexpLoadLead(hub, this, modexpMetadata);
@@ -121,8 +133,7 @@ public class LondonModexpSubsection extends PrecompileSubsection {
 
     /// MODEXP pricing row
     //////////////////////
-    final ImcFragment sixthImcFragment = ImcFragment.empty(hub);
-    fragments().add(sixthImcFragment);
+
     // Note: we must compute the callee gas here as the eponymous PrecompileSubsection field gets
     // computed at traceContextEnter() which happens after the constructor invocation.
     final long calleeGas = callSection.stpCall.effectiveChildContextGasAllowance();
@@ -150,6 +161,8 @@ public class LondonModexpSubsection extends PrecompileSubsection {
       precompileScenarioFragment.scenario(PRC_FAILURE_KNOWN_TO_RAM);
       return;
     }
+
+    checkState(allXbsesAreInBounds(), "");
 
     modexpMetadata.rawResult(extractReturnData());
     hub.blakeModexpData().callModexp(getForkAppropriateBlakeModexpOperation());
@@ -207,6 +220,6 @@ public class LondonModexpSubsection extends PrecompileSubsection {
   }
 
   protected boolean allXbsesAreInBounds() {
-    return true;
+    return modexpMetadata.allXbsesAreInBounds();
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/LondonModexpSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/LondonModexpSubsection.java
@@ -162,7 +162,7 @@ public class LondonModexpSubsection extends PrecompileSubsection {
       return;
     }
 
-    checkState(allXbsesAreInBounds(), "");
+    checkState(allXbsesAreInBounds(), "MODEXP' callSucess requires that all XBS' be in bounds");
 
     modexpMetadata.rawResult(extractReturnData());
     hub.blakeModexpData().callModexp(getForkAppropriateBlakeModexpOperation());

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/OsakaModexpSubsection.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/OsakaModexpSubsection.java
@@ -55,11 +55,4 @@ public class OsakaModexpSubsection extends LondonModexpSubsection {
     return new OsakaBlakeModexpDataOperation(
         getForkAppropriateModexpMetadata(), exoModuleOperationId());
   }
-
-  @Override
-  protected boolean allXbsesAreInBounds() {
-    return modexpMetadata.tracedIsWithinBounds(MODEXP_XBS_CASE_BBS)
-        && modexpMetadata.tracedIsWithinBounds(MODEXP_XBS_CASE_EBS)
-        && modexpMetadata.tracedIsWithinBounds(MODEXP_XBS_CASE_MBS);
-  }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes XBS bounds validation in ModexpMetadata and updates MODEXP subsections to short-circuit and conditionally execute pricing/extraction based on bounds.
> 
> - **ModexpMetadata**:
>   - Add abstract `allXbsesAreInBounds()`; implement in `LondonModexpMetadata` (always true) and `OsakaModexpMetadata` (checks `BBS`, `EBS`, `MBS` via `tracedIsWithinBounds`).
> - **LondonModexpSubsection**:
>   - Pre-create 5th/6th IMC fragments and return early if `allXbsesAreInBounds()` is false.
>   - Gate lead-word load, EXP log, and pricing/extraction on metadata-driven bounds; add state check enforcing in-bounds on success.
>   - Delegate `allXbsesAreInBounds()` to `modexpMetadata`.
> - **OsakaModexpSubsection**:
>   - Remove local bounds logic; rely on metadata for XBS bounds and keep Osaka-specific operations unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bced50a3f16ca0e1f002744c48e5e7ba40939205. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->