### PR TITLE
chore: add osaka unit tests before releasing

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -107,6 +107,13 @@ jobs:
       zkevm_fork: PRAGUE
       tests-with-ssh: false
 
+  unit-tests-osaka:
+    needs: [ build ]
+    uses: ./.github/workflows/reusable-unit-tests.yml
+    with:
+      zkevm_fork: OSAKA
+      tests-with-ssh: false
+
   # ==================================================================
   # Fast Replay Tests
   # ==================================================================


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new `unit-tests-osaka` job to `.github/workflows/manual-release.yml` running reusable unit tests with `zkevm_fork: OSAKA`.
> 
> - **CI/CD**:
>   - Add `unit-tests-osaka` job in `.github/workflows/manual-release.yml`, invoking `./.github/workflows/reusable-unit-tests.yml` with `zkevm_fork: OSAKA` and `tests-with-ssh: false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 011a0533e66e9ff23c41539c0589b4087cbbcdbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->