### PR TITLE
Chore: Update Besu to 25.11.0-linea1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 releaseVersion=beta-v4.4-rc1
-besuVersion=25.11.0-RC1-linea2
+besuVersion=25.11.0-linea1
 shomeiVersion=2.4-develop
 besuShomeiPluginVersion=v0.8.2
 besuArtifactGroup=org.hyperledger.besu

--- a/reference-tests/src/test/java/net/consensys/linea/CorsetBlockProcessor.java
+++ b/reference-tests/src/test/java/net/consensys/linea/CorsetBlockProcessor.java
@@ -64,7 +64,8 @@ public class CorsetBlockProcessor extends MainnetBlockProcessor {
         blockReward,
         miningBeneficiaryCalculator,
         skipZeroBlockRewards,
-        protocolSchedule);
+        protocolSchedule,
+        BalConfiguration.DEFAULT);
     this.protocolSchedule = protocolSchedule;
     this.zkTracer = zkTracer;
   }
@@ -95,7 +96,8 @@ public class CorsetBlockProcessor extends MainnetBlockProcessor {
             worldState,
             protocolSpec,
             preExecutionProcessor.createBlockHashLookup(blockchain, blockHeader),
-            OperationTracer.NO_TRACING);
+            OperationTracer.NO_TRACING,
+            Optional.empty());
     preExecutionProcessor.process(blockProcessingContext, Optional.empty());
 
     for (final Transaction transaction : transactions) {
@@ -162,7 +164,8 @@ public class CorsetBlockProcessor extends MainnetBlockProcessor {
       try {
         maybeWithdrawalsProcessor
             .get()
-            .processWithdrawals(maybeWithdrawals.get(), worldState.updater(), Optional.empty());
+            .processWithdrawals(
+                maybeWithdrawals.get(), worldState.updater(), Optional.empty(), Optional.empty());
       } catch (final Exception e) {
         log.error("failed processing withdrawals", e);
         return new BlockProcessingResult(Optional.empty(), e);

--- a/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
@@ -50,6 +50,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.MiningConfiguration;
+import org.hyperledger.besu.ethereum.mainnet.BalConfiguration;
 import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSpecFactory;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
@@ -165,7 +166,7 @@ public class ExecutionEnvironment {
             MiningConfiguration.MINING_DISABLED,
             badBlockManager,
             false,
-            false,
+            BalConfiguration.DEFAULT,
             new NoOpMetricsSystem());
 
     final MainnetProtocolSpecFactory protocol =
@@ -176,7 +177,7 @@ public class ExecutionEnvironment {
             EvmConfiguration.DEFAULT,
             MiningConfiguration.MINING_DISABLED,
             false,
-            false,
+            BalConfiguration.DEFAULT,
             new NoOpMetricsSystem());
 
     final ProtocolSpecBuilder builder =

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionTools.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionTools.java
@@ -343,7 +343,8 @@ public class ToyExecutionTools {
               world,
               spec,
               preExecutionProcessor.createBlockHashLookup(blockchain, header),
-              tracer);
+              tracer,
+              Optional.empty());
       preExecutionProcessor.process(context, Optional.empty());
     }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade Besu to 25.11.0-linea1 and adapt code to new BAL and processing APIs.
> 
> - **Dependencies**:
>   - Bump `besuVersion` to `25.11.0-linea1` in `gradle.properties`.
> - **Core/Test Harness API updates**:
>   - Pass `BalConfiguration.DEFAULT` to `MainnetBlockProcessor` (via `CorsetBlockProcessor`), `CliqueProtocolSchedule.create`, and `MainnetProtocolSpecFactory`.
>   - Update `BlockProcessingContext` construction to include new `Optional.empty()` parameter in `CorsetBlockProcessor` and `ToyExecutionTools`.
>   - Adjust `WithdrawalsProcessor.processWithdrawals(...)` calls to include the new extra `Optional.empty()` argument.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e15f7790ccaa6d9c1a888b47ca6df37690cef962. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->