### PR TITLE
fix: unnecessary cast of block header

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Blockhash.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blockhash/Blockhash.java
@@ -99,7 +99,7 @@ public class Blockhash implements OperationSetModule<BlockhashOperation>, PostOp
     hub.defers().scheduleForPostExecution(this);
   }
 
-  public void callBlockhashForParent(BlockHeader blockHeader) {
+  public void callBlockhashForParent(ProcessableBlockHeader blockHeader) {
     final long blockNumber = blockHeader.getNumber();
     checkArgument(blockNumber > 0, "BLOCKHASH can't be called for genesis block");
     final Bytes32 parentBlockNumber = longToBytes32(blockNumber - 1);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/systemTransaction/EIP2935HistoricalHash.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/systemTransaction/EIP2935HistoricalHash.java
@@ -35,7 +35,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.worldstate.WorldView;
-import org.hyperledger.besu.plugin.data.BlockHeader;
 import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 
 public class EIP2935HistoricalHash extends TraceSection {
@@ -55,7 +54,7 @@ public class EIP2935HistoricalHash extends TraceSection {
     // Note: this is supposed to be useless in prod, as BLOCKHASH must have already loaded the
     // historical blockhashes
     if (!currentBlockIsGenesis) {
-      hub.blockhash().callBlockhashForParent((BlockHeader) blockHeader);
+      hub.blockhash().callBlockhashForParent(blockHeader);
     }
     final long previousBlockNumber = currentBlockIsGenesis ? 0 : blockNumber - 1;
     final short previousBlockNumberMod8191 = (short) (previousBlockNumber % HISTORY_SERVE_WINDOW);

--- a/arithmetization/src/test/java/net/consensys/linea/pragueReplayTests/BlockHashTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/pragueReplayTests/BlockHashTests.java
@@ -19,6 +19,7 @@ import static net.consensys.linea.zktracer.ChainConfig.SEPOLIA_PRAGUE_TESTCONFIG
 
 import net.consensys.linea.UnitTestWatcher;
 import net.consensys.linea.reporting.TracerTestBase;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -37,6 +38,7 @@ public class BlockHashTests extends TracerTestBase {
    * The purpose of this second replay tests is to provide two consecutive conflation to the prover,
    * with BLOCKHASH checking the "historical hashes" in both conflations.
    */
+  @Disabled
   @Test
   void conflationFollowingThePreviousOneWithAgainHistoricalBlockhashesChecked(TestInfo testInfo) {
     replay(SEPOLIA_PRAGUE_TESTCONFIG, "prague/19562399-19562417.sepolia.prague.json.gz", testInfo);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-releaseVersion=beta-v4.4-rc1
+releaseVersion=beta-v4.4-rc2
 besuVersion=25.11.0-linea1
 shomeiVersion=2.4-develop
 besuShomeiPluginVersion=v0.8.2


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use ProcessableBlockHeader for parent blockhash flow, updating caller, disable one replay test, and bump release version to rc2.
> 
> - **Blockhash**:
>   - Change `callBlockhashForParent` param from `BlockHeader` to `ProcessableBlockHeader` and adjust usage.
> - **System transaction (`EIP2935HistoricalHash`)**:
>   - Update call to `hub.blockhash().callBlockhashForParent(blockHeader)` with `ProcessableBlockHeader`.
> - **Tests**:
>   - Disable second replay test in `pragueReplayTests/BlockHashTests`.
> - **Release**:
>   - Bump `releaseVersion` in `gradle.properties` to `beta-v4.4-rc2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49babe44720c7b16fbdff56f82d15f18a110535a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->