### PR TITLE
Fix: suppressing the warning on lib publication

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -30,6 +30,11 @@ tasks.register('javadocJar', Jar) {
   from javadoc.destinationDir
 }
 
+tasks.withType(GenerateModuleMetadata).configureEach {
+    // We want to enforce the dependency on Besu BOM
+    suppressedValidationErrors.add('enforced-platform')
+}
+
 publishing {
   repositories {
     maven {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Suppresses Gradle module metadata `enforced-platform` warning to enforce Besu BOM during publication.
> 
> - **Build/Publishing**:
>   - Configure `GenerateModuleMetadata` to suppress `enforced-platform` validation, enforcing dependency on the Besu BOM in `gradle/publishing.gradle`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adf0b14901e1bc40fb0e02c8937a53e5720b1231. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->