### PR TITLE
`EIP-7883` --- MODEXP pricing tests

### DIFF
--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
@@ -52,13 +52,17 @@ public class ModexpEIP7883Tests extends TracerTestBase {
                   ebsItem -> {
                     List<String> leadingWords = new ArrayList<>();
                     final int minEbs32 = Math.min(ebsItem, 32);
-                    BigInteger leadingWord = new BigInteger("ff".repeat(minEbs32), 16);
+                    BigInteger leadingWord =
+                        minEbs32 > 0 ? new BigInteger("ff".repeat(minEbs32), 16) : BigInteger.ZERO;
                     for (int z = 0; z <= 8 * minEbs32; z++) {
-                      final String leadingWordAsHex = leadingWord.toString(16);
+                      final String leadingWordAsHex =
+                          leadingWord.signum() != 0 ? leadingWord.toString(16) : "";
                       final String leftPaddedLeadingWordAsHex =
                           "0".repeat(Math.max(0, 2 * minEbs32 - leadingWordAsHex.length()))
                               + leadingWordAsHex;
+
                       leadingWords.add(leftPaddedLeadingWordAsHex);
+
                       leadingWord = leadingWord.shiftRight(1);
                     }
                     return leadingWords;

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
@@ -14,10 +14,16 @@
  */
 package net.consensys.linea.zktracer.precompiles.modexp;
 
+import static net.consensys.linea.zktracer.types.Conversions.bytesToBoolean;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.math.BigInteger;
+import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -31,6 +37,7 @@ import org.apache.commons.math3.util.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -61,7 +68,8 @@ public class ModexpEIP7883Tests extends TracerTestBase {
                       final String leftPaddedLeadingWordAsHex =
                           "0".repeat(Math.max(0, 2 * minEbs32 - leadingWordAsHex.length()))
                               + leadingWordAsHex;
-                      Preconditions.checkArgument(leftPaddedLeadingWordAsHex.length() == 2 * minEbs32);
+                      Preconditions.checkArgument(
+                          leftPaddedLeadingWordAsHex.length() == 2 * minEbs32);
                       leadingWords.add(leftPaddedLeadingWordAsHex);
                       leadingWord = leadingWord.shiftRight(1);
                     }
@@ -80,6 +88,14 @@ public class ModexpEIP7883Tests extends TracerTestBase {
   @ParameterizedTest
   @MethodSource("modexpEIP7883TestSource")
   void modexpEIP7883Test(
+      int bbs, int ebs, int mbs, int cds, String exponentLeadingWord, TestInfo testInfo) {
+    modexpEIP7883TestBody(bbs, ebs, mbs, cds, exponentLeadingWord, testInfo);
+  }
+
+  @Tag("nightly")
+  @ParameterizedTest
+  @MethodSource("modexpEIP7883TestSourceNightly")
+  void modexpEIP7883TestNightly(
       int bbs, int ebs, int mbs, int cds, String exponentLeadingWord, TestInfo testInfo) {
     modexpEIP7883TestBody(bbs, ebs, mbs, cds, exponentLeadingWord, testInfo);
   }
@@ -131,13 +147,23 @@ public class ModexpEIP7883Tests extends TracerTestBase {
         .op(OpCode.RETURNDATASIZE)
         .op(OpCode.JUMPDEST, 32); // TODO: temporary workaround for go-corset issue
 
-    // TODO: do we want to add a RETURNDATACOPY?
-
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
     bytecodeRunner.run(List.of(codeOwnerAccount), chainConfig, testInfo);
+
+    final Bytes returnDataSize = bytecodeRunner.getHub().currentFrame().frame().getStackItem(0);
+    final Bytes callSuccess = bytecodeRunner.getHub().currentFrame().frame().getStackItem(1);
+    if (bytesToBoolean(callSuccess)) {
+      assertEquals(mbs, returnDataSize.toInt());
+    }
   }
 
   static Stream<Arguments> modexpEIP7883TestSource() {
+    List<Arguments> arguments = new ArrayList<>(modexpEIP7883TestSourceNightly().toList());
+    Collections.shuffle(arguments, new Random(LocalDate.now().toEpochDay()));
+    return arguments.stream().limit(arguments.size() / 40); // Execute 2.5 % of the tests
+  }
+
+  static Stream<Arguments> modexpEIP7883TestSourceNightly() {
     List<Arguments> arguments = new ArrayList<>();
     for (Pair<Integer, Integer> bbsMbs : bbsMbsPairOfValues) {
       Integer bbs = bbsMbs.getFirst();

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
@@ -134,7 +134,7 @@ public class ModexpEIP7883Tests extends TracerTestBase {
         .op(OpCode.JUMPDEST, 32); // TODO: temporary workaround for go-corset issue
 
     // TODO: do we want to add a RETURNDATACOPY?
-    
+
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
     bytecodeRunner.run(List.of(codeOwnerAccount), chainConfig, testInfo);
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
@@ -38,14 +38,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class ModexpEIP7883Tests extends TracerTestBase {
 
   // See https://github.com/Consensys/linea-tracer/issues/2496
-  static final List<Pair<Integer, Integer>> bbsMbsPairs =
+  static final List<Pair<Integer, Integer>> bbsMbsPairOfValues =
       List.of(Pair.create(0, 0), Pair.create(0, 3), Pair.create(21, 23), Pair.create(56, 55));
 
-  static final List<Integer> ebss = List.of(0, 1, 16, 27, 32, 39, 173);
+  static final List<Integer> ebsValues = List.of(0, 1, 16, 27, 32, 39, 173);
 
   // Pre-computed leading words for the exponent for each ebs value
   static final Map<Integer, List<String>> ebsToExponentLeadingWords =
-      ebss.stream()
+      ebsValues.stream()
           .collect(
               Collectors.toMap(
                   ebsItem -> ebsItem,
@@ -69,24 +69,36 @@ public class ModexpEIP7883Tests extends TracerTestBase {
                   }));
 
   // Support method to compute cds given bbs, ebs, mbs
-  static List<Integer> cdss(Integer bbs, Integer ebs, Integer mbs) {
-    List<Integer> cds = new ArrayList<>();
+  static List<Integer> cdsValues(Integer bbs, Integer ebs, Integer mbs) {
+    List<Integer> cdsValues = new ArrayList<>();
     for (Integer extra : ebs != 0 ? List.of(ebs / 2, ebs, ebs + mbs) : List.of(0, mbs)) {
-      cds.add(bbs + extra);
+      cdsValues.add(bbs + extra);
     }
-    return cds;
+    return cdsValues;
   }
 
   @ParameterizedTest
   @MethodSource("modexpEIP7883TestSource")
-  void modexpEIP7883Test(int bbs, int ebs, int mbs, int cds, String exponentLeadingWord) {
-    // TODO
-
+  void modexpEIP7883Test(
+      int bbs, int ebs, int mbs, int cds, String exponentLeadingWord, TestInfo testInfo) {
+    modexpEIP7883TestBody(bbs, ebs, mbs, cds, exponentLeadingWord, testInfo);
   }
 
   private void modexpEIP7883TestBody(
       int bbs, int ebs, int mbs, int cds, String exponentLeadingWord, TestInfo testInfo) {
-    final Bytes input = Bytes.fromHexString("...");
+    final String bbsHex = String.format("%064x", bbs);
+    final String ebsHex = String.format("%064x", ebs);
+    final String mbsHex = String.format("%064x", mbs);
+
+    final Bytes input =
+        Bytes.fromHexString(
+            bbsHex
+                + ebsHex
+                + mbsHex
+                + "00".repeat(bbs)
+                + exponentLeadingWord
+                + "00".repeat(Math.max(0, ebs - Math.min(ebs, 32)))
+                + "00".repeat(mbs));
 
     BytecodeCompiler program = BytecodeCompiler.newProgram(chainConfig);
 
@@ -113,7 +125,7 @@ public class ModexpEIP7883Tests extends TracerTestBase {
     program
         .push(mbs) // retSize
         .push(input.size()) // retOffset
-        .push(input.size()) // argSize
+        .push(cds) // argSize
         .push(0) // argOffset
         .push(Address.MODEXP) // address
         .push(Bytes.fromHexStringLenient("0xFFFFFFFF")) // gas
@@ -127,15 +139,15 @@ public class ModexpEIP7883Tests extends TracerTestBase {
 
   static Stream<Arguments> modexpEIP7883TestSource() {
     List<Arguments> arguments = new ArrayList<>();
-    for (Pair<Integer, Integer> bbsMbs : bbsMbsPairs) {
+    for (Pair<Integer, Integer> bbsMbs : bbsMbsPairOfValues) {
       Integer bbs = bbsMbs.getFirst();
       Integer mbs = bbsMbs.getSecond();
-      for (Integer ebs : ebss) {
-        List<Integer> cdss = cdss(bbs, ebs, mbs);
-        List<String> exponentLeadsForEbs = ebsToExponentLeadingWords.get(ebs);
-        for (Integer cds : cdss) {
-          for (String exponentLeadForEbs : exponentLeadsForEbs) {
-            arguments.add(Arguments.of(bbs, ebs, mbs, cds, exponentLeadForEbs));
+      for (Integer ebs : ebsValues) {
+        List<Integer> cdsValues = cdsValues(bbs, ebs, mbs);
+        List<String> exponentLeadingWordsForEbs = ebsToExponentLeadingWords.get(ebs);
+        for (Integer cds : cdsValues) {
+          for (String exponentLeadingWordForEbs : exponentLeadingWordsForEbs) {
+            arguments.add(Arguments.of(bbs, ebs, mbs, cds, exponentLeadingWordForEbs));
           }
         }
       }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
@@ -19,10 +19,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import net.consensys.linea.reporting.TracerTestBase;
 import org.apache.commons.math3.util.Pair;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ModexpEIP7883Tests extends TracerTestBase {
 
@@ -30,26 +34,25 @@ public class ModexpEIP7883Tests extends TracerTestBase {
   static final List<Pair<Integer, Integer>> bbsMbsPairs =
       List.of(Pair.create(0, 0), Pair.create(0, 3), Pair.create(21, 23), Pair.create(56, 55));
 
-  static final List<Integer> ebs = List.of(0, 1, 16, 27, 32, 39, 173);
+  static final List<Integer> ebss = List.of(0, 1, 16, 27, 32, 39, 173);
 
   // Pre-computed exponents for each ebs value
-  static final Map<Integer, List<BigInteger>> exponents =
-      ebs.stream()
+  static final Map<Integer, List<String>> exponentLeads =
+      ebss.stream()
           .collect(
               Collectors.toMap(
                   ebsItem -> ebsItem,
                   ebsItem -> {
                     final int minEbs32 = Math.min(ebsItem, 32);
-                    List<BigInteger> exponents = new ArrayList<>();
+                    List<String> exponents = new ArrayList<>();
                     for (int z = 0; z <= 8 * minEbs32; z++) {
-                      final String exponent = "0".repeat(8 * minEbs32 - z) + "1".repeat(z);
-                      exponents.add(new BigInteger(exponent, 2));
+                      exponents.add("0".repeat(8 * minEbs32 - z) + "1".repeat(z));
                     }
                     return exponents;
                   }));
 
   // Support method to compute cds given bbs, ebs, mbs
-  static List<Integer> cds(Integer bbs, Integer ebs, Integer mbs) {
+  static List<Integer> cdss(Integer bbs, Integer ebs, Integer mbs) {
     List<Integer> cds = new ArrayList<>();
     for (Integer extra : List.of(ebs / 2, ebs, ebs + mbs)) {
       cds.add(bbs + extra);
@@ -57,7 +60,28 @@ public class ModexpEIP7883Tests extends TracerTestBase {
     return cds;
   }
 
-  // TODO: tests
-  @Test
-  void test() {}
+  @ParameterizedTest
+  @MethodSource("modexpEIP7883TestSource")
+  void modexpEIP7883Test(int bbs, int ebs, int mbs, int cds, String exponentLead) {
+    // TODO
+
+  }
+
+  static Stream<Arguments> modexpEIP7883TestSource() {
+    List<Arguments> arguments = new ArrayList<>();
+    for (Pair<Integer, Integer> bbsMbs : bbsMbsPairs) {
+      Integer bbs = bbsMbs.getFirst();
+      Integer mbs = bbsMbs.getSecond();
+      for (Integer ebs : ebss) {
+        List<Integer> cdss = cdss(bbs, ebs, mbs);
+        List<String> exponentLeadsForEbs = exponentLeads.get(ebs);
+          for (Integer cds : cdss) {
+            for (String exponentLeadForEbs : exponentLeadsForEbs) {
+            arguments.add(Arguments.of(bbs, ebs, mbs, cds, exponentLeadForEbs));
+          }
+        }
+      }
+    }
+    return arguments.stream();
+  }
 }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package net.consensys.linea.zktracer.precompiles.modexp;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import net.consensys.linea.reporting.TracerTestBase;
+import org.apache.commons.math3.util.Pair;
+import org.junit.jupiter.api.Test;
+
+public class ModexpEIP7883Tests extends TracerTestBase {
+
+  // See https://github.com/Consensys/linea-tracer/issues/2496
+  static final List<Pair<Integer, Integer>> bbsMbsPairs =
+      List.of(Pair.create(0, 0), Pair.create(0, 3), Pair.create(21, 23), Pair.create(56, 55));
+
+  static final List<Integer> ebs = List.of(0, 1, 16, 27, 32, 39, 173);
+
+  // Pre-computed exponents for each ebs value
+  static final Map<Integer, List<BigInteger>> exponents =
+      ebs.stream()
+          .collect(
+              Collectors.toMap(
+                  ebsItem -> ebsItem,
+                  ebsItem -> {
+                    final int minEbs32 = Math.min(ebsItem, 32);
+                    List<BigInteger> exponents = new ArrayList<>();
+                    for (int z = 0; z <= 8 * minEbs32; z++) {
+                      final String exponent = "0".repeat(8 * minEbs32 - z) + "1".repeat(z);
+                      exponents.add(new BigInteger(exponent, 2));
+                    }
+                    return exponents;
+                  }));
+
+  // Support method to compute cds given bbs, ebs, mbs
+  static List<Integer> cds(Integer bbs, Integer ebs, Integer mbs) {
+    List<Integer> cds = new ArrayList<>();
+    for (Integer extra : List.of(ebs / 2, ebs, ebs + mbs)) {
+      cds.add(bbs + extra);
+    }
+    return cds;
+  }
+
+  // TODO: tests
+  @Test
+  void test() {}
+}

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
@@ -14,7 +14,8 @@
  */
 package net.consensys.linea.zktracer.precompiles.modexp;
 
-import java.math.BigInteger;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,8 +23,15 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import net.consensys.linea.reporting.TracerTestBase;
+import net.consensys.linea.testing.BytecodeCompiler;
+import net.consensys.linea.testing.BytecodeRunner;
+import net.consensys.linea.testing.ToyAccount;
+import net.consensys.linea.zktracer.opcode.OpCode;
 import org.apache.commons.math3.util.Pair;
-import org.junit.jupiter.api.Test;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Wei;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -37,18 +45,18 @@ public class ModexpEIP7883Tests extends TracerTestBase {
   static final List<Integer> ebss = List.of(0, 1, 16, 27, 32, 39, 173);
 
   // Pre-computed exponents for each ebs value
-  static final Map<Integer, List<String>> exponentLeads =
+  static final Map<Integer, List<String>> ebsToExponentLeadingWords =
       ebss.stream()
           .collect(
               Collectors.toMap(
                   ebsItem -> ebsItem,
                   ebsItem -> {
                     final int minEbs32 = Math.min(ebsItem, 32);
-                    List<String> exponents = new ArrayList<>();
+                    List<String> exponentLeadingWords = new ArrayList<>();
                     for (int z = 0; z <= 8 * minEbs32; z++) {
-                      exponents.add("0".repeat(8 * minEbs32 - z) + "1".repeat(z));
+                      exponentLeadingWords.add("0".repeat(8 * minEbs32 - z) + "1".repeat(z));
                     }
-                    return exponents;
+                    return exponentLeadingWords;
                   }));
 
   // Support method to compute cds given bbs, ebs, mbs
@@ -62,9 +70,49 @@ public class ModexpEIP7883Tests extends TracerTestBase {
 
   @ParameterizedTest
   @MethodSource("modexpEIP7883TestSource")
-  void modexpEIP7883Test(int bbs, int ebs, int mbs, int cds, String exponentLead) {
+  void modexpEIP7883Test(int bbs, int ebs, int mbs, int cds, String exponentLeadingWord) {
     // TODO
 
+  }
+
+  private void modexpEIP7883TestBody(int bbs, int ebs, int mbs, int cds, String exponentLeadingWord, TestInfo testInfo) {
+    final Bytes input = Bytes.fromHexString("...");
+
+    BytecodeCompiler program = BytecodeCompiler.newProgram(chainConfig);
+
+    final Address codeOwnerAddress = Address.fromHexString("0xC0DE");
+    final ToyAccount codeOwnerAccount =
+      ToyAccount.builder()
+        .balance(Wei.of(0))
+        .nonce(1)
+        .address(codeOwnerAddress)
+        .code(input)
+        .build();
+
+    // First place the parameters in memory
+    // Copy to targetOffset the code of codeOwnerAccount
+    program
+      .push(codeOwnerAddress)
+      .op(OpCode.EXTCODESIZE) // size
+      .push(0) // offset
+      .push(0) // targetOffset
+      .push(codeOwnerAddress) // address
+      .op(OpCode.EXTCODECOPY);
+
+    // Do the call
+    program
+      .push(mbs) // retSize
+      .push(input.size()) // retOffset
+      .push(input.size()) // argSize
+      .push(0) // argOffset
+      .push(Address.MODEXP) // address
+      .push(Bytes.fromHexStringLenient("0xFFFFFFFF")) // gas
+      .op(OpCode.STATICCALL)
+      .op(OpCode.RETURNDATASIZE)
+      .op(OpCode.JUMPDEST, 32);
+
+    BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
+    bytecodeRunner.run(List.of(codeOwnerAccount), chainConfig, testInfo);
   }
 
   static Stream<Arguments> modexpEIP7883TestSource() {
@@ -74,7 +122,7 @@ public class ModexpEIP7883Tests extends TracerTestBase {
       Integer mbs = bbsMbs.getSecond();
       for (Integer ebs : ebss) {
         List<Integer> cdss = cdss(bbs, ebs, mbs);
-        List<String> exponentLeadsForEbs = exponentLeads.get(ebs);
+        List<String> exponentLeadsForEbs = ebsToExponentLeadingWords.get(ebs);
           for (Integer cds : cdss) {
             for (String exponentLeadForEbs : exponentLeadsForEbs) {
             arguments.add(Arguments.of(bbs, ebs, mbs, cds, exponentLeadForEbs));

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.base.Preconditions;
 import net.consensys.linea.reporting.TracerTestBase;
 import net.consensys.linea.testing.BytecodeCompiler;
 import net.consensys.linea.testing.BytecodeRunner;
@@ -60,9 +61,8 @@ public class ModexpEIP7883Tests extends TracerTestBase {
                       final String leftPaddedLeadingWordAsHex =
                           "0".repeat(Math.max(0, 2 * minEbs32 - leadingWordAsHex.length()))
                               + leadingWordAsHex;
-
+                      Preconditions.checkArgument(leftPaddedLeadingWordAsHex.length() == 2 * minEbs32);
                       leadingWords.add(leftPaddedLeadingWordAsHex);
-
                       leadingWord = leadingWord.shiftRight(1);
                     }
                     return leadingWords;
@@ -72,7 +72,7 @@ public class ModexpEIP7883Tests extends TracerTestBase {
   static List<Integer> cdsValues(Integer bbs, Integer ebs, Integer mbs) {
     List<Integer> cdsValues = new ArrayList<>();
     for (Integer extra : ebs != 0 ? List.of(ebs / 2, ebs, ebs + mbs) : List.of(0, mbs)) {
-      cdsValues.add(bbs + extra);
+      cdsValues.add(96 + bbs + extra);
     }
     return cdsValues;
   }
@@ -96,35 +96,33 @@ public class ModexpEIP7883Tests extends TracerTestBase {
                 + ebsHex
                 + mbsHex
                 + "00".repeat(bbs)
-                + exponentLeadingWord
-                + "00".repeat(Math.max(0, ebs - Math.min(ebs, 32)))
-                + "00".repeat(mbs));
+                + exponentLeadingWord); // Then the right cds implicitly adds the right padding
 
     BytecodeCompiler program = BytecodeCompiler.newProgram(chainConfig);
 
-    final Address codeOwnerAddress = Address.fromHexString("0xC0DE");
+    final Address callDataAsBytecodeAddress = Address.fromHexString("0xC0DE");
     final ToyAccount codeOwnerAccount =
         ToyAccount.builder()
             .balance(Wei.of(0))
             .nonce(1)
-            .address(codeOwnerAddress)
+            .address(callDataAsBytecodeAddress)
             .code(input)
             .build();
 
     // First place the parameters in memory
     // Copy to targetOffset the code of codeOwnerAccount
     program
-        .push(codeOwnerAddress)
+        .push(callDataAsBytecodeAddress)
         .op(OpCode.EXTCODESIZE) // size
         .push(0) // offset
         .push(0) // targetOffset
-        .push(codeOwnerAddress) // address
+        .push(callDataAsBytecodeAddress) // address
         .op(OpCode.EXTCODECOPY);
 
     // Do the call
     program
         .push(mbs) // retSize
-        .push(input.size()) // retOffset
+        .push(cds) // retOffset
         .push(cds) // argSize
         .push(0) // argOffset
         .push(Address.MODEXP) // address

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
@@ -131,8 +131,10 @@ public class ModexpEIP7883Tests extends TracerTestBase {
         .push(Bytes.fromHexStringLenient("0xFFFFFFFF")) // gas
         .op(OpCode.STATICCALL)
         .op(OpCode.RETURNDATASIZE)
-        .op(OpCode.JUMPDEST, 32);
+        .op(OpCode.JUMPDEST, 32); // TODO: temporary workaround for go-corset issue
 
+    // TODO: do we want to add a RETURNDATACOPY?
+    
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
     bytecodeRunner.run(List.of(codeOwnerAccount), chainConfig, testInfo);
   }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpEIP7883Tests.java
@@ -14,8 +14,7 @@
  */
 package net.consensys.linea.zktracer.precompiles.modexp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -44,25 +43,31 @@ public class ModexpEIP7883Tests extends TracerTestBase {
 
   static final List<Integer> ebss = List.of(0, 1, 16, 27, 32, 39, 173);
 
-  // Pre-computed exponents for each ebs value
+  // Pre-computed leading words for the exponent for each ebs value
   static final Map<Integer, List<String>> ebsToExponentLeadingWords =
       ebss.stream()
           .collect(
               Collectors.toMap(
                   ebsItem -> ebsItem,
                   ebsItem -> {
+                    List<String> leadingWords = new ArrayList<>();
                     final int minEbs32 = Math.min(ebsItem, 32);
-                    List<String> exponentLeadingWords = new ArrayList<>();
+                    BigInteger leadingWord = new BigInteger("ff".repeat(minEbs32), 16);
                     for (int z = 0; z <= 8 * minEbs32; z++) {
-                      exponentLeadingWords.add("0".repeat(8 * minEbs32 - z) + "1".repeat(z));
+                      final String leadingWordAsHex = leadingWord.toString(16);
+                      final String leftPaddedLeadingWordAsHex =
+                          "0".repeat(Math.max(0, 2 * minEbs32 - leadingWordAsHex.length()))
+                              + leadingWordAsHex;
+                      leadingWords.add(leftPaddedLeadingWordAsHex);
+                      leadingWord = leadingWord.shiftRight(1);
                     }
-                    return exponentLeadingWords;
+                    return leadingWords;
                   }));
 
   // Support method to compute cds given bbs, ebs, mbs
   static List<Integer> cdss(Integer bbs, Integer ebs, Integer mbs) {
     List<Integer> cds = new ArrayList<>();
-    for (Integer extra : List.of(ebs / 2, ebs, ebs + mbs)) {
+    for (Integer extra : ebs != 0 ? List.of(ebs / 2, ebs, ebs + mbs) : List.of(0, mbs)) {
       cds.add(bbs + extra);
     }
     return cds;
@@ -75,41 +80,42 @@ public class ModexpEIP7883Tests extends TracerTestBase {
 
   }
 
-  private void modexpEIP7883TestBody(int bbs, int ebs, int mbs, int cds, String exponentLeadingWord, TestInfo testInfo) {
+  private void modexpEIP7883TestBody(
+      int bbs, int ebs, int mbs, int cds, String exponentLeadingWord, TestInfo testInfo) {
     final Bytes input = Bytes.fromHexString("...");
 
     BytecodeCompiler program = BytecodeCompiler.newProgram(chainConfig);
 
     final Address codeOwnerAddress = Address.fromHexString("0xC0DE");
     final ToyAccount codeOwnerAccount =
-      ToyAccount.builder()
-        .balance(Wei.of(0))
-        .nonce(1)
-        .address(codeOwnerAddress)
-        .code(input)
-        .build();
+        ToyAccount.builder()
+            .balance(Wei.of(0))
+            .nonce(1)
+            .address(codeOwnerAddress)
+            .code(input)
+            .build();
 
     // First place the parameters in memory
     // Copy to targetOffset the code of codeOwnerAccount
     program
-      .push(codeOwnerAddress)
-      .op(OpCode.EXTCODESIZE) // size
-      .push(0) // offset
-      .push(0) // targetOffset
-      .push(codeOwnerAddress) // address
-      .op(OpCode.EXTCODECOPY);
+        .push(codeOwnerAddress)
+        .op(OpCode.EXTCODESIZE) // size
+        .push(0) // offset
+        .push(0) // targetOffset
+        .push(codeOwnerAddress) // address
+        .op(OpCode.EXTCODECOPY);
 
     // Do the call
     program
-      .push(mbs) // retSize
-      .push(input.size()) // retOffset
-      .push(input.size()) // argSize
-      .push(0) // argOffset
-      .push(Address.MODEXP) // address
-      .push(Bytes.fromHexStringLenient("0xFFFFFFFF")) // gas
-      .op(OpCode.STATICCALL)
-      .op(OpCode.RETURNDATASIZE)
-      .op(OpCode.JUMPDEST, 32);
+        .push(mbs) // retSize
+        .push(input.size()) // retOffset
+        .push(input.size()) // argSize
+        .push(0) // argOffset
+        .push(Address.MODEXP) // address
+        .push(Bytes.fromHexStringLenient("0xFFFFFFFF")) // gas
+        .op(OpCode.STATICCALL)
+        .op(OpCode.RETURNDATASIZE)
+        .op(OpCode.JUMPDEST, 32);
 
     BytecodeRunner bytecodeRunner = BytecodeRunner.of(program.compile());
     bytecodeRunner.run(List.of(codeOwnerAccount), chainConfig, testInfo);
@@ -123,8 +129,8 @@ public class ModexpEIP7883Tests extends TracerTestBase {
       for (Integer ebs : ebss) {
         List<Integer> cdss = cdss(bbs, ebs, mbs);
         List<String> exponentLeadsForEbs = ebsToExponentLeadingWords.get(ebs);
-          for (Integer cds : cdss) {
-            for (String exponentLeadForEbs : exponentLeadsForEbs) {
+        for (Integer cds : cdss) {
+          for (String exponentLeadForEbs : exponentLeadsForEbs) {
             arguments.add(Arguments.of(bbs, ebs, mbs, cds, exponentLeadForEbs));
           }
         }

--- a/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpTests.java
+++ b/arithmetization/src/test/java/net/consensys/linea/zktracer/precompiles/modexp/ModexpTests.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package net.consensys.linea.zktracer.precompiles;
+package net.consensys.linea.zktracer.precompiles.modexp;
 
 import static net.consensys.linea.zktracer.Fork.forkPredatesOsaka;
 import static net.consensys.linea.zktracer.Trace.WORD_SIZE;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add parameterized EIP‑7883 MODEXP tests (with nightly full matrix) and move existing Modexp tests into the modexp package.
> 
> - **Tests**:
>   - **EIP‑7883 MODEXP**: Add `ModexpEIP7883Tests` with parameterized/nightly matrices generating calldata permutations (`bbs`, `ebs`, `mbs`, `cds`, exponent leading words), invoking `STATICCALL` to `Address.MODEXP` and asserting return size on success.
>   - **Refactor**: Move `ModexpTests` into `net.consensys.linea.zktracer.precompiles.modexp` package.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6103d0baa0384cfb5283a32c75ae3efdeff0d9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->