### PR TITLE
Chore: Update Besu and Shomei plugin

### DIFF
--- a/arithmetization/build.gradle
+++ b/arithmetization/build.gradle
@@ -32,7 +32,6 @@ apply from: rootProject.file("gradle/check-licenses.gradle")
 apply from: rootProject.file("gradle/lint.gradle")
 
 dependencies {
-  implementation 'org.hyperledger.besu:gnark:1.4.1-SNAPSHOT'
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   testImplementation project(':testing')
   testImplementation 'org.assertj:assertj-core'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 releaseVersion=beta-v4.4-rc4
-besuVersion=25.11.0-linea2
+besuVersion=25.11.0-linea3
 shomeiVersion=2.4-develop
-besuShomeiPluginVersion=v0.8.2
+besuShomeiPluginVersion=v0.8.4
 besuRepo=https://artifacts.consensys.net/public/linea-besu/maven/
 distributionIdentifier=linea-tracer
 besuShomeiPluginBaseUrl=https://github.com/Consensys/besu-shomei-plugin/releases/download/

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -154,7 +154,7 @@ tasks.withType(Test).configureEach {
 
 tasks.test.configure {
   // Following required as some unit tests run BESU checks
-  dependsOn("copyTracerPlugin", "downloadShomeiBesuPlugin")
+  dependsOn("copyTracerPlugin", "extractShomeiBesuPlugin")
   //
   useJUnitPlatform {
     excludeTags("nightly | replay | weekly")
@@ -212,7 +212,7 @@ tasks.register("prcCallTests", Test) {
 // =============================================================================
 
 tasks.register("besuNodeTests", Test) {
-  dependsOn("copyTracerPlugin", "downloadShomeiBesuPlugin")
+  dependsOn("copyTracerPlugin", "extractShomeiBesuPlugin")
   //
   forkEvery = 1
   maxParallelForks = 3
@@ -228,7 +228,7 @@ tasks.register("besuNodeTests", Test) {
 }
 
 tasks.register("besuNodeFastReplayTests", Test) {
-  dependsOn("copyTracerPlugin", "downloadShomeiBesuPlugin")
+  dependsOn("copyTracerPlugin", "extractShomeiBesuPlugin")
   //
   forkEvery = 1
   maxParallelForks = 3
@@ -316,9 +316,21 @@ tasks.register("copyTracerPlugin", Copy) {
 }
 
 tasks.register("downloadShomeiBesuPlugin", Download) {
-  src "${besuShomeiPluginBaseUrl}${besuShomeiPluginVersion}/besu-shomei-plugin-${besuShomeiPluginVersion}.jar"
-  dest "${System.getProperty("besu.plugins.dir")}"
+  src "${besuShomeiPluginBaseUrl}${besuShomeiPluginVersion}/besu-shomei-plugin-${besuShomeiPluginVersion}.zip"
+  dest project.buildDir
   overwrite false
+}
+
+tasks.register("extractShomeiBesuPlugin", Copy) {
+    dependsOn "downloadShomeiBesuPlugin"
+    //
+    from zipTree("${project.buildDir}/besu-shomei-plugin-${besuShomeiPluginVersion}.zip")
+    into "${System.getProperty("besu.plugins.dir")}"
+    eachFile { fcp ->
+        fcp.relativePath = new RelativePath(true, fcp.file.name)
+    }
+    includeEmptyDirs = false
+    duplicatesStrategy = DuplicatesStrategy.FAIL
 }
 
 

--- a/reference-tests/build.gradle
+++ b/reference-tests/build.gradle
@@ -101,7 +101,6 @@ tasks.register("jacocoReferenceExecutionSpecBlockchainTestsReport", JacocoReport
 dependencies {
   implementation project(':arithmetization')
   implementation project(':testing')
-  implementation "org.hyperledger.besu:gnark:1.4.1-SNAPSHOT"
   implementation 'org.junit.platform:junit-platform-launcher'
 
   testImplementation 'org.assertj:assertj-core'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adapt tests to Shomei plugin ZIP distribution, bump Besu/Shomei versions, and remove gnark dependency.
> 
> - **Build/Test infrastructure**:
>   - Switch Shomei plugin handling from JAR to ZIP: add `extractShomeiBesuPlugin` task and update `downloadShomeiBesuPlugin` to fetch ZIP to `build/`; adjust test tasks (`tasks.test`, `besuNodeTests`, `besuNodeFastReplayTests`) to depend on `extractShomeiBesuPlugin`.
>   - Ensure plugin ZIP contents are unpacked into `besu.plugins.dir` with flattened paths in `gradle/tests.gradle`.
> - **Version bumps**:
>   - Update `besuVersion` to `25.11.0-linea3` and `besuShomeiPluginVersion` to `v0.8.4` in `gradle.properties`.
> - **Dependencies**:
>   - Remove `org.hyperledger.besu:gnark` implementation from `arithmetization/build.gradle` and `reference-tests/build.gradle`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c65823add34d110b8fc739b0f06aefc2aeac18e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->