### PR TITLE
fix: line counting for BLOCKHASH from RPC calls

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaTracerSharedCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaTracerSharedCliOptions.java
@@ -41,7 +41,7 @@ public class LineaTracerSharedCliOptions implements LineaCliOptions {
       hidden = true,
       paramLabel = "<BOOLEAN>",
       description =
-          "If the sequencer needs to use or not the limitless prover (default: ${DEFAULT-VALUE})")
+          "If the sequencer/coordinator needs to count the lines from historical blockhashes (default: ${DEFAULT-VALUE})")
   private boolean countHistoricalBlockHashes = DEFAULT_COUNT_HISTORICAL_BLOCKHASHES_ENABLED;
 
   private LineaTracerSharedCliOptions() {}

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaTracerSharedCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaTracerSharedCliOptions.java
@@ -23,7 +23,10 @@ public class LineaTracerSharedCliOptions implements LineaCliOptions {
   public static final String CONFIG_KEY = "tracer-shared-config";
 
   public static final String LIMITLESS_ENABLED = "--plugin-linea-limitless-enabled";
+  public static final String COUNT_HISTORICAL_BLOCKHASHES_ENABLED =
+      "--plugin-linea-count-historical-blockhash-enabled";
   public static final boolean DEFAULT_LIMITLESS_ENABLED = false;
+  public static final boolean DEFAULT_COUNT_HISTORICAL_BLOCKHASHES_ENABLED = true;
 
   @CommandLine.Option(
       names = {LIMITLESS_ENABLED},
@@ -32,6 +35,14 @@ public class LineaTracerSharedCliOptions implements LineaCliOptions {
       description =
           "If the sequencer needs to use or not the limitless prover (default: ${DEFAULT-VALUE})")
   private boolean limitlessEnabled = DEFAULT_LIMITLESS_ENABLED;
+
+  @CommandLine.Option(
+      names = {COUNT_HISTORICAL_BLOCKHASHES_ENABLED},
+      hidden = true,
+      paramLabel = "<BOOLEAN>",
+      description =
+          "If the sequencer needs to use or not the limitless prover (default: ${DEFAULT-VALUE})")
+  private boolean countHistoricalBlockHashes = DEFAULT_COUNT_HISTORICAL_BLOCKHASHES_ENABLED;
 
   private LineaTracerSharedCliOptions() {}
 
@@ -54,6 +65,7 @@ public class LineaTracerSharedCliOptions implements LineaCliOptions {
       final LineaTracerSharedConfiguration config) {
     final LineaTracerSharedCliOptions options = create();
     options.limitlessEnabled = config.isLimitless();
+    options.countHistoricalBlockHashes = config.countHistoricalBlockHashes();
     return options;
   }
 
@@ -64,11 +76,17 @@ public class LineaTracerSharedCliOptions implements LineaCliOptions {
    */
   @Override
   public LineaTracerSharedConfiguration toDomainObject() {
-    return LineaTracerSharedConfiguration.builder().isLimitless(limitlessEnabled).build();
+    return LineaTracerSharedConfiguration.builder()
+        .isLimitless(limitlessEnabled)
+        .countHistoricalBlockHashes(countHistoricalBlockHashes)
+        .build();
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add(LIMITLESS_ENABLED, limitlessEnabled).toString();
+    return MoreObjects.toStringHelper(this)
+        .add(LIMITLESS_ENABLED, limitlessEnabled)
+        .add(COUNT_HISTORICAL_BLOCKHASHES_ENABLED, countHistoricalBlockHashes)
+        .toString();
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaTracerSharedConfiguration.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaTracerSharedConfiguration.java
@@ -20,5 +20,5 @@ import net.consensys.linea.plugins.LineaOptionsConfiguration;
 
 /** The Linea tracer shared configuration. */
 @Builder(toBuilder = true)
-public record LineaTracerSharedConfiguration(boolean isLimitless)
-    implements LineaOptionsConfiguration {}
+public record LineaTracerSharedConfiguration(
+    boolean isLimitless, boolean countHistoricalBlockHashes) implements LineaOptionsConfiguration {}

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/LineCounterGenerator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/LineCounterGenerator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright ConsenSys Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package net.consensys.linea.plugins.rpc;
+
+import static net.consensys.linea.zktracer.Fork.getForkFromBesuBlockchainService;
+import static net.consensys.linea.zktracer.types.PublicInputs.generatePublicInputs;
+
+import java.math.BigInteger;
+
+import net.consensys.linea.plugins.BesuServiceProvider;
+import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
+import net.consensys.linea.plugins.config.LineaTracerSharedConfiguration;
+import net.consensys.linea.zktracer.Fork;
+import net.consensys.linea.zktracer.LineCountingTracer;
+import net.consensys.linea.zktracer.ZkCounter;
+import net.consensys.linea.zktracer.ZkTracer;
+import net.consensys.linea.zktracer.types.PublicInputs;
+import org.hyperledger.besu.plugin.ServiceManager;
+import org.hyperledger.besu.plugin.services.BlockchainService;
+
+public class LineCounterGenerator {
+
+  public static LineCountingTracer createLineCountingTracer(
+      ServiceManager besuContext,
+      LineaTracerSharedConfiguration tracerSharedConfiguration,
+      LineaL1L2BridgeSharedConfiguration l1L2BridgeSharedConfiguration,
+      long fromBlock,
+      long toBlock) {
+    final BlockchainService blockchainService =
+        BesuServiceProvider.getBesuService(besuContext, BlockchainService.class);
+    final Fork fork = getForkFromBesuBlockchainService(blockchainService, fromBlock, toBlock);
+
+    if (tracerSharedConfiguration.isLimitless()) {
+      return new ZkCounter(
+          l1L2BridgeSharedConfiguration,
+          fork,
+          tracerSharedConfiguration.countHistoricalBlockHashes());
+    } else {
+      final BigInteger chainId =
+          blockchainService
+              .getChainId()
+              .orElseThrow(() -> new IllegalStateException("ChainId must be provided"));
+      if (tracerSharedConfiguration.countHistoricalBlockHashes()) {
+        final PublicInputs publicInputs =
+            generatePublicInputs(blockchainService, fromBlock, toBlock);
+        return new ZkTracer(fork, l1L2BridgeSharedConfiguration, chainId, publicInputs);
+      } else {
+        return new ZkTracer(fork, l1L2BridgeSharedConfiguration, chainId);
+      }
+    }
+  }
+}

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/batchlinecount/ConflatedCountTracesV2.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/batchlinecount/ConflatedCountTracesV2.java
@@ -16,7 +16,9 @@
 package net.consensys.linea.plugins.rpc.batchlinecount;
 
 import static net.consensys.linea.zktracer.Fork.getForkFromBesuBlockchainService;
+import static net.consensys.linea.zktracer.types.PublicInputs.generatePublicInputs;
 
+import java.math.BigInteger;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -35,6 +37,7 @@ import net.consensys.linea.zktracer.LineCountingTracer;
 import net.consensys.linea.zktracer.ZkCounter;
 import net.consensys.linea.zktracer.ZkTracer;
 import net.consensys.linea.zktracer.json.JsonConverter;
+import net.consensys.linea.zktracer.types.PublicInputs;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.TraceService;
@@ -113,16 +116,19 @@ public class ConflatedCountTracesV2 {
   }
 
   private LineCountingTracer createLineCountingTracer(long fromBlock, long toBlock) {
-    // Retrieve fork from Besu plugin API with block number
-    final Fork fork = getForkFromBesuBlockchainService(besuContext, fromBlock, toBlock);
+    final BlockchainService blockchainService =
+        BesuServiceProvider.getBesuService(besuContext, BlockchainService.class);
+    final Fork fork = getForkFromBesuBlockchainService(blockchainService, fromBlock, toBlock);
 
-    return tracerSharedConfiguration.isLimitless()
-        ? new ZkCounter(l1L2BridgeSharedConfiguration, fork)
-        : new ZkTracer(
-            fork,
-            l1L2BridgeSharedConfiguration,
-            BesuServiceProvider.getBesuService(besuContext, BlockchainService.class)
-                .getChainId()
-                .orElseThrow());
+    if (tracerSharedConfiguration.isLimitless()) {
+      return new ZkCounter(l1L2BridgeSharedConfiguration, fork);
+    } else {
+      final BigInteger chainId =
+          blockchainService
+              .getChainId()
+              .orElseThrow(() -> new IllegalStateException("ChainId must be provided"));
+      final PublicInputs publicInputs = generatePublicInputs(blockchainService, fromBlock, toBlock);
+      return new ZkTracer(fork, l1L2BridgeSharedConfiguration, chainId, publicInputs);
+    }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/batchlinecount/ConflatedCountTracesV2.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/batchlinecount/ConflatedCountTracesV2.java
@@ -15,10 +15,8 @@
 
 package net.consensys.linea.plugins.rpc.batchlinecount;
 
-import static net.consensys.linea.zktracer.Fork.getForkFromBesuBlockchainService;
-import static net.consensys.linea.zktracer.types.PublicInputs.generatePublicInputs;
+import static net.consensys.linea.plugins.rpc.LineCounterGenerator.createLineCountingTracer;
 
-import java.math.BigInteger;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -32,14 +30,9 @@ import net.consensys.linea.plugins.config.LineaTracerSharedConfiguration;
 import net.consensys.linea.plugins.rpc.RequestLimiter;
 import net.consensys.linea.plugins.rpc.Validator;
 import net.consensys.linea.plugins.rpc.tracegeneration.TraceRequestParams;
-import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.LineCountingTracer;
-import net.consensys.linea.zktracer.ZkCounter;
-import net.consensys.linea.zktracer.ZkTracer;
 import net.consensys.linea.zktracer.json.JsonConverter;
-import net.consensys.linea.zktracer.types.PublicInputs;
 import org.hyperledger.besu.plugin.ServiceManager;
-import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.TraceService;
 import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
 
@@ -94,7 +87,13 @@ public class ConflatedCountTracesV2 {
 
     final long fromBlock = params.startBlockNumber();
     final long toBlock = params.endBlockNumber();
-    final LineCountingTracer counter = createLineCountingTracer(fromBlock, toBlock);
+    final LineCountingTracer counter =
+        createLineCountingTracer(
+            besuContext,
+            tracerSharedConfiguration,
+            l1L2BridgeSharedConfiguration,
+            fromBlock,
+            toBlock);
 
     traceService.trace(
         fromBlock,
@@ -113,22 +112,5 @@ public class ConflatedCountTracesV2 {
 
     return new ConflatedLineCounts(
         params.expectedTracesEngineVersion(), fromBlock, toBlock, new TreeMap<>(counts));
-  }
-
-  private LineCountingTracer createLineCountingTracer(long fromBlock, long toBlock) {
-    final BlockchainService blockchainService =
-        BesuServiceProvider.getBesuService(besuContext, BlockchainService.class);
-    final Fork fork = getForkFromBesuBlockchainService(blockchainService, fromBlock, toBlock);
-
-    if (tracerSharedConfiguration.isLimitless()) {
-      return new ZkCounter(l1L2BridgeSharedConfiguration, fork);
-    } else {
-      final BigInteger chainId =
-          blockchainService
-              .getChainId()
-              .orElseThrow(() -> new IllegalStateException("ChainId must be provided"));
-      final PublicInputs publicInputs = generatePublicInputs(blockchainService, fromBlock, toBlock);
-      return new ZkTracer(fork, l1L2BridgeSharedConfiguration, chainId, publicInputs);
-    }
   }
 }

--- a/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/rpc/tracegeneration/GenerateConflatedTracesV2.java
@@ -16,14 +16,12 @@
 package net.consensys.linea.plugins.rpc.tracegeneration;
 
 import static net.consensys.linea.zktracer.Fork.getForkFromBesuBlockchainService;
-import static net.consensys.linea.zktracer.types.PublicInputs.getBlobBaseFees;
-import static net.consensys.linea.zktracer.types.PublicInputs.retrieveHistoricalBlockHashes;
+import static net.consensys.linea.zktracer.types.PublicInputs.*;
 
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Map;
 import java.util.Optional;
 
 import com.google.common.base.Stopwatch;
@@ -37,8 +35,6 @@ import net.consensys.linea.zktracer.Fork;
 import net.consensys.linea.zktracer.ZkTracer;
 import net.consensys.linea.zktracer.json.JsonConverter;
 import net.consensys.linea.zktracer.types.PublicInputs;
-import org.apache.tuweni.bytes.Bytes;
-import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.TraceService;
@@ -129,16 +125,12 @@ public class GenerateConflatedTracesV2 {
     } else {
       final BlockchainService blockchainService =
           BesuServiceProvider.getBesuService(besuContext, BlockchainService.class);
-      // Retrieve fork from Besu plugin API with block number
       final Fork fork = getForkFromBesuBlockchainService(blockchainService, fromBlock, toBlock);
       final BigInteger chainId =
           blockchainService
               .getChainId()
               .orElseThrow(() -> new IllegalStateException("ChainId must be provided"));
-      final Map<Long, Hash> historicalBlockHashes =
-          retrieveHistoricalBlockHashes(blockchainService, fromBlock, toBlock);
-      final Map<Long, Bytes> blobBaseFees = getBlobBaseFees(blockchainService, fromBlock, toBlock);
-      final PublicInputs publicInputs = new PublicInputs(historicalBlockHashes, blobBaseFees);
+      final PublicInputs publicInputs = generatePublicInputs(blockchainService, fromBlock, toBlock);
 
       final ZkTracer tracer =
           new ZkTracer(fork, l1L2BridgeSharedConfiguration, chainId, publicInputs);

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
@@ -139,6 +139,7 @@ import org.hyperledger.besu.plugin.data.BlockHeader;
 public class ZkCounter implements LineCountingTracer {
 
   public final Fork fork;
+  private final boolean countHistoricalBlockHashes;
 
   private final OpCodes opCodes;
   private final Trace trace;
@@ -325,7 +326,15 @@ public class ZkCounter implements LineCountingTracer {
   }
 
   public ZkCounter(LineaL1L2BridgeSharedConfiguration bridgeConfiguration, Fork fork) {
+    this(bridgeConfiguration, fork, false);
+  }
+
+  public ZkCounter(
+      LineaL1L2BridgeSharedConfiguration bridgeConfiguration,
+      Fork fork,
+      boolean countHistoricalBlockHashes) {
     this.fork = fork;
+    this.countHistoricalBlockHashes = countHistoricalBlockHashes;
     this.opCodes = OpCodes.load(fork);
     this.trace = getTraceFromFork(fork);
     this.blakemodexp =
@@ -388,12 +397,18 @@ public class ZkCounter implements LineCountingTracer {
     moduleToCount = Stream.concat(checkedModules().stream(), uncheckedModules().stream()).toList();
 
     log.info("[ZkCounter] Created ZkCounter for fork {}", fork);
+    if (!countHistoricalBlockHashes) {
+      log.info(
+          "[ZkCounter] Historical BlockHashes not counted for BLOCKHASH, might miss 256*6 lines that are common for the whole conflation.");
+    }
   }
 
   @Override
   public void traceStartConflation(long numBlocksInConflation) {
-    blockHash.updateTally(
-        (int) ((BLOCKHASH_MAX_HISTORY + numBlocksInConflation) * NB_ROWS_BLOCKHASH));
+    if (countHistoricalBlockHashes) {
+      blockHash.updateTally(
+          (int) ((BLOCKHASH_MAX_HISTORY + numBlocksInConflation) * NB_ROWS_BLOCKHASH));
+    }
   }
 
   @Override

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
@@ -326,7 +326,7 @@ public class ZkCounter implements LineCountingTracer {
   }
 
   public ZkCounter(LineaL1L2BridgeSharedConfiguration bridgeConfiguration, Fork fork) {
-    this(bridgeConfiguration, fork, false);
+    this(bridgeConfiguration, fork, true);
   }
 
   public ZkCounter(

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ModuleName.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/ModuleName.java
@@ -93,7 +93,6 @@ public enum ModuleName {
   BLOCK_KECCAK,
 
   // reference tables
-  BIN_REFERENCE_TABLE,
   BLS_REFERENCE_TABLE,
   INSTRUCTION_DECODER,
   POWER_REFERENCE_TABLE

--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/types/PublicInputs.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/types/PublicInputs.java
@@ -63,6 +63,16 @@ public record PublicInputs(Map<Long, Hash> historicalBlockhashes, Map<Long, Byte
   }
 
   // Some methods to retrieve public inputs information from BlockchainService
+  public static PublicInputs generatePublicInputs(
+      BlockchainService blockchain,
+      long firstBlockNumberOfConflation,
+      long lastBlockNumberOfConflation) {
+    return new PublicInputs(
+        retrieveHistoricalBlockHashes(
+            blockchain, firstBlockNumberOfConflation, lastBlockNumberOfConflation),
+        getBlobBaseFees(blockchain, firstBlockNumberOfConflation, lastBlockNumberOfConflation));
+  }
+
   public static Map<Long, Hash> retrieveHistoricalBlockHashes(
       BlockchainService blockchain,
       long firstBlockNumberOfConflation,

--- a/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
+++ b/testing/src/main/java/net/consensys/linea/testing/ToyExecutionEnvironmentV2.java
@@ -175,7 +175,7 @@ public class ToyExecutionEnvironmentV2 {
   }
 
   public void runForCounting() {
-    zkCounter = new ZkCounter(unitTestsChain.bridgeConfiguration, fork);
+    zkCounter = new ZkCounter(unitTestsChain.bridgeConfiguration, fork, true);
 
     final ProtocolSpec protocolSpec =
         ExecutionEnvironment.getProtocolSpec(unitTestsChain.id, unitTestsChain.fork);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a config flag to include historical BLOCKHASH lines in counts and refactors RPCs to use a shared tracer generator with proper public inputs.
> 
> - **Config**:
>   - Add `boolean` `countHistoricalBlockHashes` to `LineaTracerSharedConfiguration` and CLI flag `--plugin-linea-count-historical-blockhash-enabled` (default: true) in `LineaTracerSharedCliOptions`.
> - **RPC**:
>   - Introduce `rpc/LineCounterGenerator` to create `LineCountingTracer` based on `isLimitless` and `countHistoricalBlockHashes`.
>   - Update `linecounts/GenerateLineCountsV2` and `batchlinecount/ConflatedCountTracesV2` to use the generator and pass config.
>   - `tracegeneration/GenerateConflatedTracesV2` now builds `PublicInputs` via `generatePublicInputs(...)`.
> - **Tracing**:
>   - Enhance `ZkCounter` with constructor accepting `countHistoricalBlockHashes`; conditionally tally `BLOCK_HASH` historical rows in `traceStartConflation` and add info logging.
> - **Utilities**:
>   - Add `PublicInputs.generatePublicInputs(...)` helper; consolidate historical blockhashes and blob base fee retrieval.
>   - Remove `BIN_REFERENCE_TABLE` from `ModuleName`.
> - **Testing**:
>   - Update `ToyExecutionEnvironmentV2` to use new `ZkCounter(..., true)` constructor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3fc083cd045476395dd4c2edae03c8f6b40acdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->