### PR TITLE
feat: add osaka fork switch test

### DIFF
--- a/testing/src/main/resources/BesuExecutionToolsGenesis_ParisToOsaka.json
+++ b/testing/src/main/resources/BesuExecutionToolsGenesis_ParisToOsaka.json
@@ -15,6 +15,7 @@
     "shanghaiTime": 1670496244,
     "cancunTime": 1670496244,
     "pragueTime": 1670496245,
+    "osakaTime": 1670496246,
     "clique": {
       "blockperiodseconds": 1,
       "epochlength": 1,

--- a/testing/src/main/resources/BesuExecutionToolsGenesis_PragueToOsaka.json
+++ b/testing/src/main/resources/BesuExecutionToolsGenesis_PragueToOsaka.json
@@ -14,8 +14,8 @@
     "terminalTotalDifficulty": 1,
     "shanghaiTime": 1670496244,
     "cancunTime": 1670496244,
-    "pragueTime": 1670496245,
-    "osakaTime": 1670496246,
+    "pragueTime": 1670496244,
+    "osakaTime": 1670496245,
     "clique": {
       "blockperiodseconds": 1,
       "epochlength": 1,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a Besu-based fork switch test from Prague to Osaka (MCOPY→CLZ) and a new genesis config enabling that transition.
> 
> - **Tests (ForkTracingAndSwitchingBesuTest.java)**
>   - Rename and refactor fork switch test to `testForkSwitchPragueToOsaka`, executing MCOPY on Prague then CLZ on Osaka.
>   - Build per-fork bytecode (`0x5E` MCOPY, `0x1E` CLZ), update accounts/transactions to Prague→Osaka, and point to new genesis file.
>   - Simplify per-fork opcode handling: restrict MCOPY path to `PRAGUE` (remove `CANCUN`).
> - **Config**
>   - Add `testing/src/main/resources/BesuExecutionToolsGenesis_PragueToOsaka.json` with `pragueTime` and `osakaTime` to drive the fork transition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f6af94ddc49fbc2a5db70b73cc4a0de5391823a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->