### PR TITLE
feat: rm submodule no longer used ethereum/tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "linea-constraints"]
 	path = linea-constraints
 	url = https://github.com/Consensys/linea-constraints
-[submodule "reference-tests/src/test/resources/ethereum-tests"]
-	path = reference-tests/src/test/resources/ethereum-tests
-	url = https://github.com/ethereum/tests.git


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remove the unused `ethereum/tests` submodule from `.gitmodules`, keeping only `linea-constraints`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c510b9925c705252db00299b114e8959510cbc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->