### PR TITLE
fix: historical blockhash count false by default from rpc

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaTracerSharedCliOptions.java
+++ b/arithmetization/src/main/java/net/consensys/linea/plugins/config/LineaTracerSharedCliOptions.java
@@ -26,7 +26,7 @@ public class LineaTracerSharedCliOptions implements LineaCliOptions {
   public static final String COUNT_HISTORICAL_BLOCKHASHES_ENABLED =
       "--plugin-linea-count-historical-blockhash-enabled";
   public static final boolean DEFAULT_LIMITLESS_ENABLED = false;
-  public static final boolean DEFAULT_COUNT_HISTORICAL_BLOCKHASHES_ENABLED = true;
+  public static final boolean DEFAULT_COUNT_HISTORICAL_BLOCKHASHES_ENABLED = false;
 
   @CommandLine.Option(
       names = {LIMITLESS_ENABLED},


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Changes default `countHistoricalBlockHashes` CLI option to false in `LineaTracerSharedCliOptions`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f296f5a24837aa76c3d5df651a52da4ea24a3510. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->