### PR TITLE
chore: testing go corset version 120

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -12,4 +12,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@d452c81774418b0be18aaaf587fe5333b18fe1dd # v1.2.0-rc1?
+      run: go install github.com/consensys/go-corset/cmd/go-corset@e9e7224b7ca911a9c608f4115f756f318d9ba493 # v1.2.0-rc1?

--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -12,4 +12,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@b10664b16fc73ea1da464fd4ce65ca40c594b34b #v1.1.30
+      run: go install github.com/consensys/go-corset/cmd/go-corset@bc0ae68f5fdf3d538ac6aa6e411001fee8a473df # v1.2.0-rc1?

--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -12,4 +12,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@bc0ae68f5fdf3d538ac6aa6e411001fee8a473df # v1.2.0-rc1?
+      run: go install github.com/consensys/go-corset/cmd/go-corset@d452c81774418b0be18aaaf587fe5333b18fe1dd # v1.2.0-rc1?

--- a/arithmetization/src/main/java/net/consensys/linea/corset/CorsetValidator.java
+++ b/arithmetization/src/main/java/net/consensys/linea/corset/CorsetValidator.java
@@ -130,6 +130,8 @@ public class CorsetValidator extends AbstractExecutable {
         System.getenv().getOrDefault("GOCORSET_FLAGS", "--report --report-context 2 --air ");
     // Determine whether to generate a coverage report (or not).
     String coverage = System.getenv().get("GOCORSET_COVERAGE");
+    // Determine whether field override provided
+    String field = System.getenv().get("GOCORSET_FIELD");
     // Specify corset binary
     options.add("go-corset");
     // Set chain properties
@@ -143,6 +145,11 @@ public class CorsetValidator extends AbstractExecutable {
       Path coverageFilename = determineCoverageFile(traceFile);
       options.add("--coverage");
       options.add(coverageFilename.toString());
+    }
+    // Set underlying field
+    if (field != null) {
+      options.add("--field");
+      options.add(field);
     }
     // Specify trace file to use
     options.add(traceFile.toAbsolutePath().toString());


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `go-corset` in CI and adds `GOCORSET_FIELD` support to pass `--field` in `CorsetValidator`.
> 
> - **CI**:
>   - Update `go-corset` install in `.github/actions/setup-go-corset/action.yml` to commit `e9e7224...` (v1.2.0-rc1).
> - **Validator**:
>   - `CorsetValidator.buildCommandLine(...)`: add support for `GOCORSET_FIELD` env var to pass `--field <value>` to `go-corset`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0097534c653d7c06f239b0452dfd936e52ff56ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->