### PR TITLE
fix: prevent scheduled github actions

### DIFF
--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -3,8 +3,6 @@ permissions:
   contents: read
 
 on:
-  schedule:
-    - cron: "0 22 * * 1-5"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/gradle-weekly-tests.yml
+++ b/.github/workflows/gradle-weekly-tests.yml
@@ -2,8 +2,6 @@ permissions: read-all
 name: Weekly Tests
 
 on:
-  schedule:
-    - cron: "0 4 * * 1"
   workflow_dispatch:
 
 

--- a/.github/workflows/reference-blockchain-tests.yml
+++ b/.github/workflows/reference-blockchain-tests.yml
@@ -2,8 +2,6 @@ permissions: read-all
 name: Daily Blockchain Tests
 
 on:
-  schedule:
-    - cron: 0 21 * * 1-5
   workflow_dispatch:
     inputs:
       test_filter:


### PR DESCRIPTION
This stops all scheduled actions from running now by simply removing the schedule trigger.  Thus, the actions still existing and could be run (in principle) by a workflow trigger, or similar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables automatic scheduled CI runs across test workflows; they remain manually runnable via `workflow_dispatch`.
> 
> - Remove `schedule` cron triggers from `github/workflows/gradle-nightly-tests.yml`, `gradle-weekly-tests.yml`, and `reference-blockchain-tests.yml`, leaving only `workflow_dispatch`
> - Existing jobs, inputs, and concurrency settings remain; no test logic or code changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 159f90575788c2f8780a5696b5f91f8fb2f3aeb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->