### PR TITLE
chore: move to default ubuntu 24 runners

### DIFF
--- a/.github/workflows/gradle-besu-node-tests.yml
+++ b/.github/workflows/gradle-besu-node-tests.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   unit-tests-with-besu-node:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/gradle-nightly-tests.yml
+++ b/.github/workflows/gradle-nightly-tests.yml
@@ -28,7 +28,7 @@ jobs:
   # Replay Tests
   # ==================================================================
   nightly-replay-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -27,7 +27,7 @@ jobs:
   # ==================================================================
   build:
     if: github.event.pull_request.draft == false && github.base_ref != 'main'
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     steps:
 
       - name: Checkout repository
@@ -78,7 +78,7 @@ jobs:
   replay-tests:
     if: github.event.pull_request.draft == false && github.base_ref != 'main'
     needs: [ build ]
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/gradle-weekly-tests.yml
+++ b/.github/workflows/gradle-weekly-tests.yml
@@ -35,7 +35,7 @@ jobs:
       zkevm_fork: OSAKA
 
   weekly-replay-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -11,7 +11,7 @@ jobs:
   validation:
     if: github.event.pull_request.draft == false && github.base_ref != 'main'
     name: "Validation"
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: gradle/actions/wrapper-validation@017a9effdb900e5b5b2fddfb590a105619dca3c3 #v4.4.2

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -119,7 +119,7 @@ jobs:
   # ==================================================================
   replay-tests:
     needs: [ build ]
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -166,7 +166,7 @@ jobs:
   publish:
     needs: [ build ]
     if: github.event_name != 'pull_request'
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     env:
       architecture: "amd64"
       GRADLE_OPTS: "-Xmx6g -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4"

--- a/.github/workflows/reusable-blockchain-tests.yml
+++ b/.github/workflows/reusable-blockchain-tests.yml
@@ -25,7 +25,7 @@ jobs:
   # Blockchain ref Tests
   # ==================================================================
   blockchain-reference-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/reusable-nightly-tests.yml
+++ b/.github/workflows/reusable-nightly-tests.yml
@@ -15,7 +15,7 @@ jobs:
   # Nightly Tests
   # ==================================================================
   nightly-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
   # Unit Tests
   # ==================================================================
   unit-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/reusable-weekly-prc-tests.yml
+++ b/.github/workflows/reusable-weekly-prc-tests.yml
@@ -12,7 +12,7 @@ jobs:
   # Weekly PRC Call Tests
   # ==================================================================
   weekly-prc-calltests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/reusable-weekly-tests.yml
+++ b/.github/workflows/reusable-weekly-tests.yml
@@ -12,7 +12,7 @@ jobs:
   # Weekly Tests
   # ==================================================================
   weekly-unit-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI/test execution environment changes from Ubuntu 22.04 to 24.04 across multiple workflows, which can surface new dependency/toolchain differences and cause unexpected pipeline failures.
> 
> **Overview**
> Switches the `runs-on` labels across Gradle CI workflows (unit/fast replay, nightly/weekly, Besu integration, blockchain reference tests, wrapper validation, and manual release post-test jobs) from `gha-runner-scale-set-ubuntu-22.04-*` to `gha-runner-scale-set-ubuntu-24-*`, standardizing CI on Ubuntu 24.04.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c31befc0242f7657d0848fbfae39ff590b68274f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->