### PR TITLE
Add archive notice and redirect to new repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> **This repository has been archived and is no longer actively maintained.**
+> The content has been moved to [**Consensys/linea-monorepo**](https://github.com/Consensys/linea-monorepo).
+> Please refer to that repository for the latest implementation of the Linea tracer system.
+
 # Linea tracer (zkEVM)
 
 This repository hosts a Linea tracing implementation for


### PR DESCRIPTION
Added a warning about the repository being archived and redirected users to the new repository.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds an archive notice and points users to the new repository; no code or behavior changes.
> 
> **Overview**
> Adds a prominent `WARNING` banner at the top of `README.md` stating the repository is archived/unmaintained and directing readers to `Consensys/linea-monorepo` for the latest Linea tracer implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5ae1a701a7d2b908a7296c4173f8f6db6f391e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->